### PR TITLE
Test to demonstrate incorrect behavior with Pick<> and optional value

### DIFF
--- a/test/valid-data.test.ts
+++ b/test/valid-data.test.ts
@@ -120,6 +120,7 @@ describe("valid-data", () => {
     it("type-mapped-native", assertSchema("type-mapped-native", "MyObject"));
     it("type-mapped-native-single-literal", assertSchema("type-mapped-native-single-literal", "MyObject"));
     it("type-mapped-widened", assertSchema("type-mapped-widened", "MyObject"));
+    it("type-omit-optional", assertSchema("type-omit-optional", "MyObject"));
 
     it("generic-simple", assertSchema("generic-simple", "MyObject"));
     it("generic-arrays", assertSchema("generic-arrays", "MyObject"));

--- a/test/valid-data/type-omit-optional/main.ts
+++ b/test/valid-data/type-omit-optional/main.ts
@@ -1,0 +1,7 @@
+export interface A {
+  req: string;
+  opt?: string;
+  unpicked: string;
+}
+
+export type MyObject = Pick<A, "req" | "opt">;

--- a/test/valid-data/type-omit-optional/schema.json
+++ b/test/valid-data/type-omit-optional/schema.json
@@ -1,0 +1,21 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "opt": {
+          "type": "string"
+        },
+        "req": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "req"
+      ],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
I stumbled upon what I believe to be a bug when `Pick` is being used. The resulting type seems to lose the optionality qualifier for all picked keys. In the test case the resulting `required` array reads `["req", "opt"]` instead of leaving out `"opt"` of the list.

Any pointers on where to start debugging this? I can't even properly determine the type of the Node where the operation goes wrong, AST Explorer sends me down looking at `TypeReference`, but I fail to see where the actual resolving takes place (and therefore the qualifier is probably lost).