### PR TITLE
Failed Attempt to support conditional types

### DIFF
--- a/factory/parser.ts
+++ b/factory/parser.ts
@@ -2,6 +2,7 @@ import * as ts from "typescript";
 import { BasicAnnotationsReader } from "../src/AnnotationsReader/BasicAnnotationsReader";
 import { ExtendedAnnotationsReader } from "../src/AnnotationsReader/ExtendedAnnotationsReader";
 import { ChainNodeParser } from "../src/ChainNodeParser";
+import { ConditionalTypeNodeParser } from '../src/NodeParser/ConditionalTypeNodeParser';
 import { CircularReferenceNodeParser } from "../src/CircularReferenceNodeParser";
 import { Config } from "../src/Config";
 import { ExposeNodeParser } from "../src/ExposeNodeParser";
@@ -83,6 +84,7 @@ export function createParser(program: ts.Program, config: Config): NodeParser {
         .addNodeParser(new IndexedAccessTypeNodeParser(typeChecker, chainNodeParser))
         .addNodeParser(new TypeofNodeParser(typeChecker, chainNodeParser))
         .addNodeParser(new MappedTypeNodeParser(typeChecker, chainNodeParser))
+        .addNodeParser(new ConditionalTypeNodeParser(typeChecker, chainNodeParser))
         .addNodeParser(new TypeOperatorNodeParser(typeChecker, chainNodeParser))
 
         .addNodeParser(new UnionNodeParser(typeChecker, chainNodeParser))

--- a/src/NodeParser/ConditionalTypeNodeParser.ts
+++ b/src/NodeParser/ConditionalTypeNodeParser.ts
@@ -1,0 +1,27 @@
+import * as ts from "typescript";
+
+import { SubNodeParser } from "../SubNodeParser";
+import { Context, NodeParser } from "../NodeParser";
+import { BaseType } from "../Type/BaseType";
+import { NullType } from "../Type/NullType";
+
+export class ConditionalTypeNodeParser implements SubNodeParser {
+    public constructor(
+        private typeChecker: ts.TypeChecker,
+        private childNodeParser: NodeParser,
+    ) {
+    }
+
+    public supportsNode(node: ts.Node): boolean {
+        return (node.kind === ts.SyntaxKind.ConditionalType);
+    }
+
+    public createType(node: ts.ConditionalTypeNode, context: Context): BaseType {
+        // Wanted: Resolving the conditional type and somehow let the rest of
+        // the generator do its magic
+        const actualType = this.typeChecker.getTypeFromTypeNode(node);
+
+        // Obviously wrong, just checking what happens
+        return (new NullType());
+    }
+}

--- a/test/valid-data.test.ts
+++ b/test/valid-data.test.ts
@@ -108,6 +108,8 @@ describe("valid-data", () => {
     assertSchema("type-typeof", "MyType");
     assertSchema("type-typeof-value", "MyType");
 
+    assertSchema("type-conditional-simple", "Usage");
+
     assertSchema("type-indexed-access-tuple-1", "MyType");
     assertSchema("type-indexed-access-tuple-2", "MyType");
     assertSchema("type-indexed-access-object-1", "MyType");

--- a/test/valid-data/type-conditional-simple/main.ts
+++ b/test/valid-data/type-conditional-simple/main.ts
@@ -1,0 +1,20 @@
+// Basically the first example from
+// https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
+type TypeName<T> =
+    T extends string ? "string" :
+    T extends number ? "number" :
+    T extends boolean ? "boolean" :
+    T extends undefined ? "undefined" :
+    "object";
+
+export type T0 = TypeName<string>;  // "string"
+export type T1 = TypeName<"a">;  // "string"
+export type T2 = TypeName<true>;  // "boolean"
+export type T3 = TypeName<string[]>;  // "object"
+
+export interface Usage {
+    t0: T0,
+    t1: T1,
+    t2: T2,
+    t3: T3
+}

--- a/test/valid-data/type-conditional-simple/schema.json
+++ b/test/valid-data/type-conditional-simple/schema.json
@@ -1,0 +1,49 @@
+{
+    "$ref": "#/definitions/Usage",
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "definitions": {
+      "Usage": {
+        "additionalProperties": false,
+        "properties": {
+          "t0": {
+            "enum": [
+              "string"
+            ],
+            "type": "string"
+          },
+          "t1": {
+            "enum": [
+              "string"
+            ],
+            "type": "string"
+          },
+          "t2": {
+            "enum": [
+              "boolean"
+            ],
+            "type": "string"
+          },
+          "t3": {
+            "enum": [
+              "function"
+            ],
+            "type": "string"
+          },
+          "t4": {
+            "enum": [
+              "object"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "t0",
+          "t1",
+          "t2",
+          "t3",
+          "t4"
+        ],
+        "type": "object"
+      }
+    }
+  }


### PR DESCRIPTION
Please do not merge this right now, the code is plainly wrong and simply generates `null`-definitions for every conditional type. But maybe someone can point me in the right direction on how to tackle this?

My problem (and the reason for my attempt) is a continuation from yesterday, this time the source I am interested in uses conditional types and reads as follows:

```
// Resolves a value at runtime. The value must be the name of a parameter
// that has been formally introduced before.
export interface ParameterReference {
  "$ref": string
}

// Allows properties of an object to be optional and to be
// a reference that can be resolved to an actual value later.
export type ParameterReferenceable<T> = {
  [P in keyof T]?: T[P] extends Object
  ? ParameterReferenceable<T[P]> | ParameterReference
  : T[P] | ParameterReference
}

export interface Instructions {
  str: string
  num: number
  obj: {
    [name:string]: string
  }
}

// Of interest: A type that is generated by the conditional mapped type.
export type ParamInstructions = ParameterReferenceable<Instructions>
```

This input is rejected because of the conditional type `ParameterReferenceable` which is, at least to my knowledge, not a type that could be expressed directly using JSON-schema.

I am however interested in the the type `ParamInstructions` that is generated by this mapped conditional type. My knowledge of the Typescript internals is close to zero, but I am aware that the `tsserver` can properly resolve a conditional mapped type to show me the actual resulting type. So I am hopeful that it shouldn't be impossible to to incorporate this and attempted to start hacking on.

From my understanding I would need to introduce a new subclass of `NodeParser` and register it. But the more I am looking in to this the more I recognize that I don't quite get how to go from here. My first impression was to simply call `typeChecker.getTypeAtLocation()` but then I realized that this is exactly what this generator prides itself in **not** doing.

So before I wander of in an entirely unreasonable direction ... My basic approach boils down to two steps and I have no Idea on how to do either of them:

1) Resolve the conditional type to the "actual" type (instead of all those `true` and `false` types the AST-Explorer shows).
2) Hand of that type to be treated as the generator treats every type.

Maybe conditional types are even something that could be treated as part of the `derefType`-function? From my limited understanding this would mean that they could be transparently treated altogether.

Could anyone point me in the correct direction in how to do that? It feels like both of those building blocks should be in arms reach but I have no idea where to look for them.