### PR TITLE
Add support for FunctionType

### DIFF
--- a/factory/formatter.ts
+++ b/factory/formatter.ts
@@ -9,6 +9,7 @@ import { ArrayTypeFormatter } from "../src/TypeFormatter/ArrayTypeFormatter";
 import { BooleanTypeFormatter } from "../src/TypeFormatter/BooleanTypeFormatter";
 import { DefinitionTypeFormatter } from "../src/TypeFormatter/DefinitionTypeFormatter";
 import { EnumTypeFormatter } from "../src/TypeFormatter/EnumTypeFormatter";
+import { FunctionTypeFormatter } from "../src/TypeFormatter/FunctionTypeFormatter";
 import { IntersectionTypeFormatter } from "../src/TypeFormatter/IntersectionTypeFormatter";
 import { LiteralTypeFormatter } from "../src/TypeFormatter/LiteralTypeFormatter";
 import { LiteralUnionTypeFormatter } from "../src/TypeFormatter/LiteralUnionTypeFormatter";
@@ -58,7 +59,8 @@ export function createFormatter(config: Config): TypeFormatter {
         .addTypeFormatter(new ArrayTypeFormatter(circularReferenceTypeFormatter))
         .addTypeFormatter(new TupleTypeFormatter(circularReferenceTypeFormatter))
         .addTypeFormatter(new UnionTypeFormatter(circularReferenceTypeFormatter))
-        .addTypeFormatter(new IntersectionTypeFormatter(circularReferenceTypeFormatter));
+        .addTypeFormatter(new IntersectionTypeFormatter(circularReferenceTypeFormatter))
+        .addTypeFormatter(new FunctionTypeFormatter(circularReferenceTypeFormatter));
 
     return circularReferenceTypeFormatter;
 }

--- a/factory/parser.ts
+++ b/factory/parser.ts
@@ -14,6 +14,7 @@ import { BooleanTypeNodeParser } from "../src/NodeParser/BooleanTypeNodeParser";
 import { CallExpressionParser } from "../src/NodeParser/CallExpressionParser";
 import { EnumNodeParser } from "../src/NodeParser/EnumNodeParser";
 import { ExpressionWithTypeArgumentsNodeParser } from "../src/NodeParser/ExpressionWithTypeArgumentsNodeParser";
+import { FunctionTypeNodeParser } from "../src/NodeParser/FunctionTypeNodeParser";
 import { IndexedAccessTypeNodeParser } from "../src/NodeParser/IndexedAccessTypeNodeParser";
 import { InterfaceNodeParser } from "../src/NodeParser/InterfaceNodeParser";
 import { IntersectionNodeParser } from "../src/NodeParser/IntersectionNodeParser";
