### PR TITLE
add --strictTuples option: disallows additional elements in tuples

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,23 +30,23 @@ npm install --save ts-json-schema-generator
 
 ```
 -e, --expose <all|none|export>
-    all: Create shared $ref definitions for all types
-    none: Do not create shared $ref definitions
-    export:  Create shared $ref definitions only for exported types
+    all: Create shared $ref definitions for all types.
+    none: Do not create shared $ref definitions.
+    export:  Create shared $ref definitions only for exported types.
 
 -r, --no-top-ref
-    Do not create a top-level $ref definition
+    Do not create a top-level $ref definition.
 
 -j, --jsDoc <extended|none|basic>
     basic: Read JsDoc annotations to provide schema properties.
-    extended: Also read @nullable, and @asType annotations
-    none: Do not use JsDoc annotations
+    extended: Also read @nullable, and @asType annotations.
+    none: Do not use JsDoc annotations.
 
 -u, --unstable
-    Do not sort properties
+    Do not sort properties.
 
 -s, --strictTuples
-    Do not allow additional items on tuples
+    Do not allow additional items on tuples.
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,33 @@ npm install --save ts-json-schema-generator
     --path 'my/project/**.*.ts' \
     --type 'My.Type.Full.Name' \
     --expose 'export' \
-    --jsDoc 'extended'
+    --jsDoc 'extended' \
+    --strictTuples
 ```
+
+## Options
+
+```
+-e, --expose <all|none|export>
+    all: Create shared $ref definitions for all types
+    none: Do not create shared $ref definitions
+    export:  Create shared $ref definitions only for exported types
+
+-r, --no-top-ref
+    Do not create a top-level $ref definition
+
+-j, --jsDoc <extended|none|basic>
+    basic: Read JsDoc annotations to provide schema properties.
+    extended: Also read @nullable, and @asType annotations
+    none: Do not use JsDoc annotations
+
+-u, --unstable
+    Do not sort properties
+
+-s, --strictTuples
+    Do not allow additional items on tuples
+```
+
 
 ## Current state
 

