### PR TITLE
Incorrect behaviour with recursive top level definitions

### DIFF
--- a/test/valid-data.test.ts
+++ b/test/valid-data.test.ts
@@ -64,6 +64,7 @@ describe("valid-data", () => {
     assertSchema("structure-private", "MyObject");
     assertSchema("structure-anonymous", "MyObject");
     assertSchema("structure-recursion", "MyObject");
+    assertSchema("structure-recursion-optional-children", "MyObject");
     assertSchema("structure-extra-props", "MyObject");
 
     assertSchema("enums-string", "Enum");

--- a/test/valid-data/structure-recursion-optional-children/main.ts
+++ b/test/valid-data/structure-recursion-optional-children/main.ts
@@ -1,0 +1,41 @@
+/**
+ * This description regulates how all ASTs should be stored when
+ * written to disk or sent over the wire. It requires every
+ * node to at least tell its name and some hint how a node can be
+ * constructed at runtime.
+ *
+ * The data of a node is split up in two broader categories:
+ * Children, which may be nested and properties, which should
+ * not allow any nesting.
+ */
+export interface MyObject {
+    /**
+     * The name of this not, this is used to lookup the name of a
+     * corresponding type.
+     */
+    name: string
+
+    /**
+     * This is effectively a namespace, allowing identical
+     * names for nodes in different languages.
+     */
+    language: string
+
+    /**
+     * Nodes may have children in various categories. This base class
+     * makes no assumptions about the names of children. Examples for
+     * children in multiple categories would be things like "attributes"
+     * and generic "children" in a specialization for XML.
+     */
+    children?: {
+        [childrenCategory: string]: MyObject[];
+    }
+
+    /**
+     * Nodes may have all kinds of properties that are specific to their
+     * concrete use.
+     */
+    properties?: {
+        [propertyName: string]: any;
+    }
+}

--- a/test/valid-data/structure-recursion-optional-children/schema.json
+++ b/test/valid-data/structure-recursion-optional-children/schema.json
@@ -1,0 +1,34 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "children": {
+          "additionalProperties": {
+            "items": {
+              "$ref": "#/definitions/MyObject"
+            },
+            "type": "array"
+          },
+          "type": "object"
+        },
+        "language": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "name",
+        "language"
+      ],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
The attached test case is my attempt to tackle down some weird behavior that I have observed while testing whether this project solves some of the issues I had with [the other schema generator](https://github.com/YousefED/typescript-json-schema/issues/172). However, the problem seems to be in the command line handling and not in the actual schema generation.  As I currently do not have the time to investigate it further, I open up the pull request with nothing but a half-baked test case (that doesn't even fail). I didn't even have the time to check this with the tests that are included, sorry!

If I run the program with the `--topRef` option from the command line, the resulting `JSON`-schema *always* has an empty `definitions` object but still contains the (recursive) reference to `"#/definitions/MyObject"`. I suspect there may be two problems at hand:

* If the top level object is referenced recursively `--topRef no` may incorrectly strip it.
* Something is wrong when handling the `--topRef` argument, it seems to be false in any case if specified at all.

Call with `--topRef 1`:

    node dist/ts-json-schema-generator.js --path test/valid-data/structure-recursion-optional-children/main.ts --type MyObject --topRef 1 
    {
      "$schema": "http://json-schema.org/draft-04/schema#",
      "additionalProperties": false,
      "definitions": {},
      "description": "This description regulates how all ASTs should be stored when\nwritten to disk or sent over the wire. It requires every\nnode to at least tell its name and some hint how a node can be\nconstructed at runtime.\n\nThe data of a node is split up in two broader categories:\nChildren, which may be nested and properties, which should\nnot allow any nesting.",
      "properties": {
        "children": {
          "additionalProperties": {
            "items": {
              "$ref": "#/definitions/MyObject"
            },
            "type": "array"
          },
          "description": "Nodes may have children in various categories. This base class\nmakes no assumptions about the names of children. Examples for\nchildren in multiple categories would be things like \"attributes\"\nand generic \"children\" in a specialization for XML.",
          "type": "object"
        },
        "language": {
          "description": "This is effectively a namespace, allowing identical\nnames for nodes in different languages.",
          "type": "string"
        },
        "name": {
          "description": "The name of this not, this is used to lookup the name of a\ncorresponding type.",
          "type": "string"
        },
        "properties": {
          "description": "Nodes may have all kinds of properties that are specific to their\nconcrete use.",
          "type": "object"
        }
      },
      "required": [
        "name",
        "language"
      ],
      "type": "object"
    }

If I omit the `--topRef` argument completely, everything looks fine:

    node dist/ts-json-schema-generator.js --path test/valid-data/structure-recursion-optional-children/main.ts --type MyObject
    {
      "$ref": "#/definitions/MyObject",
      "$schema": "http://json-schema.org/draft-04/schema#",
      "definitions": {
        "MyObject": {
          "additionalProperties": false,
          "description": "This description regulates how all ASTs should be stored when\nwritten to disk or sent over the wire. It requires every\nnode to at least tell its name and some hint how a node can be\nconstructed at runtime.\n\nThe data of a node is split up in two broader categories:\nChildren, which may be nested and properties, which should\nnot allow any nesting.",
          "properties": {
            "children": {
              "additionalProperties": {
                "items": {
                  "$ref": "#/definitions/MyObject"
                },
                "type": "array"
              },
              "description": "Nodes may have children in various categories. This base class\nmakes no assumptions about the names of children. Examples for\nchildren in multiple categories would be things like \"attributes\"\nand generic \"children\" in a specialization for XML.",
              "type": "object"
            },
            "language": {
              "description": "This is effectively a namespace, allowing identical\nnames for nodes in different languages.",
              "type": "string"
            },
            "name": {
              "description": "The name of this not, this is used to lookup the name of a\ncorresponding type.",
              "type": "string"
            },
            "properties": {
              "description": "Nodes may have all kinds of properties that are specific to their\nconcrete use.",
              "type": "object"
            }
          },
          "required": [
            "name",
            "language"
          ],
          "type": "object"
        }
      }
    }
    