### PR TITLE
handle dom interfaces 

### DIFF
--- a/factory/formatter.ts
+++ b/factory/formatter.ts
@@ -23,7 +23,7 @@ import { StringTypeFormatter } from "../src/TypeFormatter/StringTypeFormatter";
 import { TupleTypeFormatter } from "../src/TypeFormatter/TupleTypeFormatter";
 import { UndefinedTypeFormatter } from "../src/TypeFormatter/UndefinedTypeFormatter";
 import { UnionTypeFormatter } from "../src/TypeFormatter/UnionTypeFormatter";
-
+import { UnknownNodeFormatter } from "../src/TypeFormatter/UnknownNodeFormatter";
 
 
 export function createFormatter(config: Config): TypeFormatter {
@@ -58,7 +58,10 @@ export function createFormatter(config: Config): TypeFormatter {
         .addTypeFormatter(new ArrayTypeFormatter(circularReferenceTypeFormatter))
         .addTypeFormatter(new TupleTypeFormatter(circularReferenceTypeFormatter))
         .addTypeFormatter(new UnionTypeFormatter(circularReferenceTypeFormatter))
-        .addTypeFormatter(new IntersectionTypeFormatter(circularReferenceTypeFormatter));
+
+        .addTypeFormatter(new IntersectionTypeFormatter(circularReferenceTypeFormatter))
+
+        .addTypeFormatter(new UnknownNodeFormatter());
 
     return circularReferenceTypeFormatter;
 }

--- a/factory/parser.ts
+++ b/factory/parser.ts
@@ -36,6 +36,7 @@ import { TypeOperatorNodeParser } from "../src/NodeParser/TypeOperatorNodeParser
 import { TypeReferenceNodeParser } from "../src/NodeParser/TypeReferenceNodeParser";
 import { UndefinedTypeNodeParser } from "../src/NodeParser/UndefinedTypeNodeParser";
 import { UnionNodeParser } from "../src/NodeParser/UnionNodeParser";
+import { UnknownNodeParser } from "../src/NodeParser/UnknownNodeParser";
 import { SubNodeParser } from "../src/SubNodeParser";
 import { TopRefNodeParser } from "../src/TopRefNodeParser";
 
@@ -64,6 +65,7 @@ export function createParser(program: ts.Program, config: Config): NodeParser {
     }
 
     chainNodeParser
+
         .addNodeParser(new StringTypeNodeParser())
         .addNodeParser(new NumberTypeNodeParser())
         .addNodeParser(new BooleanTypeNodeParser())
@@ -105,7 +107,10 @@ export function createParser(program: ts.Program, config: Config): NodeParser {
             new TypeLiteralNodeParser(withJsDoc(chainNodeParser)),
         ))))
 
-        .addNodeParser(new ArrayNodeParser(chainNodeParser));
+        .addNodeParser(new ArrayNodeParser(chainNodeParser))
+
+        .addNodeParser(new UnknownNodeParser());
+
 
     return withTopRef(chainNodeParser);
 }

--- a/src/CircularReferenceNodeParser.ts
+++ b/src/CircularReferenceNodeParser.ts
@@ -4,6 +4,10 @@ import { SubNodeParser } from "./SubNodeParser";
 import { BaseType } from "./Type/BaseType";
 import { ReferenceType } from "./Type/ReferenceType";
 
+const reserveTypes: { [index: number]: boolean } = {
+    [ts.SyntaxKind.TypeAliasDeclaration]: true,
+};
+
 export class CircularReferenceNodeParser implements SubNodeParser {
     private circular = new Map<string, BaseType>();
 
@@ -13,6 +17,9 @@ export class CircularReferenceNodeParser implements SubNodeParser {
     }
 
     public supportsNode(node: ts.Node): boolean {
+        if (!reserveTypes[node.kind] && node.getSourceFile().fileName.includes("/node_modules/")) {
+            return false;
+        }
         return this.childNodeParser.supportsNode(node);
     }
     public createType(node: ts.Node, context: Context): BaseType {

--- a/src/NodeParser/UnknownNodeParser.ts
+++ b/src/NodeParser/UnknownNodeParser.ts
@@ -1,0 +1,22 @@
+import * as ts from "typescript";
+import { Context } from "../NodeParser";
+import { SubNodeParser } from "../SubNodeParser";
+import { BaseType } from "../Type/BaseType";
+import { UnknownNodeType } from "../Type/UnknownNodeType";
+import { symbolAtNode } from "../Utils/symbolAtNode";
+
+const ignoreTypes: { [index: number]: boolean } = {
+    [ts.SyntaxKind.ObjectLiteralExpression]: true,
+};
+
+export class UnknownNodeParser implements SubNodeParser {
+    public supportsNode(node: ts.Node): boolean {
+        if (ignoreTypes[node.kind]) { return false; }
+        const symbol = symbolAtNode(node);
+        return symbol ? true : false;
+    }
+    public createType(node: ts.Node, context: Context): BaseType {
+        const symbol = symbolAtNode(node)!;
+        return new UnknownNodeType(symbol.name);
+    }
+}

--- a/src/Type/UnknownNodeType.ts
+++ b/src/Type/UnknownNodeType.ts
@@ -1,0 +1,11 @@
+import { PrimitiveType } from "./PrimitiveType";
+
+export class UnknownNodeType extends PrimitiveType {
+    public constructor(private type: string) {
+        super();
+    }
+
+    public getId(): string {
+        return this.type;
+    }
+}

--- a/src/TypeFormatter/UnknownNodeFormatter.ts
+++ b/src/TypeFormatter/UnknownNodeFormatter.ts
@@ -1,0 +1,16 @@
+import { Definition } from "../Schema/Definition";
+import { SubTypeFormatter } from "../SubTypeFormatter";
+import { BaseType } from "../Type/BaseType";
+import { UnknownNodeType } from "../Type/UnknownNodeType";
+
+export class UnknownNodeFormatter implements SubTypeFormatter {
+    public supportsType(type: UnknownNodeType): boolean {
+        return type instanceof UnknownNodeType;
+    }
+    public getDefinition(type: UnknownNodeType): Definition {
+        return { type: type.getId() };
+    }
+    public getChildren(type: UnknownNodeType): BaseType[] {
+        return [];
+    }
+}


### PR DESCRIPTION
I need the 'HTMLElement' type for a property, because HTMLElement is an interface it causes the program to loop all the members of HTMLElement, to solve the problem I created this PR, it will ignore the circularly referenced types that are from the node_modules folder and use their name for type.

so the result would be:

```
export interface MyObject {
    el: HTMLElement;
}
```

JSON:

```
{
  "$schema": "http://json-schema.org/draft-06/schema#",
  "definitions": {
    "MyObject": {
      "type": "object",
      "properties": {
        "el": {
          "type": "HTMLElement"
        }
      },
      "required": [
        "el"
      ],
      "additionalProperties": false
    }
  },
  "$ref": "#/definitions/MyObject"
}
```

not sure if its a good idea, but it works for, it could help someone else too. if there is a better way to do this please let me know.

Thanks,