--- a/factory/formatter.ts
+++ b/factory/formatter.ts
@@ -51,7 +51,7 @@ export function createFormatter(config: Config): TypeFormatter {
         .addTypeFormatter(new LiteralUnionTypeFormatter())
 
         .addTypeFormatter(new ArrayTypeFormatter(circularReferenceTypeFormatter))
-        .addTypeFormatter(new TupleTypeFormatter(circularReferenceTypeFormatter))
+        .addTypeFormatter(new TupleTypeFormatter(circularReferenceTypeFormatter, config))
         .addTypeFormatter(new UnionTypeFormatter(circularReferenceTypeFormatter))
         .addTypeFormatter(new IntersectionTypeFormatter(circularReferenceTypeFormatter));
 

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -4,6 +4,7 @@ export interface PartialConfig {
     topRef: boolean;
     jsDoc: "none" | "extended" | "basic";
     sortProps?: boolean;
+    strictTuples?: boolean;
 }
 
 export interface Config extends PartialConfig {
@@ -16,4 +17,5 @@ export const DEFAULT_CONFIG: PartialConfig = {
     topRef: true,
     jsDoc: "extended",
     sortProps: true,
+    strictTuples: false,
 };

--- a/src/Schema/Definition.ts
+++ b/src/Schema/Definition.ts
@@ -12,6 +12,7 @@ export interface Definition {
     format?: string;
     items?: Definition | Definition[];
     minItems?: number;
+    maxItems?: number;
     additionalItems?: {
         anyOf: Definition[],
     };

--- a/src/TypeFormatter/TupleTypeFormatter.ts
+++ b/src/TypeFormatter/TupleTypeFormatter.ts
@@ -1,3 +1,4 @@
+import { Config } from "../Config";
 import { Definition } from "../Schema/Definition";
 import { SubTypeFormatter } from "../SubTypeFormatter";
 import { BaseType } from "../Type/BaseType";
@@ -7,6 +8,7 @@ import { TypeFormatter } from "../TypeFormatter";
 export class TupleTypeFormatter implements SubTypeFormatter {
     public constructor(
         private childTypeFormatter: TypeFormatter,
+        private config: Config,
     ) {
     }
 
@@ -15,12 +17,13 @@ export class TupleTypeFormatter implements SubTypeFormatter {
     }
     public getDefinition(type: TupleType): Definition {
         const tupleDefinitions = type.getTypes().map((item) => this.childTypeFormatter.getDefinition(item));
-
+        const addAdditionalItems = tupleDefinitions.length > 1 && !this.config.strictTuples;
+        const additionalItems = {additionalItems: {anyOf: tupleDefinitions}};
         return {
             type: "array",
             items: tupleDefinitions,
             minItems: tupleDefinitions.length,
-            ...(tupleDefinitions.length > 1 ? {additionalItems: {anyOf: tupleDefinitions}} : {}),
+            ...(addAdditionalItems ? additionalItems : {maxItems: tupleDefinitions.length}),
         };
     }
     public getChildren(type: TupleType): BaseType[] {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -62,6 +62,18 @@ describe("config", () => {
     assertSchema("jsdoc-hide", {type: "MyObject", expose: "export", topRef: true, jsDoc: "extended"});
     assertSchema("jsdoc-inheritance", {type: "MyObject", expose: "export", topRef: true, jsDoc: "extended"});
 
-    assertSchema("strict-tuples-true", {type: "MyObject", expose: "export", topRef: true, jsDoc: "none", strictTuples: true});
-    assertSchema("strict-tuples-false", {type: "MyObject", expose: "export", topRef: true, jsDoc: "none", strictTuples: false});
+    assertSchema("strict-tuples-true", {
+        type: "MyObject",
+        expose: "export",
+        topRef: true,
+        jsDoc: "none",
+        strictTuples: true,
+    });
+    assertSchema("strict-tuples-false", {
+        type: "MyObject",
+        expose: "export",
+        topRef: true,
+        jsDoc: "none",
+        strictTuples: false,
+    });
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -21,7 +21,7 @@ function assertSchema(name: string, partialConfig: PartialConfig & {type: string
     const run: Run = only ? it.only : it;
     run(name, () => {
         const config: Config = {
-            ... DEFAULT_CONFIG,
+            ...DEFAULT_CONFIG,
             ...partialConfig,
             path: resolve(`${basePath}/${name}/*.ts`),
         };
@@ -61,4 +61,7 @@ describe("config", () => {
 
     assertSchema("jsdoc-hide", {type: "MyObject", expose: "export", topRef: true, jsDoc: "extended"});
     assertSchema("jsdoc-inheritance", {type: "MyObject", expose: "export", topRef: true, jsDoc: "extended"});
+
+    assertSchema("strict-tuples-true", {type: "MyObject", expose: "export", topRef: true, jsDoc: "none", strictTuples: true});
+    assertSchema("strict-tuples-false", {type: "MyObject", expose: "export", topRef: true, jsDoc: "none", strictTuples: false});
 });

--- a/test/config/strict-tuples-false/main.ts
+++ b/test/config/strict-tuples-false/main.ts
@@ -1,0 +1,3 @@
+export interface MyObject {
+    tuple: [number, string];
+}

--- a/test/config/strict-tuples-false/schema.json
+++ b/test/config/strict-tuples-false/schema.json
@@ -1,0 +1,37 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "tuple": {
+          "additionalItems": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "minItems": 2,
+          "type": "array"
+        }
+      },
+      "required": [
+        "tuple"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/test/config/strict-tuples-true/main.ts
+++ b/test/config/strict-tuples-true/main.ts
@@ -1,0 +1,3 @@
+export interface MyObject {
+    tuple: [number, string];
+}

--- a/test/config/strict-tuples-true/schema.json
+++ b/test/config/strict-tuples-true/schema.json
@@ -1,0 +1,28 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "tuple": {
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        }
+      },
+      "required": [
+        "tuple"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/ts-json-schema-generator.ts
+++ b/ts-json-schema-generator.ts
@@ -43,7 +43,6 @@ const config: Config = {
     topRef: args.topRef,
     jsDoc: args.jsDoc,
     sortProps: !args.unstable,
-    typeFile: args.typeFile,
     strictTuples: args.strictTuples,
 };
 

--- a/ts-json-schema-generator.ts
+++ b/ts-json-schema-generator.ts
@@ -29,6 +29,10 @@ const args = commander
         "-u, --unstable",
         "Do not sort properties",
     )
+    .option(
+        "-s, --strictTuples",
+        "Do not allow additional items on tuples",
+    )
     .parse(process.argv);
 
 const config: Config = {
@@ -39,6 +43,8 @@ const config: Config = {
     topRef: args.topRef,
     jsDoc: args.jsDoc,
     sortProps: !args.unstable,
+    typeFile: args.typeFile,
+    strictTuples: args.strictTuples,
 };
 
 try {


### PR DESCRIPTION
With the `--strictTuples` option enabled, the generated schema does not allow for additional properties. 

See issue #28 