### PR TITLE
Parse additional keywords from jsDoc annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ npm install --save ts-json-schema-generator
 
 -u, --unstable
     Do not sort properties.
+
+-k, --validationKeywords
+    Provide additional validation keywords to include.
 ```
 
 

--- a/factory/parser.ts
+++ b/factory/parser.ts
@@ -52,9 +52,11 @@ export function createParser(program: ts.Program, config: Config): NodeParser {
     }
     function withJsDoc(nodeParser: SubNodeParser): SubNodeParser {
         if (config.jsDoc === "extended") {
-            return new AnnotatedNodeParser(nodeParser, new ExtendedAnnotationsReader(typeChecker, config.extraJsonTags));
+            return new AnnotatedNodeParser(nodeParser,
+                new ExtendedAnnotationsReader(typeChecker, config.extraJsonTags));
         } else if (config.jsDoc === "basic") {
-            return new AnnotatedNodeParser(nodeParser, new BasicAnnotationsReader(config.extraJsonTags));
+            return new AnnotatedNodeParser(nodeParser,
+                new BasicAnnotationsReader(config.extraJsonTags));
         } else {
             return nodeParser;
         }

--- a/factory/parser.ts
+++ b/factory/parser.ts
@@ -52,9 +52,9 @@ export function createParser(program: ts.Program, config: Config): NodeParser {
     }
     function withJsDoc(nodeParser: SubNodeParser): SubNodeParser {
         if (config.jsDoc === "extended") {
-            return new AnnotatedNodeParser(nodeParser, new ExtendedAnnotationsReader(typeChecker));
+            return new AnnotatedNodeParser(nodeParser, new ExtendedAnnotationsReader(typeChecker, config.extraJsonTags));
         } else if (config.jsDoc === "basic") {
-            return new AnnotatedNodeParser(nodeParser, new BasicAnnotationsReader());
+            return new AnnotatedNodeParser(nodeParser, new BasicAnnotationsReader(config.extraJsonTags));
         } else {
             return nodeParser;
         }

--- a/src/AnnotationsReader/BasicAnnotationsReader.ts
+++ b/src/AnnotationsReader/BasicAnnotationsReader.ts
@@ -35,6 +35,9 @@ export class BasicAnnotationsReader implements AnnotationsReader {
         "default",
     ];
 
+    constructor(private extraJsonTags?: string[]) { }
+
+
     public getAnnotations(node: ts.Node): Annotations | undefined {
         const symbol = symbolAtNode(node);
         if (!symbol) {
@@ -65,6 +68,8 @@ export class BasicAnnotationsReader implements AnnotationsReader {
         if (BasicAnnotationsReader.textTags.indexOf(jsDocTag.name) >= 0) {
             return jsDocTag.text;
         } else if (BasicAnnotationsReader.jsonTags.indexOf(jsDocTag.name) >= 0) {
+            return this.parseJson(jsDocTag.text);
+        } else if (this.extraJsonTags !== undefined && this.extraJsonTags.indexOf(jsDocTag.name) >= 0) {
             return this.parseJson(jsDocTag.text);
         } else {
             return undefined;

--- a/src/AnnotationsReader/BasicAnnotationsReader.ts
+++ b/src/AnnotationsReader/BasicAnnotationsReader.ts
@@ -69,7 +69,7 @@ export class BasicAnnotationsReader implements AnnotationsReader {
             return jsDocTag.text;
         } else if (BasicAnnotationsReader.jsonTags.indexOf(jsDocTag.name) >= 0) {
             return this.parseJson(jsDocTag.text);
-        } else if (this.extraJsonTags !== undefined && this.extraJsonTags.indexOf(jsDocTag.name) >= 0) {
+        } else if (this.extraJsonTags && this.extraJsonTags.indexOf(jsDocTag.name) >= 0) {
             return this.parseJson(jsDocTag.text);
         } else {
             return undefined;

--- a/src/AnnotationsReader/ExtendedAnnotationsReader.ts
+++ b/src/AnnotationsReader/ExtendedAnnotationsReader.ts
@@ -4,8 +4,8 @@ import { symbolAtNode } from "../Utils/symbolAtNode";
 import { BasicAnnotationsReader } from "./BasicAnnotationsReader";
 
 export class ExtendedAnnotationsReader extends BasicAnnotationsReader {
-    constructor(private typeChecker: ts.TypeChecker) {
-        super();
+    constructor(private typeChecker: ts.TypeChecker, extraJsonTags?: string[]) {
+        super(extraJsonTags);
     }
 
     public getAnnotations(node: ts.Node): Annotations | undefined {

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -6,6 +6,7 @@ export interface PartialConfig {
     sortProps?: boolean;
     strictTuples?: boolean;
     skipTypeCheck?: boolean;
+    extraJsonTags?: string[];
 }
 
 export interface Config extends PartialConfig {
@@ -20,4 +21,5 @@ export const DEFAULT_CONFIG: PartialConfig = {
     sortProps: true,
     strictTuples: false,
     skipTypeCheck: false,
+    extraJsonTags: [],
 };

--- a/test/valid-data.test.ts
+++ b/test/valid-data.test.ts
@@ -14,7 +14,7 @@ validator.addMetaSchema(metaSchema);
 
 const basePath = "test/valid-data";
 
-function assertSchema(name: string, type: string) {
+function assertSchema(name: string, type: string, jsDoc: Config["jsDoc"] = "none", extra?: Config["extraJsonTags"]) {
     return () => {
         const config: Config = {
             path: resolve(`${basePath}/${name}/*.ts`),
@@ -22,7 +22,8 @@ function assertSchema(name: string, type: string) {
 
             expose: "export",
             topRef: true,
-            jsDoc: "none",
+            jsDoc: jsDoc,
+            extraJsonTags: extra,
             skipTypeCheck: !!process.env.FAST_TEST,
         };
 
@@ -129,6 +130,14 @@ describe("valid-data", () => {
     it("generic-recursive", assertSchema("generic-recursive", "MyObject"));
     it("generic-hell", assertSchema("generic-hell", "MyObject"));
     it("generic-default", assertSchema("generic-default", "MyObject"));
+
+    it("annotation-custom", assertSchema("annotation-custom", "MyObject", "basic", [
+        "customNumberProperty",
+        "customStringProperty",
+        "customComplexProperty",
+        "customMultilineProperty",
+        "customInvalidProperty",
+    ]));
 
     it("nullable-null", assertSchema("nullable-null", "MyObject"));
 

--- a/test/valid-data/annotation-custom/main.ts
+++ b/test/valid-data/annotation-custom/main.ts
@@ -1,0 +1,13 @@
+/**
+ * @customNumberProperty 14
+ * @customStringProperty "string-value"
+ * @customComplexProperty { "a": 1, "b": 2 }
+ * @customMultilineProperty [
+ *     "value1",
+ *     "value2",
+ *     "value3"
+ * ]
+ * @customInvalidProperty not-a-valid-json
+ * @customOmittedProperty 42
+ */
+export interface MyObject {}