@@ -90,6 +91,7 @@ export function createParser(program: ts.Program, config: Config): NodeParser {
         .addNodeParser(new UnionNodeParser(typeChecker, chainNodeParser))
         .addNodeParser(new IntersectionNodeParser(typeChecker, chainNodeParser))
         .addNodeParser(new TupleNodeParser(typeChecker, chainNodeParser))
+        .addNodeParser(new FunctionTypeNodeParser(typeChecker, chainNodeParser))
         .addNodeParser(new OptionalTypeNodeParser(chainNodeParser))
         .addNodeParser(new RestTypeNodeParser(chainNodeParser))
 

--- a/src/NodeParser/FunctionTypeNodeParser.ts
+++ b/src/NodeParser/FunctionTypeNodeParser.ts
@@ -1,0 +1,34 @@
+import * as ts from "typescript";
+import { Context, NodeParser } from "../NodeParser";
+import { SubNodeParser } from "../SubNodeParser";
+import { BaseType } from "../Type/BaseType";
+import { FunctionType } from "../Type/FunctionType";
+import { referenceHidden } from "../Utils/isHidden";
+
+export class FunctionTypeNodeParser implements SubNodeParser {
+    public constructor(
+        private typeChecker: ts.TypeChecker,
+        private childNodeParser: NodeParser,
+    ) {
+    }
+
+    public supportsNode(node: ts.FunctionTypeNode): boolean {
+      return node.kind === ts.SyntaxKind.FunctionType;
+    }
+
+    public createType(node: ts.FunctionTypeNode, context: Context): BaseType {
+      const hidden = referenceHidden(this.typeChecker);
+      return new FunctionType(
+            node.parameters
+                .filter((item) => !hidden(item))
+                .map((item) => {
+                  if (item.type) {
+                    return this.childNodeParser.createType(item.type, context);
+                  }
+
+                  throw new Error("FunctionTypeNodeParser: parameter does not have a type");
+                }),
+            this.childNodeParser.createType(node.type, context),
+      );
+    }
+}

--- a/src/Type/FunctionType.ts
+++ b/src/Type/FunctionType.ts
@@ -1,0 +1,22 @@
+import { BaseType } from "./BaseType";
+
+export class FunctionType extends BaseType {
+  public constructor(
+    private argumentTypes: BaseType[],
+    private returnType: BaseType,
+  ) {
+    super();
+  }
+
+  public getId(): string {
+    return "(" + this.argumentTypes.map((item) => item.getId()).join(",") + ") => " + this.returnType.getId();
+  }
+
+  public getArgumentTypes(): BaseType[] {
+    return this.argumentTypes;
+  }
+
+  public getReturnType(): BaseType {
+    return this.returnType;
+  }
+}

--- a/src/Type/FunctionType.ts
+++ b/src/Type/FunctionType.ts
@@ -2,17 +2,25 @@ import { BaseType } from "./BaseType";
 
 export class FunctionType extends BaseType {
   public constructor(
-    private argumentTypes: BaseType[],
+    private argumentOrder: string[],
+    private argumentTypes: { [key: string]: BaseType },
     private returnType: BaseType,
   ) {
     super();
   }
 
   public getId(): string {
-    return "(" + this.argumentTypes.map((item) => item.getId()).join(",") + ") => " + this.returnType.getId();
+    return "("
+      + Object.values(this.argumentTypes).map((item) => item.getId()).join(",")
+      + ") => "
+      + this.returnType.getId();
   }
 
-  public getArgumentTypes(): BaseType[] {
+  public getArgumentOrder(): string[] {
+    return this.argumentOrder;
+  }
+
+  public getArgumentTypes(): { [key: string]: BaseType } {
     return this.argumentTypes;
   }
 

--- a/src/TypeFormatter/FunctionTypeFormatter.ts
+++ b/src/TypeFormatter/FunctionTypeFormatter.ts
@@ -1,0 +1,32 @@
+import { Definition } from "../Schema/Definition";
+import { SubTypeFormatter } from "../SubTypeFormatter";
+import { BaseType } from "../Type/BaseType";
+import { FunctionType } from "../Type/FunctionType";
+import { TypeFormatter } from "../TypeFormatter";
+
+export class FunctionTypeFormatter implements SubTypeFormatter {
+    public constructor(
+        private childTypeFormatter: TypeFormatter,
+    ) {
+    }
+
+    public supportsType(type: FunctionType): boolean {
+        return type instanceof FunctionType;
+    }
+    public getDefinition(type: FunctionType): Definition {
+        const argTypes = type.getArgumentTypes();
+        const returnType = type.getReturnType();
+
+        const argDefinitions = argTypes.map((item) => this.childTypeFormatter.getDefinition(item));
+
+        return {
+          type: "function",
+          items: argDefinitions,
+          additionalItems: this.childTypeFormatter.getDefinition(returnType),
+        };
+    }
+    public getChildren(type: FunctionType): BaseType[] {
+        return [];
+    }
+}
+

--- a/src/TypeFormatter/FunctionTypeFormatter.ts
+++ b/src/TypeFormatter/FunctionTypeFormatter.ts
@@ -18,7 +18,9 @@ export class FunctionTypeFormatter implements SubTypeFormatter {
         const propertyOrder = type.getArgumentOrder();
         const returnType = type.getReturnType();
 
-        const properties: DefinitionMap = {};
+        const properties: DefinitionMap = {
+          __returnValue__: this.childTypeFormatter.getDefinition(returnType),
+        };
         Object.entries(argTypes).forEach(([key, value]) => {
           properties[key] = this.childTypeFormatter.getDefinition(value);
         });
@@ -27,7 +29,6 @@ export class FunctionTypeFormatter implements SubTypeFormatter {
           type: "function",
           properties,
           propertyOrder,
-          additionalItems: this.childTypeFormatter.getDefinition(returnType),
         };
     }
     public getChildren(type: FunctionType): BaseType[] {

--- a/src/TypeFormatter/FunctionTypeFormatter.ts
+++ b/src/TypeFormatter/FunctionTypeFormatter.ts
@@ -1,4 +1,4 @@
-import { Definition } from "../Schema/Definition";
+import { Definition, DefinitionMap } from "../Schema/Definition";
 import { SubTypeFormatter } from "../SubTypeFormatter";
 import { BaseType } from "../Type/BaseType";
 import { FunctionType } from "../Type/FunctionType";
@@ -15,18 +15,26 @@ export class FunctionTypeFormatter implements SubTypeFormatter {
     }
     public getDefinition(type: FunctionType): Definition {
         const argTypes = type.getArgumentTypes();
+        const propertyOrder = type.getArgumentOrder();
         const returnType = type.getReturnType();
 
-        const argDefinitions = argTypes.map((item) => this.childTypeFormatter.getDefinition(item));
+        const properties: DefinitionMap = {};
+        Object.entries(argTypes).forEach(([key, value]) => {
+          properties[key] = this.childTypeFormatter.getDefinition(value);
+        });
 
         return {
           type: "function",
-          items: argDefinitions,
+          properties,
+          propertyOrder,
           additionalItems: this.childTypeFormatter.getDefinition(returnType),
         };
     }
     public getChildren(type: FunctionType): BaseType[] {
-        return [];
+        return Object.values(type.getArgumentTypes()).reduce((result: BaseType[], item) => [
+            ...result,
+            ...this.childTypeFormatter.getChildren(item),
+        ], []);
     }
 }
 


### PR DESCRIPTION
Hi @domoritz,

As mentioned in https://github.com/YousefED/typescript-json-schema/issues/246#issuecomment-424806533 i ran into an unsupported type that happens to be `FunctionType`. Here's my first pass at implementing support and if possible would love to get some feedback.

Some things are still rough around the edges... I have a random error being thrown in `FunctionTypeNodeParser` and the indentation isn't consistent yet, but before fixing up all of that want to make sure I'm on the right path.

Thanks for any guidance!