### PR TITLE
cache `allTypes` Map inside of SchemaGenerator instance

### DIFF
--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -10,6 +10,8 @@ import { StringMap } from "./Utils/StringMap";
 import { localSymbolAtNode, symbolAtNode } from "./Utils/symbolAtNode";
 
 export class SchemaGenerator {
+    private allTypes: Map<string, ts.Node>;
+
     public constructor(
         private program: ts.Program,
         private nodeParser: NodeParser,
@@ -30,15 +32,20 @@ export class SchemaGenerator {
 
     private findRootNode(fullName: string): ts.Node {
         const typeChecker = this.program.getTypeChecker();
-        const allTypes = new Map<string, ts.Node>();
 
-        this.program.getSourceFiles().forEach((sourceFile) => this.inspectNode(sourceFile, typeChecker, allTypes));
+        if (!this.allTypes) {
+            this.allTypes = new Map<string, ts.Node>();
 
-        if (!allTypes.has(fullName)) {
+            this.program.getSourceFiles().forEach(
+                (sourceFile) => this.inspectNode(sourceFile, typeChecker, this.allTypes),
+            );
+        }
+
+        if (!this.allTypes.has(fullName)) {
             throw new NoRootTypeError(fullName);
         }
 
-        return allTypes.get(fullName)!;
+        return this.allTypes.get(fullName)!;
     }
     private inspectNode(node: ts.Node, typeChecker: ts.TypeChecker, allTypes: Map<string, ts.Node>): void {
         if (


### PR DESCRIPTION
Hi! Thanks for maintaining this great library.

We're running into a performance issue when generating schemas on a large codebase.

Our simplified usage pattern is:

```js
const program = createProgram(config);
const parser = createParser(program, config);
const formatter = createFormatter(config);
const g = new SchemaGenerator(program, parser, formatter);

const schemasToGenerate = [ ... ] // insert long array of type names here

schemasToGenerate.forEach((type) => generator.createSchema(type))
```

What we're seeing is that it takes about 11s to initialize the program, parser, formatter, and generator. Then it takes ~800ms for each schema we want to generate using the same instance of the generator.

Upon further investigation, we've found that `createSchema()` calls `findRootNode()`, which walks every files' AST to recreate a mapping (`allTypes`) in order to find the AST node for a particular type. Caching the mapping (as implemented in this PR) improves performance to ~1ms per schema we generate.

We've verified that tests pass and there are no lint issues. Let us know if there's anything else we can do to get this merged 😄