### PR TITLE
add flag to prioritize glob of files when searching for types

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ npm install --save ts-json-schema-generator
 
 -u, --unstable
     Do not sort properties.
+
+-f, --files
+    Hint to the compiler which files to search first for your type. Should be a quoted glob (e.g., `'my/project/**/*.ts'`).
 ```
 
 

--- a/factory/generator.ts
+++ b/factory/generator.ts
@@ -9,5 +9,5 @@ export function createGenerator(config: Config): SchemaGenerator {
     const parser = createParser(program, config);
     const formatter = createFormatter(config);
 
-    return new SchemaGenerator(program, parser, formatter);
+    return new SchemaGenerator(program, parser, formatter, config);
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "commander": "~2.19.0",
     "glob": "~7.1.3",
+    "glob-to-regexp": "^0.4.0",
     "json-stable-stringify": "^1.0.1",
     "typescript": "^3.2.4"
   },

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -6,6 +6,7 @@ export interface PartialConfig {
     sortProps?: boolean;
     strictTuples?: boolean;
     skipTypeCheck?: boolean;
+    files?: string;
 }
 
 export interface Config extends PartialConfig {

--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -1,4 +1,6 @@
+import * as path from "path";
 import * as ts from "typescript";
+import { Config } from "./Config";
 import { NoRootTypeError } from "./Error/NoRootTypeError";
 import { Context, NodeParser } from "./NodeParser";
 import { Definition } from "./Schema/Definition";
@@ -8,15 +10,36 @@ import { DefinitionType } from "./Type/DefinitionType";
 import { TypeFormatter } from "./TypeFormatter";
 import { StringMap } from "./Utils/StringMap";
 import { localSymbolAtNode, symbolAtNode } from "./Utils/symbolAtNode";
+const globToRegExp = require("glob-to-regexp");
 
 export class SchemaGenerator {
     private allTypes: Map<string, ts.Node>;
+    private prioritizedFiles: ts.SourceFile[];
+    private unprioritizedFiles: ts.SourceFile[];
 
     public constructor(
         private program: ts.Program,
         private nodeParser: NodeParser,
         private typeFormatter: TypeFormatter,
+        config: Config,
     ) {
+        this.allTypes = new Map<string, ts.Node>();
+
+        const sourceFiles = this.program.getSourceFiles();
+        this.prioritizedFiles = [];
+        this.unprioritizedFiles = [];
+        if (config.files) {
+            const fileRegex: RegExp = globToRegExp(path.resolve(config.files), {globstar: true});
+            sourceFiles.forEach((f) => {
+                if (fileRegex.test(f.fileName)) {
+                    this.prioritizedFiles.push(f);
+                } else {
+                    this.unprioritizedFiles.push(f);
+                }
+            });
+        } else {
+            this.unprioritizedFiles = sourceFiles.slice();
+        }
     }
 
     public createSchema(fullName: string): Schema {
@@ -33,19 +56,33 @@ export class SchemaGenerator {
     private findRootNode(fullName: string): ts.Node {
         const typeChecker = this.program.getTypeChecker();
 
-        if (!this.allTypes) {
-            this.allTypes = new Map<string, ts.Node>();
-
-            this.program.getSourceFiles().forEach(
-                (sourceFile) => this.inspectNode(sourceFile, typeChecker, this.allTypes),
+        if (this.prioritizedFiles.length) {
+            this.prioritizedFiles.forEach(
+                (sourceFile) => {
+                    this.inspectNode(sourceFile, typeChecker, this.allTypes);
+                },
             );
+            this.prioritizedFiles = [];
         }
 
-        if (!this.allTypes.has(fullName)) {
-            throw new NoRootTypeError(fullName);
+        if (this.allTypes.has(fullName)) {
+            return this.allTypes.get(fullName)!;
         }
 
-        return this.allTypes.get(fullName)!;
+        if (this.unprioritizedFiles.length) {
+            this.unprioritizedFiles.forEach(
+                (sourceFile) => {
+                    this.inspectNode(sourceFile, typeChecker, this.allTypes);
+                },
+            );
+            this.unprioritizedFiles = [];
+        }
+
+        if (this.allTypes.has(fullName)) {
+            return this.allTypes.get(fullName)!;
+        }
+
+        throw new NoRootTypeError(fullName);
     }
     private inspectNode(node: ts.Node, typeChecker: ts.TypeChecker, allTypes: Map<string, ts.Node>): void {
         if (

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -31,6 +31,7 @@ function assertSchema(name: string, partialConfig: PartialConfig & {type: string
             program,
             createParser(program, config),
             createFormatter(config),
+            config,
         );
 
         const expected: any = JSON.parse(readFileSync(resolve(`${basePath}/${name}/schema.json`), "utf8"));
@@ -69,5 +70,14 @@ describe("config", () => {
         topRef: true,
         jsDoc: "extended",
         skipTypeCheck: true,
+    });
+
+    // ensure that prioritizing files doesn't alter the JSON schema output
+    assertSchema("jsdoc-complex-extended", {
+        type: "MyObject",
+        expose: "export",
+        topRef: true,
+        jsDoc: "extended",
+        files: "test/config/**/*",
     });
 });

--- a/test/invalid-data.test.ts
+++ b/test/invalid-data.test.ts
@@ -23,6 +23,7 @@ function assertSchema(name: string, type: string, message: string): void {
             program,
             createParser(program, config),
             createFormatter(config),
+            config,
         );
 
         assert.throws(() => generator.createSchema(type), message);

--- a/test/valid-data.test.ts
+++ b/test/valid-data.test.ts
@@ -37,6 +37,7 @@ function assertSchema(name: string, type: string, only: boolean = false): void {
             program,
             createParser(program, config),
             createFormatter(config),
+            config,
         );
 
         const schema = generator.createSchema(type);

--- a/ts-json-schema-generator.ts
+++ b/ts-json-schema-generator.ts
@@ -33,8 +33,12 @@ const args = commander
         "Do not allow additional items on tuples",
     )
     .option(
-        "-c, --no-type-check",
+        "-c, --skip-type-check",
         "Skip type checks to improve performance",
+    )
+    .option(
+        "-f, --files <files>",
+        "Hint to the compiler which files to search first for your type",
     )
     .parse(process.argv);
 
@@ -47,7 +51,8 @@ const config: Config = {
     jsDoc: args.jsDoc,
     sortProps: !args.unstable,
     strictTuples: args.strictTuples,
-    skipTypeCheck: !args.typeCheck,
+    skipTypeCheck: args.skipTypeCheck,
+    files: args.files,
 };
 
 try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1243,6 +1243,11 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
+glob-to-regexp@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.0.tgz#49bd677b1671022bd10921c3788f23cdebf9c7e6"
+  integrity sha512-fyPCII4vn9Gvjq2U/oDAfP433aiE64cyP/CJjRJcpVGjqqNdioUYn9+r0cSzT1XPwmGAHuTT7iv+rQT8u/YHKQ==
+
 glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"


### PR DESCRIPTION
`--files 'src/resources/**'` argument will search those files first for the given type.

Shaves off less than a second in my usage, but it's still an improvement:

```
~/d/api ❯❯❯ time node ../ts-json-schema-generator/bin/ts-json-schema-generator --path ./tsconfig.json --type 'UserConvertTypePayload' --skip-type-check
10.38s user 0.65s system 166% cpu 6.609 total
~/d/api ❯❯❯ time node ../ts-json-schema-generator/bin/ts-json-schema-generator --path ./tsconfig.json --type 'UserConvertTypePayload' --skip-type-check --files 'src/resources/**'
9.65s user 0.62s system 168% cpu 6.085 total
```
resolves #59 