### PR TITLE
add support for mapped types with single property

### DIFF
--- a/src/NodeParser/MappedTypeNodeParser.ts
+++ b/src/NodeParser/MappedTypeNodeParser.ts
@@ -27,6 +27,9 @@ export class MappedTypeNodeParser implements SubNodeParser {
         if (keyListType instanceof UnionType) {
             // Key type resolves to a set of known properties
             return new ObjectType(id, [], this.getProperties(node, keyListType, context), false);
+        } else if (keyListType instanceof LiteralType) {
+            // Key type resolves to single known property
+            return new ObjectType(id, [], this.getProperties(node, new UnionType([keyListType]), context), false);
         } else if (keyListType instanceof StringType) {
             // Key type widens to `string`
             return new ObjectType(id, [], [], this.childNodeParser.createType(node.type!, context));

--- a/test/valid-data.test.ts
+++ b/test/valid-data.test.ts
@@ -124,6 +124,7 @@ describe("valid-data", () => {
     assertSchema("type-mapped-literal", "MyObject");
     assertSchema("type-mapped-generic", "MyObject");
     assertSchema("type-mapped-native", "MyObject");
+    assertSchema("type-mapped-native-single-literal", "MyObject");
     assertSchema("type-mapped-widened", "MyObject");
 
     assertSchema("generic-simple", "MyObject");

--- a/test/valid-data/type-mapped-native-single-literal/main.ts
+++ b/test/valid-data/type-mapped-native-single-literal/main.ts
@@ -1,0 +1,1 @@
+export type MyObject = Pick<Record<"a" | "b" | "c", string>, "a">;

--- a/test/valid-data/type-mapped-native-single-literal/schema.json
+++ b/test/valid-data/type-mapped-native-single-literal/schema.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "definitions": {
+        "MyObject": {
+            "type": "object",
+            "properties": {
+                "a": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "a"
+            ]
+        }
+    },
+    "$ref": "#/definitions/MyObject"
+}


### PR DESCRIPTION
Found a case where we use `Pick` with a single property and it was failing.