### PR TITLE
add test to ensure skipTypeCheck doesn't alter output

### DIFF
--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -63,5 +63,11 @@ describe("config", () => {
     assertSchema("jsdoc-inheritance", {type: "MyObject", expose: "export", topRef: true, jsDoc: "extended"});
 
     // ensure that skipping type checking doesn't alter the JSON schema output
-    assertSchema("jsdoc-complex-extended", {type: "MyObject", expose: "export", topRef: true, jsDoc: "extended", skipTypeCheck: true});
+    assertSchema("jsdoc-complex-extended", {
+        type: "MyObject",
+        expose: "export",
+        topRef: true,
+        jsDoc: "extended",
+        skipTypeCheck: true,
+    });
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -61,4 +61,7 @@ describe("config", () => {
 
     assertSchema("jsdoc-hide", {type: "MyObject", expose: "export", topRef: true, jsDoc: "extended"});
     assertSchema("jsdoc-inheritance", {type: "MyObject", expose: "export", topRef: true, jsDoc: "extended"});
+
+    // ensure that skipping type checking doesn't alter the JSON schema output
+    assertSchema("jsdoc-complex-extended", {type: "MyObject", expose: "export", topRef: true, jsDoc: "extended", skipTypeCheck: true});
 });


### PR DESCRIPTION
Hey, thanks for merging https://github.com/vega/ts-json-schema-generator/pull/50 😄 

What do you think of this for adding tests? I basically want to ensure that adding the `skipTypeCheck` option doesn't alter the output in any way. I chose `jsdoc-complex-extended` because it seemed to be the most complex case. Another option is to double up every test with `skipTypeCheck: true`, but that will significantly increase test time.