### PR TITLE
Anonymous type literals

### DIFF
--- a/src/ExposeNodeParser.ts
+++ b/src/ExposeNodeParser.ts
@@ -30,7 +30,7 @@ export class ExposeNodeParser implements SubNodeParser {
 
     private isExportNode(node: ts.Node): boolean {
         if (this.expose === "all") {
-            return true;
+            return node.kind !== ts.SyntaxKind.TypeLiteral;
         } else if (this.expose === "none") {
             return false;
         }

--- a/test/config/expose-all-topref-false/main.ts
+++ b/test/config/expose-all-topref-false/main.ts
@@ -31,6 +31,7 @@ export interface MyObject {
 
     mixedInterface: MixedInterface;
     mixedAlias: MixedAlias;
+
     publicAnonymousTypeLiteral: PublicAnonymousTypeLiteral;
     privateAnonymousTypeLiteral: PrivateAnonymousTypeLiteral;
 }

--- a/test/config/expose-all-topref-false/main.ts
+++ b/test/config/expose-all-topref-false/main.ts
@@ -14,6 +14,14 @@ interface MixedInterface {
 export type MixedAlias = PrivateInterface;
 
 
+export type PublicAnonymousTypeLiteral = {
+    publicValue: string;
+};
+
+type PrivateAnonymousTypeLiteral = {
+    privateValue: string;
+};
+
 export interface MyObject {
     exportInterface: ExportInterface;
     exportAlias: ExportAlias;
@@ -23,4 +31,6 @@ export interface MyObject {
 
     mixedInterface: MixedInterface;
     mixedAlias: MixedAlias;
+    publicAnonymousTypeLiteral: PublicAnonymousTypeLiteral;
+    privateAnonymousTypeLiteral: PrivateAnonymousTypeLiteral;
 }

--- a/test/config/expose-all-topref-false/schema.json
+++ b/test/config/expose-all-topref-false/schema.json
@@ -45,6 +45,30 @@
         },
         "MixedAlias": {
             "$ref": "#/definitions/PrivateInterface"
+        },
+        "PublicAnonymousTypeLiteral": {
+            "type": "object",
+            "properties": {
+                "publicValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "publicValue"
+            ],
+            "additionalProperties": false
+        },
+        "PrivateAnonymousTypeLiteral": {
+            "type": "object",
+            "properties": {
+                "privateValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "privateValue"
+            ],
+            "additionalProperties": false
         }
     },
     "type": "object",

--- a/test/config/expose-all-topref-false/schema.json
+++ b/test/config/expose-all-topref-false/schema.json
@@ -1,104 +1,112 @@
 {
     "$schema": "http://json-schema.org/draft-06/schema#",
     "definitions": {
-        "ExportInterface": {
-            "type": "object",
-            "properties": {
-                "exportValue": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "exportValue"
-            ],
-            "additionalProperties": false
+      "ExportInterface": {
+        "type": "object",
+        "properties": {
+          "exportValue": {
+            "type": "string"
+          }
         },
-        "ExportAlias": {
-            "$ref": "#/definitions/ExportInterface"
+        "required": [
+          "exportValue"
+        ],
+        "additionalProperties": false
+      },
+      "ExportAlias": {
+        "$ref": "#/definitions/ExportInterface"
+      },
+      "PrivateInterface": {
+        "type": "object",
+        "properties": {
+          "privateValue": {
+            "type": "string"
+          }
         },
-        "PrivateInterface": {
-            "type": "object",
-            "properties": {
-                "privateValue": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "privateValue"
-            ],
-            "additionalProperties": false
+        "required": [
+          "privateValue"
+        ],
+        "additionalProperties": false
+      },
+      "PrivateAlias": {
+        "$ref": "#/definitions/PrivateInterface"
+      },
+      "MixedInterface": {
+        "type": "object",
+        "properties": {
+          "mixedValue": {
+            "$ref": "#/definitions/ExportAlias"
+          }
         },
-        "PrivateAlias": {
-            "$ref": "#/definitions/PrivateInterface"
+        "required": [
+          "mixedValue"
+        ],
+        "additionalProperties": false
+      },
+      "MixedAlias": {
+        "$ref": "#/definitions/PrivateInterface"
+      },
+      "PublicAnonymousTypeLiteral": {
+        "type": "object",
+        "properties": {
+          "publicValue": {
+            "type": "string"
+          }
         },
-        "MixedInterface": {
-            "type": "object",
-            "properties": {
-                "mixedValue": {
-                    "$ref": "#/definitions/ExportAlias"
-                }
-            },
-            "required": [
-                "mixedValue"
-            ],
-            "additionalProperties": false
+        "required": [
+          "publicValue"
+        ],
+        "additionalProperties": false
+      },
+      "PrivateAnonymousTypeLiteral": {
+        "type": "object",
+        "properties": {
+          "privateValue": {
+            "type": "string"
+          }
         },
-        "MixedAlias": {
-            "$ref": "#/definitions/PrivateInterface"
-        },
-        "PublicAnonymousTypeLiteral": {
-            "type": "object",
-            "properties": {
-                "publicValue": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "publicValue"
-            ],
-            "additionalProperties": false
-        },
-        "PrivateAnonymousTypeLiteral": {
-            "type": "object",
-            "properties": {
-                "privateValue": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "privateValue"
-            ],
-            "additionalProperties": false
-        }
+        "required": [
+          "privateValue"
+        ],
+        "additionalProperties": false
+      }
     },
     "type": "object",
     "properties": {
-        "exportInterface": {
-            "$ref": "#/definitions/ExportInterface"
-        },
-        "exportAlias": {
-            "$ref": "#/definitions/ExportAlias"
-        },
-        "privateInterface": {
-            "$ref": "#/definitions/PrivateInterface"
-        },
-        "privateAlias": {
-            "$ref": "#/definitions/PrivateAlias"
-        },
-        "mixedInterface": {
-            "$ref": "#/definitions/MixedInterface"
-        },
-        "mixedAlias": {
-            "$ref": "#/definitions/MixedAlias"
-        }
+      "exportInterface": {
+        "$ref": "#/definitions/ExportInterface"
+      },
+      "exportAlias": {
+        "$ref": "#/definitions/ExportAlias"
+      },
+      "privateInterface": {
+        "$ref": "#/definitions/PrivateInterface"
+      },
+      "privateAlias": {
+        "$ref": "#/definitions/PrivateAlias"
+      },
+      "mixedInterface": {
+        "$ref": "#/definitions/MixedInterface"
+      },
+      "mixedAlias": {
+        "$ref": "#/definitions/MixedAlias"
+      },
+      "publicAnonymousTypeLiteral": {
+        "$ref": "#/definitions/PublicAnonymousTypeLiteral"
+      },
+      "privateAnonymousTypeLiteral": {
+        "$ref": "#/definitions/PrivateAnonymousTypeLiteral"
+      }
     },
     "required": [
-        "exportInterface",
-        "exportAlias",
-        "privateInterface",
-        "privateAlias",
-        "mixedInterface",
-        "mixedAlias"
+      "exportInterface",
+      "exportAlias",
+      "privateInterface",
+      "privateAlias",
+      "mixedInterface",
+      "mixedAlias",
+      "publicAnonymousTypeLiteral",
+      "privateAnonymousTypeLiteral"
     ],
     "additionalProperties": false
-}
+  }

--- a/test/config/expose-all-topref-false/schema.json
+++ b/test/config/expose-all-topref-false/schema.json
@@ -1,112 +1,112 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
-    "definitions": {
-      "ExportInterface": {
-        "type": "object",
-        "properties": {
-          "exportValue": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "exportValue"
-        ],
-        "additionalProperties": false
-      },
-      "ExportAlias": {
-        "$ref": "#/definitions/ExportInterface"
-      },
-      "PrivateInterface": {
-        "type": "object",
-        "properties": {
-          "privateValue": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "privateValue"
-        ],
-        "additionalProperties": false
-      },
-      "PrivateAlias": {
-        "$ref": "#/definitions/PrivateInterface"
-      },
-      "MixedInterface": {
-        "type": "object",
-        "properties": {
-          "mixedValue": {
-            "$ref": "#/definitions/ExportAlias"
-          }
-        },
-        "required": [
-          "mixedValue"
-        ],
-        "additionalProperties": false
-      },
-      "MixedAlias": {
-        "$ref": "#/definitions/PrivateInterface"
-      },
-      "PublicAnonymousTypeLiteral": {
-        "type": "object",
-        "properties": {
-          "publicValue": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "publicValue"
-        ],
-        "additionalProperties": false
-      },
-      "PrivateAnonymousTypeLiteral": {
-        "type": "object",
-        "properties": {
-          "privateValue": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "privateValue"
-        ],
-        "additionalProperties": false
-      }
-    },
-    "type": "object",
-    "properties": {
-      "exportInterface": {
-        "$ref": "#/definitions/ExportInterface"
-      },
-      "exportAlias": {
-        "$ref": "#/definitions/ExportAlias"
-      },
-      "privateInterface": {
-        "$ref": "#/definitions/PrivateInterface"
-      },
-      "privateAlias": {
-        "$ref": "#/definitions/PrivateAlias"
-      },
-      "mixedInterface": {
-        "$ref": "#/definitions/MixedInterface"
-      },
-      "mixedAlias": {
-        "$ref": "#/definitions/MixedAlias"
-      },
-      "publicAnonymousTypeLiteral": {
-        "$ref": "#/definitions/PublicAnonymousTypeLiteral"
-      },
-      "privateAnonymousTypeLiteral": {
-        "$ref": "#/definitions/PrivateAnonymousTypeLiteral"
-      }
-    },
-    "required": [
-      "exportInterface",
-      "exportAlias",
-      "privateInterface",
-      "privateAlias",
-      "mixedInterface",
-      "mixedAlias",
-      "publicAnonymousTypeLiteral",
-      "privateAnonymousTypeLiteral"
-    ],
-    "additionalProperties": false
-  }
+	"$schema": "http://json-schema.org/draft-06/schema#",
+	"definitions": {
+		"ExportInterface": {
+			"type": "object",
+			"properties": {
+				"exportValue": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"exportValue"
+			],
+			"additionalProperties": false
+		},
+		"ExportAlias": {
+			"$ref": "#/definitions/ExportInterface"
+		},
+		"PrivateInterface": {
+			"type": "object",
+			"properties": {
+				"privateValue": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"privateValue"
+			],
+			"additionalProperties": false
+		},
+		"PrivateAlias": {
+			"$ref": "#/definitions/PrivateInterface"
+		},
+		"MixedInterface": {
+			"type": "object",
+			"properties": {
+				"mixedValue": {
+					"$ref": "#/definitions/ExportAlias"
+				}
+			},
+			"required": [
+				"mixedValue"
+			],
+			"additionalProperties": false
+		},
+		"MixedAlias": {
+			"$ref": "#/definitions/PrivateInterface"
+		},
+		"PublicAnonymousTypeLiteral": {
+			"type": "object",
+			"properties": {
+				"publicValue": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"publicValue"
+			],
+			"additionalProperties": false
+		},
+		"PrivateAnonymousTypeLiteral": {
+			"type": "object",
+			"properties": {
+				"privateValue": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"privateValue"
+			],
+			"additionalProperties": false
+		}
+	},
+	"type": "object",
+	"properties": {
+		"exportInterface": {
+			"$ref": "#/definitions/ExportInterface"
+		},
+		"exportAlias": {
+			"$ref": "#/definitions/ExportAlias"
+		},
+		"privateInterface": {
+			"$ref": "#/definitions/PrivateInterface"
+		},
+		"privateAlias": {
+			"$ref": "#/definitions/PrivateAlias"
+		},
+		"mixedInterface": {
+			"$ref": "#/definitions/MixedInterface"
+		},
+		"mixedAlias": {
+			"$ref": "#/definitions/MixedAlias"
+		},
+		"publicAnonymousTypeLiteral": {
+			"$ref": "#/definitions/PublicAnonymousTypeLiteral"
+		},
+		"privateAnonymousTypeLiteral": {
+			"$ref": "#/definitions/PrivateAnonymousTypeLiteral"
+		}
+	},
+	"required": [
+		"exportInterface",
+		"exportAlias",
+		"privateInterface",
+		"privateAlias",
+		"mixedInterface",
+		"mixedAlias",
+		"publicAnonymousTypeLiteral",
+		"privateAnonymousTypeLiteral"
+	],
+	"additionalProperties": false
+}

--- a/test/config/expose-all-topref-true/main.ts
+++ b/test/config/expose-all-topref-true/main.ts
@@ -14,6 +14,15 @@ interface MixedInterface {
 export type MixedAlias = PrivateInterface;
 
 
+export type PublicAnonymousTypeLiteral = {
+    publicValue: string;
+};
+
+type PrivateAnonymousTypeLiteral = {
+    privateValue: string;
+};
+
+
 export interface MyObject {
     exportInterface: ExportInterface;
     exportAlias: ExportAlias;
@@ -23,4 +32,7 @@ export interface MyObject {
 
     mixedInterface: MixedInterface;
     mixedAlias: MixedAlias;
+
+    publicAnonymousTypeLiteral: PublicAnonymousTypeLiteral;
+    privateAnonymousTypeLiteral: PrivateAnonymousTypeLiteral;
 }

--- a/test/config/expose-all-topref-true/schema.json
+++ b/test/config/expose-all-topref-true/schema.json
@@ -1,83 +1,115 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
-    "definitions": {
-        "ExportInterface": {
-            "type": "object",
-            "properties": {
-                "exportValue": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "exportValue"
-            ],
-            "additionalProperties": false
+"$schema": "http://json-schema.org/draft-06/schema#",
+"definitions": {
+    "MyObject": {
+    "type": "object",
+    "properties": {
+        "exportInterface": {
+        "$ref": "#/definitions/ExportInterface"
         },
-        "ExportAlias": {
-            "$ref": "#/definitions/ExportInterface"
+        "exportAlias": {
+        "$ref": "#/definitions/ExportAlias"
         },
-        "PrivateInterface": {
-            "type": "object",
-            "properties": {
-                "privateValue": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "privateValue"
-            ],
-            "additionalProperties": false
+        "privateInterface": {
+        "$ref": "#/definitions/PrivateInterface"
         },
-        "PrivateAlias": {
-            "$ref": "#/definitions/PrivateInterface"
+        "privateAlias": {
+        "$ref": "#/definitions/PrivateAlias"
         },
-        "MixedInterface": {
-            "type": "object",
-            "properties": {
-                "mixedValue": {
-                    "$ref": "#/definitions/ExportAlias"
-                }
-            },
-            "required": [
-                "mixedValue"
-            ],
-            "additionalProperties": false
+        "mixedInterface": {
+        "$ref": "#/definitions/MixedInterface"
         },
-        "MixedAlias": {
-            "$ref": "#/definitions/PrivateInterface"
+        "mixedAlias": {
+        "$ref": "#/definitions/MixedAlias"
         },
-        "MyObject": {
-            "type": "object",
-            "properties": {
-                "exportInterface": {
-                    "$ref": "#/definitions/ExportInterface"
-                },
-                "exportAlias": {
-                    "$ref": "#/definitions/ExportAlias"
-                },
-                "privateInterface": {
-                    "$ref": "#/definitions/PrivateInterface"
-                },
-                "privateAlias": {
-                    "$ref": "#/definitions/PrivateAlias"
-                },
-                "mixedInterface": {
-                    "$ref": "#/definitions/MixedInterface"
-                },
-                "mixedAlias": {
-                    "$ref": "#/definitions/MixedAlias"
-                }
-            },
-            "required": [
-                "exportInterface",
-                "exportAlias",
-                "privateInterface",
-                "privateAlias",
-                "mixedInterface",
-                "mixedAlias"
-            ],
-            "additionalProperties": false
+        "publicAnonymousTypeLiteral": {
+        "$ref": "#/definitions/PublicAnonymousTypeLiteral"
+        },
+        "privateAnonymousTypeLiteral": {
+        "$ref": "#/definitions/PrivateAnonymousTypeLiteral"
         }
     },
-    "$ref": "#/definitions/MyObject"
+    "required": [
+        "exportInterface",
+        "exportAlias",
+        "privateInterface",
+        "privateAlias",
+        "mixedInterface",
+        "mixedAlias",
+        "publicAnonymousTypeLiteral",
+        "privateAnonymousTypeLiteral"
+    ],
+    "additionalProperties": false
+    },
+    "ExportInterface": {
+    "type": "object",
+    "properties": {
+        "exportValue": {
+        "type": "string"
+        }
+    },
+    "required": [
+        "exportValue"
+    ],
+    "additionalProperties": false
+    },
+    "ExportAlias": {
+    "$ref": "#/definitions/ExportInterface"
+    },
+    "PrivateInterface": {
+    "type": "object",
+    "properties": {
+        "privateValue": {
+        "type": "string"
+        }
+    },
+    "required": [
+        "privateValue"
+    ],
+    "additionalProperties": false
+    },
+    "PrivateAlias": {
+    "$ref": "#/definitions/PrivateInterface"
+    },
+    "MixedInterface": {
+    "type": "object",
+    "properties": {
+        "mixedValue": {
+        "$ref": "#/definitions/ExportAlias"
+        }
+    },
+    "required": [
+        "mixedValue"
+    ],
+    "additionalProperties": false
+    },
+    "MixedAlias": {
+    "$ref": "#/definitions/PrivateInterface"
+    },
+    "PublicAnonymousTypeLiteral": {
+    "type": "object",
+    "properties": {
+        "publicValue": {
+        "type": "string"
+        }
+    },
+    "required": [
+        "publicValue"
+    ],
+    "additionalProperties": false
+    },
+    "PrivateAnonymousTypeLiteral": {
+    "type": "object",
+    "properties": {
+        "privateValue": {
+        "type": "string"
+        }
+    },
+    "required": [
+        "privateValue"
+    ],
+    "additionalProperties": false
+    }
+},
+"$ref": "#/definitions/MyObject"
 }

--- a/test/config/expose-all-topref-true/schema.json
+++ b/test/config/expose-all-topref-true/schema.json
@@ -1,115 +1,115 @@
 {
-"$schema": "http://json-schema.org/draft-06/schema#",
-"definitions": {
-    "MyObject": {
-    "type": "object",
-    "properties": {
-        "exportInterface": {
-        "$ref": "#/definitions/ExportInterface"
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "definitions": {
+        "MyObject": {
+            "type": "object",
+            "properties": {
+                "exportInterface": {
+                    "$ref": "#/definitions/ExportInterface"
+                },
+                "exportAlias": {
+                    "$ref": "#/definitions/ExportAlias"
+                },
+                "privateInterface": {
+                    "$ref": "#/definitions/PrivateInterface"
+                },
+                "privateAlias": {
+                    "$ref": "#/definitions/PrivateAlias"
+                },
+                "mixedInterface": {
+                    "$ref": "#/definitions/MixedInterface"
+                },
+                "mixedAlias": {
+                    "$ref": "#/definitions/MixedAlias"
+                },
+                "publicAnonymousTypeLiteral": {
+                    "$ref": "#/definitions/PublicAnonymousTypeLiteral"
+                },
+                "privateAnonymousTypeLiteral": {
+                    "$ref": "#/definitions/PrivateAnonymousTypeLiteral"
+                }
+            },
+            "required": [
+                "exportInterface",
+                "exportAlias",
+                "privateInterface",
+                "privateAlias",
+                "mixedInterface",
+                "mixedAlias",
+                "publicAnonymousTypeLiteral",
+                "privateAnonymousTypeLiteral"
+            ],
+            "additionalProperties": false
         },
-        "exportAlias": {
-        "$ref": "#/definitions/ExportAlias"
+        "ExportInterface": {
+            "type": "object",
+            "properties": {
+                "exportValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "exportValue"
+            ],
+            "additionalProperties": false
         },
-        "privateInterface": {
-        "$ref": "#/definitions/PrivateInterface"
+        "ExportAlias": {
+            "$ref": "#/definitions/ExportInterface"
         },
-        "privateAlias": {
-        "$ref": "#/definitions/PrivateAlias"
+        "PrivateInterface": {
+            "type": "object",
+            "properties": {
+                "privateValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "privateValue"
+            ],
+            "additionalProperties": false
         },
-        "mixedInterface": {
-        "$ref": "#/definitions/MixedInterface"
+        "PrivateAlias": {
+            "$ref": "#/definitions/PrivateInterface"
         },
-        "mixedAlias": {
-        "$ref": "#/definitions/MixedAlias"
+        "MixedInterface": {
+            "type": "object",
+            "properties": {
+                "mixedValue": {
+                    "$ref": "#/definitions/ExportAlias"
+                }
+            },
+            "required": [
+                "mixedValue"
+            ],
+            "additionalProperties": false
         },
-        "publicAnonymousTypeLiteral": {
-        "$ref": "#/definitions/PublicAnonymousTypeLiteral"
+        "MixedAlias": {
+            "$ref": "#/definitions/PrivateInterface"
         },
-        "privateAnonymousTypeLiteral": {
-        "$ref": "#/definitions/PrivateAnonymousTypeLiteral"
+        "PublicAnonymousTypeLiteral": {
+            "type": "object",
+            "properties": {
+                "publicValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "publicValue"
+            ],
+            "additionalProperties": false
+        },
+        "PrivateAnonymousTypeLiteral": {
+            "type": "object",
+            "properties": {
+                "privateValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "privateValue"
+            ],
+            "additionalProperties": false
         }
     },
-    "required": [
-        "exportInterface",
-        "exportAlias",
-        "privateInterface",
-        "privateAlias",
-        "mixedInterface",
-        "mixedAlias",
-        "publicAnonymousTypeLiteral",
-        "privateAnonymousTypeLiteral"
-    ],
-    "additionalProperties": false
-    },
-    "ExportInterface": {
-    "type": "object",
-    "properties": {
-        "exportValue": {
-        "type": "string"
-        }
-    },
-    "required": [
-        "exportValue"
-    ],
-    "additionalProperties": false
-    },
-    "ExportAlias": {
-    "$ref": "#/definitions/ExportInterface"
-    },
-    "PrivateInterface": {
-    "type": "object",
-    "properties": {
-        "privateValue": {
-        "type": "string"
-        }
-    },
-    "required": [
-        "privateValue"
-    ],
-    "additionalProperties": false
-    },
-    "PrivateAlias": {
-    "$ref": "#/definitions/PrivateInterface"
-    },
-    "MixedInterface": {
-    "type": "object",
-    "properties": {
-        "mixedValue": {
-        "$ref": "#/definitions/ExportAlias"
-        }
-    },
-    "required": [
-        "mixedValue"
-    ],
-    "additionalProperties": false
-    },
-    "MixedAlias": {
-    "$ref": "#/definitions/PrivateInterface"
-    },
-    "PublicAnonymousTypeLiteral": {
-    "type": "object",
-    "properties": {
-        "publicValue": {
-        "type": "string"
-        }
-    },
-    "required": [
-        "publicValue"
-    ],
-    "additionalProperties": false
-    },
-    "PrivateAnonymousTypeLiteral": {
-    "type": "object",
-    "properties": {
-        "privateValue": {
-        "type": "string"
-        }
-    },
-    "required": [
-        "privateValue"
-    ],
-    "additionalProperties": false
-    }
-},
-"$ref": "#/definitions/MyObject"
+    "$ref": "#/definitions/MyObject"
 }

--- a/test/config/expose-export-topref-false/main.ts
+++ b/test/config/expose-export-topref-false/main.ts
@@ -14,6 +14,15 @@ interface MixedInterface {
 export type MixedAlias = PrivateInterface;
 
 
+export type PublicAnonymousTypeLiteral = {
+    publicValue: string;
+};
+
+type PrivateAnonymousTypeLiteral = {
+    privateValue: string;
+};
+
+
 export interface MyObject {
     exportInterface: ExportInterface;
     exportAlias: ExportAlias;
@@ -23,4 +32,7 @@ export interface MyObject {
 
     mixedInterface: MixedInterface;
     mixedAlias: MixedAlias;
+
+    publicAnonymousTypeLiteral: PublicAnonymousTypeLiteral;
+    privateAnonymousTypeLiteral: PrivateAnonymousTypeLiteral;
 }

--- a/test/config/expose-export-topref-false/schema.json
+++ b/test/config/expose-export-topref-false/schema.json
@@ -27,6 +27,18 @@
                 "privateValue"
             ],
             "additionalProperties": false
+        },
+        "PublicAnonymousTypeLiteral": {
+            "type": "object",
+            "properties": {
+                "publicValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "publicValue"
+            ],
+            "additionalProperties": false
         }
     },
     "type": "object",
@@ -75,6 +87,21 @@
         },
         "mixedAlias": {
             "$ref": "#/definitions/MixedAlias"
+        },
+        "publicAnonymousTypeLiteral": {
+            "$ref": "#/definitions/PublicAnonymousTypeLiteral"
+        },
+        "privateAnonymousTypeLiteral": {
+            "type": "object",
+            "properties": {
+                "privateValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "privateValue"
+            ],
+            "additionalProperties": false
         }
     },
     "required": [
@@ -83,7 +110,9 @@
         "privateInterface",
         "privateAlias",
         "mixedInterface",
-        "mixedAlias"
+        "mixedAlias",
+        "publicAnonymousTypeLiteral",
+        "privateAnonymousTypeLiteral"
     ],
     "additionalProperties": false
 }

--- a/test/config/expose-export-topref-true/main.ts
+++ b/test/config/expose-export-topref-true/main.ts
@@ -14,6 +14,15 @@ interface MixedInterface {
 export type MixedAlias = PrivateInterface;
 
 
+export type PublicAnonymousTypeLiteral = {
+    publicValue: string;
+};
+
+type PrivateAnonymousTypeLiteral = {
+    privateValue: string;
+};
+
+
 export interface MyObject {
     exportInterface: ExportInterface;
     exportAlias: ExportAlias;
@@ -23,4 +32,7 @@ export interface MyObject {
 
     mixedInterface: MixedInterface;
     mixedAlias: MixedAlias;
+
+    publicAnonymousTypeLiteral: PublicAnonymousTypeLiteral;
+    privateAnonymousTypeLiteral: PrivateAnonymousTypeLiteral;
 }

--- a/test/config/expose-export-topref-true/schema.json
+++ b/test/config/expose-export-topref-true/schema.json
@@ -2,90 +2,119 @@
     "$schema": "http://json-schema.org/draft-06/schema#",
     "definitions": {
         "MyObject": {
-            "type": "object",
-            "properties": {
-                "exportInterface": {
-                    "$ref": "#/definitions/ExportInterface"
-                },
-                "exportAlias": {
-                    "$ref": "#/definitions/ExportAlias"
-                },
-                "privateInterface": {
-                    "type": "object",
-                    "properties": {
-                        "privateValue": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "privateValue"
-                    ],
-                    "additionalProperties": false
-                },
-                "privateAlias": {
-                    "type": "object",
-                    "properties": {
-                        "privateValue": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "privateValue"
-                    ],
-                    "additionalProperties": false
-                },
-                "mixedInterface": {
-                    "type": "object",
-                    "properties": {
-                        "mixedValue": {
-                            "$ref": "#/definitions/ExportAlias"
-                        }
-                    },
-                    "required": [
-                        "mixedValue"
-                    ],
-                    "additionalProperties": false
-                },
-                "mixedAlias": {
-                    "$ref": "#/definitions/MixedAlias"
-                }
-            },
-            "required": [
-                "exportInterface",
-                "exportAlias",
-                "privateInterface",
-                "privateAlias",
-                "mixedInterface",
-                "mixedAlias"
-            ],
-            "additionalProperties": false
-        },
-        "ExportInterface": {
-            "type": "object",
-            "properties": {
-                "exportValue": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "exportValue"
-            ],
-            "additionalProperties": false
-        },
-        "ExportAlias": {
+        "type": "object",
+        "properties": {
+            "exportInterface": {
             "$ref": "#/definitions/ExportInterface"
-        },
-        "MixedAlias": {
+            },
+            "exportAlias": {
+            "$ref": "#/definitions/ExportAlias"
+            },
+            "privateInterface": {
             "type": "object",
             "properties": {
                 "privateValue": {
-                    "type": "string"
+                "type": "string"
                 }
             },
             "required": [
                 "privateValue"
             ],
             "additionalProperties": false
+            },
+            "privateAlias": {
+            "type": "object",
+            "properties": {
+                "privateValue": {
+                "type": "string"
+                }
+            },
+            "required": [
+                "privateValue"
+            ],
+            "additionalProperties": false
+            },
+            "mixedInterface": {
+            "type": "object",
+            "properties": {
+                "mixedValue": {
+                "$ref": "#/definitions/ExportAlias"
+                }
+            },
+            "required": [
+                "mixedValue"
+            ],
+            "additionalProperties": false
+            },
+            "mixedAlias": {
+            "$ref": "#/definitions/MixedAlias"
+            },
+            "publicAnonymousTypeLiteral": {
+            "$ref": "#/definitions/PublicAnonymousTypeLiteral"
+            },
+            "privateAnonymousTypeLiteral": {
+            "type": "object",
+            "properties": {
+                "privateValue": {
+                "type": "string"
+                }
+            },
+            "required": [
+                "privateValue"
+            ],
+            "additionalProperties": false
+            }
+        },
+        "required": [
+            "exportInterface",
+            "exportAlias",
+            "privateInterface",
+            "privateAlias",
+            "mixedInterface",
+            "mixedAlias",
+            "publicAnonymousTypeLiteral",
+            "privateAnonymousTypeLiteral"
+        ],
+        "additionalProperties": false
+        },
+        "ExportInterface": {
+        "type": "object",
+        "properties": {
+            "exportValue": {
+            "type": "string"
+            }
+        },
+        "required": [
+            "exportValue"
+        ],
+        "additionalProperties": false
+        },
+        "ExportAlias": {
+        "$ref": "#/definitions/ExportInterface"
+        },
+        "MixedAlias": {
+        "type": "object",
+        "properties": {
+            "privateValue": {
+            "type": "string"
+            }
+        },
+        "required": [
+            "privateValue"
+        ],
+        "additionalProperties": false
+        },
+        "PublicAnonymousTypeLiteral": {
+        "type": "object",
+        "properties": {
+            "publicValue": {
+            "type": "string"
+            }
+        },
+        "required": [
+            "publicValue"
+        ],
+        "additionalProperties": false
         }
     },
     "$ref": "#/definitions/MyObject"

--- a/test/config/expose-export-topref-true/schema.json
+++ b/test/config/expose-export-topref-true/schema.json
@@ -2,119 +2,119 @@
     "$schema": "http://json-schema.org/draft-06/schema#",
     "definitions": {
         "MyObject": {
-        "type": "object",
-        "properties": {
-            "exportInterface": {
-            "$ref": "#/definitions/ExportInterface"
-            },
-            "exportAlias": {
-            "$ref": "#/definitions/ExportAlias"
-            },
-            "privateInterface": {
             "type": "object",
             "properties": {
-                "privateValue": {
-                "type": "string"
+                "exportInterface": {
+                    "$ref": "#/definitions/ExportInterface"
+                },
+                "exportAlias": {
+                    "$ref": "#/definitions/ExportAlias"
+                },
+                "privateInterface": {
+                    "type": "object",
+                    "properties": {
+                        "privateValue": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "privateValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "privateAlias": {
+                    "type": "object",
+                    "properties": {
+                        "privateValue": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "privateValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "mixedInterface": {
+                    "type": "object",
+                    "properties": {
+                        "mixedValue": {
+                            "$ref": "#/definitions/ExportAlias"
+                        }
+                    },
+                    "required": [
+                        "mixedValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "mixedAlias": {
+                    "$ref": "#/definitions/MixedAlias"
+                },
+                "publicAnonymousTypeLiteral": {
+                    "$ref": "#/definitions/PublicAnonymousTypeLiteral"
+                },
+                "privateAnonymousTypeLiteral": {
+                    "type": "object",
+                    "properties": {
+                        "privateValue": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "privateValue"
+                    ],
+                    "additionalProperties": false
                 }
             },
             "required": [
-                "privateValue"
+                "exportInterface",
+                "exportAlias",
+                "privateInterface",
+                "privateAlias",
+                "mixedInterface",
+                "mixedAlias",
+                "publicAnonymousTypeLiteral",
+                "privateAnonymousTypeLiteral"
             ],
             "additionalProperties": false
-            },
-            "privateAlias": {
-            "type": "object",
-            "properties": {
-                "privateValue": {
-                "type": "string"
-                }
-            },
-            "required": [
-                "privateValue"
-            ],
-            "additionalProperties": false
-            },
-            "mixedInterface": {
-            "type": "object",
-            "properties": {
-                "mixedValue": {
-                "$ref": "#/definitions/ExportAlias"
-                }
-            },
-            "required": [
-                "mixedValue"
-            ],
-            "additionalProperties": false
-            },
-            "mixedAlias": {
-            "$ref": "#/definitions/MixedAlias"
-            },
-            "publicAnonymousTypeLiteral": {
-            "$ref": "#/definitions/PublicAnonymousTypeLiteral"
-            },
-            "privateAnonymousTypeLiteral": {
-            "type": "object",
-            "properties": {
-                "privateValue": {
-                "type": "string"
-                }
-            },
-            "required": [
-                "privateValue"
-            ],
-            "additionalProperties": false
-            }
-        },
-        "required": [
-            "exportInterface",
-            "exportAlias",
-            "privateInterface",
-            "privateAlias",
-            "mixedInterface",
-            "mixedAlias",
-            "publicAnonymousTypeLiteral",
-            "privateAnonymousTypeLiteral"
-        ],
-        "additionalProperties": false
         },
         "ExportInterface": {
-        "type": "object",
-        "properties": {
-            "exportValue": {
-            "type": "string"
-            }
-        },
-        "required": [
-            "exportValue"
-        ],
-        "additionalProperties": false
+            "type": "object",
+            "properties": {
+                "exportValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "exportValue"
+            ],
+            "additionalProperties": false
         },
         "ExportAlias": {
-        "$ref": "#/definitions/ExportInterface"
+            "$ref": "#/definitions/ExportInterface"
         },
         "MixedAlias": {
-        "type": "object",
-        "properties": {
-            "privateValue": {
-            "type": "string"
-            }
-        },
-        "required": [
-            "privateValue"
-        ],
-        "additionalProperties": false
+            "type": "object",
+            "properties": {
+                "privateValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "privateValue"
+            ],
+            "additionalProperties": false
         },
         "PublicAnonymousTypeLiteral": {
-        "type": "object",
-        "properties": {
-            "publicValue": {
-            "type": "string"
-            }
-        },
-        "required": [
-            "publicValue"
-        ],
-        "additionalProperties": false
+            "type": "object",
+            "properties": {
+                "publicValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "publicValue"
+            ],
+            "additionalProperties": false
         }
     },
     "$ref": "#/definitions/MyObject"

--- a/test/config/expose-none-topref-false/main.ts
+++ b/test/config/expose-none-topref-false/main.ts
@@ -14,6 +14,15 @@ interface MixedInterface {
 export type MixedAlias = PrivateInterface;
 
 
+export type PublicAnonymousTypeLiteral = {
+    publicValue: string;
+};
+
+type PrivateAnonymousTypeLiteral = {
+    privateValue: string;
+};
+
+
 export interface MyObject {
     exportInterface: ExportInterface;
     exportAlias: ExportAlias;
@@ -23,4 +32,7 @@ export interface MyObject {
 
     mixedInterface: MixedInterface;
     mixedAlias: MixedAlias;
+
+    publicAnonymousTypeLiteral: PublicAnonymousTypeLiteral;
+    privateAnonymousTypeLiteral: PrivateAnonymousTypeLiteral;
 }

--- a/test/config/expose-none-topref-false/schema.json
+++ b/test/config/expose-none-topref-false/schema.json
@@ -83,6 +83,30 @@
                 "privateValue"
             ],
             "additionalProperties": false
+        },
+        "publicAnonymousTypeLiteral": {
+            "type": "object",
+            "properties": {
+                "publicValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "publicValue"
+            ],
+            "additionalProperties": false
+        },
+        "privateAnonymousTypeLiteral": {
+            "type": "object",
+            "properties": {
+                "privateValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "privateValue"
+            ],
+            "additionalProperties": false
         }
     },
     "required": [
@@ -91,7 +115,9 @@
         "privateInterface",
         "privateAlias",
         "mixedInterface",
-        "mixedAlias"
+        "mixedAlias",
+        "publicAnonymousTypeLiteral",
+        "privateAnonymousTypeLiteral"
     ],
     "additionalProperties": false
 }

--- a/test/config/expose-none-topref-true/main.ts
+++ b/test/config/expose-none-topref-true/main.ts
@@ -14,6 +14,15 @@ interface MixedInterface {
 export type MixedAlias = PrivateInterface;
 
 
+export type PublicAnonymousTypeLiteral = {
+    publicValue: string;
+};
+
+type PrivateAnonymousTypeLiteral = {
+    privateValue: string;
+};
+
+
 export interface MyObject {
     exportInterface: ExportInterface;
     exportAlias: ExportAlias;
@@ -23,4 +32,7 @@ export interface MyObject {
 
     mixedInterface: MixedInterface;
     mixedAlias: MixedAlias;
+
+    publicAnonymousTypeLiteral: PublicAnonymousTypeLiteral;
+    privateAnonymousTypeLiteral: PrivateAnonymousTypeLiteral;
 }

--- a/test/config/expose-none-topref-true/schema.json
+++ b/test/config/expose-none-topref-true/schema.json
@@ -84,6 +84,30 @@
                         "privateValue"
                     ],
                     "additionalProperties": false
+                },
+                "publicAnonymousTypeLiteral": {
+                    "type": "object",
+                    "properties": {
+                        "publicValue": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "publicValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "privateAnonymousTypeLiteral": {
+                    "type": "object",
+                    "properties": {
+                        "privateValue": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "privateValue"
+                    ],
+                    "additionalProperties": false
                 }
             },
             "required": [
@@ -92,7 +116,9 @@
                 "privateInterface",
                 "privateAlias",
                 "mixedInterface",
-                "mixedAlias"
+                "mixedAlias",
+                "publicAnonymousTypeLiteral",
+                "privateAnonymousTypeLiteral"
             ],
             "additionalProperties": false
         }


### PR DESCRIPTION
Running `getFullyQualifiedName()` on an anonymous type literal returns `__type`. This causes all anonymous type literals to be exposed as `__type` in the schema file and overwrite each other.

```
type PrivateAnonymousTypeLiteral = {
    privateValue: string;
};
```

Would be exported as a reference to:

```
"__type": {
    "type": "object",
    "properties": {
        "privateValue": {
            "type": "string"
        }
    },
    "required": [
        "privateValue"
    ],
    "additionalProperties": false
}
```

This pull request prevents the exposing of anonymous type literals.