### PR TITLE
allow skipping of type checking to improve speed

### DIFF
--- a/factory/program.ts
+++ b/factory/program.ts
@@ -51,9 +51,11 @@ export function createProgram(config: Config): ts.Program {
         createProgramFromConfig(config.path) :
         createProgramFromGlob(config.path);
 
-    const diagnostics = ts.getPreEmitDiagnostics(program);
-    if (diagnostics.length) {
-        throw new DiagnosticError(diagnostics);
+    if (!config.skipTypeCheck) {
+        const diagnostics = ts.getPreEmitDiagnostics(program);
+        if (diagnostics.length) {
+            throw new DiagnosticError(diagnostics);
+        }
     }
 
     return program;

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -5,6 +5,7 @@ export interface PartialConfig {
     jsDoc: "none" | "extended" | "basic";
     sortProps?: boolean;
     strictTuples?: boolean;
+    skipTypeCheck?: boolean;
 }
 
 export interface Config extends PartialConfig {
@@ -18,4 +19,5 @@ export const DEFAULT_CONFIG: PartialConfig = {
     jsDoc: "extended",
     sortProps: true,
     strictTuples: false,
+    skipTypeCheck: false,
 };


### PR DESCRIPTION
Hello again!

We're looking into schema generation performance again and we've found that skipping the type checking saves us a lot of time. In our flow, the actual TS to JS compilation does type checking, so we don't need the JSON schema generation to also do type checking.

Hope you find this useful as well. If you do, let me know what else I can do to get this merged! 😄 