--- a/test/valid-data/annotation-custom/schema.json
+++ b/test/valid-data/annotation-custom/schema.json
@@ -1,0 +1,21 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "customComplexProperty": {
+        "a": 1,
+        "b": 2
+      },
+      "customMultilineProperty": [
+        "value1",
+        "value2",
+        "value3"
+      ],
+      "customNumberProperty": 14,
+      "customStringProperty": "string-value",
+      "type": "object"
+    }
+  }
+}

--- a/ts-json-schema-generator.ts
+++ b/ts-json-schema-generator.ts
@@ -39,7 +39,7 @@ const args = commander
     .option(
         "-k, --validationKeywords [value]",
         "Provide additional validation keywords to include",
-        (value: string, list: string[]) => list.concat(value), []
+        (value: string, list: string[]) => list.concat(value), [],
     )
 
     .parse(process.argv);
@@ -54,7 +54,7 @@ const config: Config = {
     sortProps: !args.unstable,
     strictTuples: args.strictTuples,
     skipTypeCheck: !args.typeCheck,
-    extraJsonTags: args.validationKeywords
+    extraJsonTags: args.validationKeywords,
 };
 
 try {

--- a/ts-json-schema-generator.ts
+++ b/ts-json-schema-generator.ts
@@ -36,6 +36,12 @@ const args = commander
         "-c, --no-type-check",
         "Skip type checks to improve performance",
     )
+    .option(
+        "-k, --validationKeywords [value]",
+        "Provide additional validation keywords to include",
+        (value: string, list: string[]) => list.concat(value), []
+    )
+
     .parse(process.argv);
 
 const config: Config = {
@@ -48,6 +54,7 @@ const config: Config = {
     sortProps: !args.unstable,
     strictTuples: args.strictTuples,
     skipTypeCheck: !args.typeCheck,
+    extraJsonTags: args.validationKeywords
 };
 
 try {


### PR DESCRIPTION
Add commandline option to parse additional terms from annotations and export them as json.
Similar to https://github.com/YousefED/typescript-json-schema --validationKeydords feature.
Can be used to provide "defaultSnippets" for monaco-editor (or vscode), etc.