### PR TITLE
Fix for id/name access before reference type is finished

### DIFF
--- a/src/ChainNodeParser.ts
+++ b/src/ChainNodeParser.ts
@@ -3,6 +3,7 @@ import { UnknownNodeError } from "./Error/UnknownNodeError";
 import { Context } from "./NodeParser";
 import { SubNodeParser } from "./SubNodeParser";
 import { BaseType } from "./Type/BaseType";
+import { ReferenceType } from "./Type/ReferenceType";
 
 export class ChainNodeParser implements SubNodeParser {
     public constructor(
@@ -19,8 +20,9 @@ export class ChainNodeParser implements SubNodeParser {
     public supportsNode(node: ts.Node): boolean {
         return this.nodeParsers.some((nodeParser) => nodeParser.supportsNode(node));
     }
-    public createType(node: ts.Node, context: Context): BaseType {
-        return this.getNodeParser(node, context).createType(node, context);
+
+    public createType(node: ts.Node, context: Context, reference?: ReferenceType): BaseType {
+        return this.getNodeParser(node, context).createType(node, context, reference);
     }
 
     private getNodeParser(node: ts.Node, context: Context): SubNodeParser {

--- a/src/CircularReferenceNodeParser.ts
+++ b/src/CircularReferenceNodeParser.ts
@@ -24,7 +24,7 @@ export class CircularReferenceNodeParser implements SubNodeParser {
 
         const reference = new ReferenceType();
         this.circular.set(key, reference);
-        reference.setType(this.childNodeParser.createType(node, context));
+        reference.setType(this.childNodeParser.createType(node, context, reference));
         this.circular.delete(key);
 
         return reference.getType();

--- a/src/ExposeNodeParser.ts
+++ b/src/ExposeNodeParser.ts
@@ -3,6 +3,7 @@ import { Context } from "./NodeParser";
 import { SubNodeParser } from "./SubNodeParser";
 import { BaseType } from "./Type/BaseType";
 import { DefinitionType } from "./Type/DefinitionType";
+import { ReferenceType } from "./Type/ReferenceType";
 import { symbolAtNode } from "./Utils/symbolAtNode";
 
 export class ExposeNodeParser implements SubNodeParser {
@@ -16,8 +17,9 @@ export class ExposeNodeParser implements SubNodeParser {
     public supportsNode(node: ts.Node): boolean {
         return this.subNodeParser.supportsNode(node);
     }
-    public createType(node: ts.Node, context: Context): BaseType {
-        const baseType: BaseType = this.subNodeParser.createType(node, context);
+
+    public createType(node: ts.Node, context: Context, reference?: ReferenceType): BaseType {
+        const baseType: BaseType = this.subNodeParser.createType(node, context, reference);
         if (!this.isExportNode(node)) {
             return baseType;
         }

--- a/src/NodeParser.ts
+++ b/src/NodeParser.ts
@@ -1,6 +1,7 @@
 import * as ts from "typescript";
 import { LogicError } from "./Error/LogicError";
 import { BaseType } from "./Type/BaseType";
+import { ReferenceType } from "./Type/ReferenceType";
 
 export class Context {
     private arguments: BaseType[] = [];
@@ -48,5 +49,5 @@ export class Context {
 }
 
 export interface NodeParser {
-    createType(node: ts.Node, context: Context): BaseType;
+    createType(node: ts.Node, context: Context, reference?: ReferenceType): BaseType;
 }

--- a/src/NodeParser/AnnotatedNodeParser.ts
+++ b/src/NodeParser/AnnotatedNodeParser.ts
@@ -5,6 +5,7 @@ import { Context } from "../NodeParser";
 import { SubNodeParser } from "../SubNodeParser";
 import { AnnotatedType, Annotations } from "../Type/AnnotatedType";
 import { BaseType } from "../Type/BaseType";
+import { ReferenceType } from "../Type/ReferenceType";
 
 export class AnnotatedNodeParser implements SubNodeParser {
     public constructor(
@@ -16,8 +17,9 @@ export class AnnotatedNodeParser implements SubNodeParser {
     public supportsNode(node: ts.Node): boolean {
         return this.childNodeParser.supportsNode(node);
     }
-    public createType(node: ts.Node, context: Context): BaseType {
-        const baseType = this.childNodeParser.createType(node, context);
+
+    public createType(node: ts.Node, context: Context, reference?: ReferenceType): BaseType {
+        const baseType = this.childNodeParser.createType(node, context, reference);
         const annotatedNode = this.getAnnotatedNode(node);
         const annotations = this.annotationsReader.getAnnotations(annotatedNode);
         const nullable = this.annotationsReader instanceof ExtendedAnnotationsReader ?

--- a/src/NodeParser/InterfaceNodeParser.ts
+++ b/src/NodeParser/InterfaceNodeParser.ts
@@ -3,6 +3,7 @@ import { Context, NodeParser } from "../NodeParser";
 import { SubNodeParser } from "../SubNodeParser";
 import { BaseType } from "../Type/BaseType";
 import { ObjectProperty, ObjectType } from "../Type/ObjectType";
+import { ReferenceType } from "../Type/ReferenceType";
 import { isHidden } from "../Utils/isHidden";
 import { getKey } from "../Utils/nodeKey";
 
@@ -16,7 +17,8 @@ export class InterfaceNodeParser implements SubNodeParser {
     public supportsNode(node: ts.InterfaceDeclaration): boolean {
         return node.kind === ts.SyntaxKind.InterfaceDeclaration;
     }
-    public createType(node: ts.InterfaceDeclaration, context: Context): BaseType {
+
+    public createType(node: ts.InterfaceDeclaration, context: Context, reference?: ReferenceType): BaseType {
         if (node.typeParameters && node.typeParameters.length) {
             node.typeParameters.forEach((typeParam) => {
                 const nameSymbol = this.typeChecker.getSymbolAtLocation(typeParam.name)!;
@@ -29,8 +31,13 @@ export class InterfaceNodeParser implements SubNodeParser {
             });
         }
 
+        const id = this.getTypeId(node, context);
+        if (reference) {
+            reference.setId(id);
+            reference.setName(id);
+        }
         return new ObjectType(
-            this.getTypeId(node, context),
+            id,
             this.getBaseTypes(node, context),
             this.getProperties(node, context),
             this.getAdditionalProperties(node, context),

--- a/src/NodeParser/TypeAliasNodeParser.ts
+++ b/src/NodeParser/TypeAliasNodeParser.ts
@@ -3,6 +3,7 @@ import { Context, NodeParser } from "../NodeParser";
 import { SubNodeParser } from "../SubNodeParser";
 import { AliasType } from "../Type/AliasType";
 import { BaseType } from "../Type/BaseType";
+import { ReferenceType } from "../Type/ReferenceType";
 import { getKey } from "../Utils/nodeKey";
 
 export class TypeAliasNodeParser implements SubNodeParser {
@@ -15,7 +16,8 @@ export class TypeAliasNodeParser implements SubNodeParser {
     public supportsNode(node: ts.TypeAliasDeclaration): boolean {
         return node.kind === ts.SyntaxKind.TypeAliasDeclaration;
     }
-    public createType(node: ts.TypeAliasDeclaration, context: Context): BaseType {
+
+    public createType(node: ts.TypeAliasDeclaration, context: Context, reference?: ReferenceType): BaseType {
         if (node.typeParameters && node.typeParameters.length) {
             node.typeParameters.forEach((typeParam) => {
                 const nameSymbol = this.typeChecker.getSymbolAtLocation(typeParam.name)!;
@@ -28,8 +30,13 @@ export class TypeAliasNodeParser implements SubNodeParser {
             });
         }
 
+        const id = this.getTypeId(node, context);
+        if (reference) {
+            reference.setId(id);
+            reference.setName(id);
+        }
         return new AliasType(
-            this.getTypeId(node, context),
+            id,
             this.childNodeParser.createType(node.type, context),
         );
     }

--- a/src/NodeParser/TypeLiteralNodeParser.ts
+++ b/src/NodeParser/TypeLiteralNodeParser.ts
@@ -3,6 +3,7 @@ import { Context, NodeParser } from "../NodeParser";
 import { SubNodeParser } from "../SubNodeParser";
 import { BaseType } from "../Type/BaseType";
 import { ObjectProperty, ObjectType } from "../Type/ObjectType";
+import { ReferenceType } from "../Type/ReferenceType";
 import { isHidden } from "../Utils/isHidden";
 import { getKey } from "../Utils/nodeKey";
 
@@ -15,9 +16,14 @@ export class TypeLiteralNodeParser implements SubNodeParser {
     public supportsNode(node: ts.TypeLiteralNode): boolean {
         return node.kind === ts.SyntaxKind.TypeLiteral;
     }
-    public createType(node: ts.TypeLiteralNode, context: Context): BaseType {
+    public createType(node: ts.TypeLiteralNode, context: Context, reference?: ReferenceType): BaseType {
+        const id = this.getTypeId(node, context);
+        if (reference) {
+            reference.setId(id);
+            reference.setName(id);
+        }
         return new ObjectType(
-            this.getTypeId(node, context),
+            id,
             [],
             this.getProperties(node, context),
             this.getAdditionalProperties(node, context),

--- a/src/Type/ReferenceType.ts
+++ b/src/Type/ReferenceType.ts
@@ -1,20 +1,44 @@
 import { BaseType } from "./BaseType";
 
 export class ReferenceType extends BaseType {
-    private type: BaseType;
+    private type: BaseType | null = null;
+
+    private id: string | null = null;
+
+    private name: string | null = null;
 
     public getId(): string {
-        return this.type.getId();
+        if (this.id == null) {
+            throw new Error("Reference type ID not set yet");
+        }
+        return this.id;
+    }
+
+    public setId(id: string): void {
+        this.id = id;
     }
 
     public getName(): string {
-        return this.type.getName();
+        if (this.name == null) {
+            throw new Error("Reference type name not set yet");
+        }
+        return this.name;
+    }
+
+    public setName(name: string): void {
+        this.name = name;
     }
 
     public getType(): BaseType {
+        if (this.type == null) {
+            throw new Error("Reference type not set yet");
+        }
         return this.type;
     }
+
     public setType(type: BaseType): void {
         this.type = type;
+        this.setId(type.getId());
+        this.setName(type.getName());
     }
 }

--- a/test/valid-data.test.ts
+++ b/test/valid-data.test.ts
@@ -90,6 +90,9 @@ describe("valid-data", () => {
     it("type-aliases-local-namespace", assertSchema("type-aliases-local-namespace", "MyObject"));
     it("type-aliases-recursive-anonymous", assertSchema("type-aliases-recursive-anonymous", "MyAlias"));
     it("type-aliases-recursive-export", assertSchema("type-aliases-recursive-export", "MyObject"));
+    it("type-aliases-recursive-generics-anonymous", assertSchema("type-aliases-recursive-generics-anonymous",
+        "MyAlias"));
+    it("type-aliases-recursive-generics-export", assertSchema("type-aliases-recursive-generics-export", "MyAlias"));
 
     it("type-aliases-tuple", assertSchema("type-aliases-tuple", "MyTuple"));
     it("type-aliases-tuple-empty", assertSchema("type-aliases-tuple-empty", "MyTuple"));

--- a/test/valid-data/type-aliases-recursive-generics-anonymous/main.ts
+++ b/test/valid-data/type-aliases-recursive-generics-anonymous/main.ts
@@ -1,0 +1,5 @@
+type Map<T> = { [ key: string]: T; };
+
+export type MyAlias = {
+    a: Map<MyAlias>;
+};

--- a/test/valid-data/type-aliases-recursive-generics-anonymous/schema.json
+++ b/test/valid-data/type-aliases-recursive-generics-anonymous/schema.json
@@ -1,6 +1,6 @@
 {
     "$ref": "#/definitions/MyAlias",
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyAlias": {
             "additionalProperties": false,

--- a/test/valid-data/type-aliases-recursive-generics-anonymous/schema.json
+++ b/test/valid-data/type-aliases-recursive-generics-anonymous/schema.json
@@ -1,0 +1,21 @@
+{
+    "$ref": "#/definitions/MyAlias",
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "definitions": {
+        "MyAlias": {
+            "additionalProperties": false,
+            "properties": {
+                "a": {
+                    "additionalProperties": {
+                        "$ref": "#/definitions/MyAlias"
+                    },
+                    "type": "object"
+                }
+            },
+            "required": [
+                "a"
+            ],
+            "type": "object"
+        }
+    }
+}

--- a/test/valid-data/type-aliases-recursive-generics-export/main.ts
+++ b/test/valid-data/type-aliases-recursive-generics-export/main.ts
@@ -1,0 +1,5 @@
+export type Map<T> = { [ key: string]: T; };
+
+export type MyAlias = {
+    a: Map<MyAlias>;
+};

--- a/test/valid-data/type-aliases-recursive-generics-export/schema.json
+++ b/test/valid-data/type-aliases-recursive-generics-export/schema.json
@@ -1,6 +1,6 @@
 {
     "$ref": "#/definitions/MyAlias",
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "Map<alias-1142561764-44-93-1142561764-0-94>": {
             "additionalProperties": {

--- a/test/valid-data/type-aliases-recursive-generics-export/schema.json
+++ b/test/valid-data/type-aliases-recursive-generics-export/schema.json
@@ -1,0 +1,24 @@
+{
+    "$ref": "#/definitions/MyAlias",
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "definitions": {
+        "Map<alias-1142561764-44-93-1142561764-0-94>": {
+            "additionalProperties": {
+                "$ref": "#/definitions/MyAlias"
+            },
+            "type": "object"
+        },
+        "MyAlias": {
+            "additionalProperties": false,
+            "properties": {
+                "a": {
+                    "$ref": "#/definitions/Map<alias-1142561764-44-93-1142561764-0-94>"
+                }
+            },
+            "required": [
+                "a"
+            ],
+            "type": "object"
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes the problem with accessing the ID (and name) of a reference type before the reference type is actually created. This is done by adding an optional ReferenceType argument to NodeParser::createType(). The CircularReferenceNodeParser passes the created (and unfinished) ReferenceType via this argument to the actual node parser and each node parser can then decide if it wants to set the ID and name on the reference node before the actual type is created.

This fixes #45 