### PR TITLE
Update to draft-07

### DIFF
--- a/src/AnnotationsReader/BasicAnnotationsReader.ts
+++ b/src/AnnotationsReader/BasicAnnotationsReader.ts
@@ -10,6 +10,12 @@ export class BasicAnnotationsReader implements AnnotationsReader {
 
         "format",
         "pattern",
+
+        // New since draft-07:
+        "$comment",
+        "contentMediaType",
+        "contentEncoding",
+
     ];
     private static jsonTags: string[] = [
         "minimum",
@@ -36,6 +42,13 @@ export class BasicAnnotationsReader implements AnnotationsReader {
         "examples",
 
         "default",
+
+        // New since draft-07:
+        "if",
+        "then",
+        "else",
+        "readOnly",
+        "writeOnly",
     ];
 
     constructor(private extraJsonTags?: string[]) { }

--- a/src/Schema/Definition.ts
+++ b/src/Schema/Definition.ts
@@ -1,3 +1,3 @@
-import { JSONSchema6, JSONSchema6Type, JSONSchema6TypeName } from "json-schema";
+import { JSONSchema7 } from "json-schema";
 
-export type Definition = JSONSchema6;
+export type Definition = JSONSchema7;

--- a/src/Schema/RawType.ts
+++ b/src/Schema/RawType.ts
@@ -1,4 +1,4 @@
-import { JSONSchema6Type, JSONSchema6TypeName } from "json-schema";
+import { JSONSchema7Type, JSONSchema7TypeName } from "json-schema";
 
-export type RawType = JSONSchema6Type;
-export type RawTypeName = JSONSchema6TypeName;
+export type RawType = JSONSchema7Type;
+export type RawTypeName = JSONSchema7TypeName;

--- a/src/Schema/Schema.ts
+++ b/src/Schema/Schema.ts
@@ -1,3 +1,3 @@
-import { JSONSchema6 } from "json-schema";
+import { JSONSchema7 } from "json-schema";
 
-export type Schema = JSONSchema6;
+export type Schema = JSONSchema7;

--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -38,7 +38,7 @@ export class SchemaGenerator {
         const rootType = this.nodeParser.createType(rootNode, new Context());
 
         return {
-            $schema: "http://json-schema.org/draft-06/schema#",
+            $schema: "http://json-schema.org/draft-07/schema#",
             definitions: this.getRootChildDefinitions(rootType),
             ...this.getRootTypeDefinition(rootType),
         };

--- a/src/TypeFormatter/AnnotatedTypeFormatter.ts
+++ b/src/TypeFormatter/AnnotatedTypeFormatter.ts
@@ -1,12 +1,9 @@
-import { JSONSchema6 } from "json-schema";
 import { isArray } from "util";
 import { Definition } from "../Schema/Definition";
 import { SubTypeFormatter } from "../SubTypeFormatter";
 import { AnnotatedType } from "../Type/AnnotatedType";
 import { BaseType } from "../Type/BaseType";
-import { NullType } from "../Type/NullType";
 import { TypeFormatter } from "../TypeFormatter";
-import { uniqueArray } from "../Utils/uniqueArray";
 
 export function makeNullable(def: Definition) {
     const union: Definition[] | undefined = def.oneOf as Definition[] || def.anyOf;

--- a/src/Utils/typeName.ts
+++ b/src/Utils/typeName.ts
@@ -19,6 +19,6 @@ export function typeName(value: RawType): RawTypeName {
     } else if (type === "object") {
         return "object";
     } else {
-        throw new Error("Unsupported type: " + type);
+        throw new Error(`JavaScript type "${type}" can't be converted to JSON type name`);
     }
 }

--- a/src/Utils/typeName.ts
+++ b/src/Utils/typeName.ts
@@ -19,6 +19,6 @@ export function typeName(value: RawType): RawTypeName {
     } else if (type === "object") {
         return "object";
     } else {
-        return "any";
+        throw new Error("Unsupported type: " + type);
     }
 }

--- a/test/config/expose-all-topref-false/schema.json
+++ b/test/config/expose-all-topref-false/schema.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "http://json-schema.org/draft-06/schema#",
+	"$schema": "http://json-schema.org/draft-07/schema#",
 	"definitions": {
 		"ExportInterface": {
 			"type": "object",

--- a/test/config/expose-all-topref-true/schema.json
+++ b/test/config/expose-all-topref-true/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/config/expose-export-topref-false/schema.json
+++ b/test/config/expose-export-topref-false/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "ExportInterface": {
             "type": "object",

--- a/test/config/expose-export-topref-true/schema.json
+++ b/test/config/expose-export-topref-true/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/config/expose-none-topref-false/schema.json
+++ b/test/config/expose-none-topref-false/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {},
     "type": "object",
     "properties": {

--- a/test/config/expose-none-topref-true/schema.json
+++ b/test/config/expose-none-topref-true/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/config/jsdoc-complex-basic/schema.json
+++ b/test/config/jsdoc-complex-basic/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/config/jsdoc-complex-extended/schema.json
+++ b/test/config/jsdoc-complex-extended/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/config/jsdoc-complex-none/schema.json
+++ b/test/config/jsdoc-complex-none/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/config/jsdoc-description-only/schema.json
+++ b/test/config/jsdoc-description-only/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/config/jsdoc-hide/schema.json
+++ b/test/config/jsdoc-hide/schema.json
@@ -1,6 +1,6 @@
 {
   "$ref": "#/definitions/MyObject",
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Enum": {
       "enum": [

--- a/test/config/jsdoc-inheritance/schema.json
+++ b/test/config/jsdoc-inheritance/schema.json
@@ -1,6 +1,6 @@
 {
   "$ref": "#/definitions/MyObject",
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "MyObject": {
       "additionalProperties": false,

--- a/test/config/tsconfig-support/schema.json
+++ b/test/config/tsconfig-support/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/annotation-custom/schema.json
+++ b/test/valid-data/annotation-custom/schema.json
@@ -1,6 +1,6 @@
 {
   "$ref": "#/definitions/MyObject",
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "MyObject": {
       "additionalProperties": false,

--- a/test/valid-data/any-unknown/schema.json
+++ b/test/valid-data/any-unknown/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/enums-compute/schema.json
+++ b/test/valid-data/enums-compute/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "Enum": {
             "type": "number",

--- a/test/valid-data/enums-initialized/schema.json
+++ b/test/valid-data/enums-initialized/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "Enum": {
             "type": "number",

--- a/test/valid-data/enums-member/schema.json
+++ b/test/valid-data/enums-member/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/enums-mixed/schema.json
+++ b/test/valid-data/enums-mixed/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "Enum": {
             "type": [

--- a/test/valid-data/enums-number/schema.json
+++ b/test/valid-data/enums-number/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "Enum": {
             "type": "number",

--- a/test/valid-data/enums-string/schema.json
+++ b/test/valid-data/enums-string/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "Enum": {
             "type": "string",

--- a/test/valid-data/generic-anonymous/schema.json
+++ b/test/valid-data/generic-anonymous/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/generic-arrays/schema.json
+++ b/test/valid-data/generic-arrays/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/generic-default/schema.json
+++ b/test/valid-data/generic-default/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "$ref": "#/definitions/Generic"

--- a/test/valid-data/generic-hell/schema.json
+++ b/test/valid-data/generic-hell/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/generic-multiargs/schema.json
+++ b/test/valid-data/generic-multiargs/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/generic-multiple/schema.json
+++ b/test/valid-data/generic-multiple/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/generic-recursive/schema.json
+++ b/test/valid-data/generic-recursive/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/generic-simple/schema.json
+++ b/test/valid-data/generic-simple/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/import-anonymous/schema.json
+++ b/test/valid-data/import-anonymous/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/import-exposed/schema.json
+++ b/test/valid-data/import-exposed/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/import-simple/schema.json
+++ b/test/valid-data/import-simple/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/interface-extra-props/schema.json
+++ b/test/valid-data/interface-extra-props/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/interface-multi/schema.json
+++ b/test/valid-data/interface-multi/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/interface-recursion/schema.json
+++ b/test/valid-data/interface-recursion/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/interface-single/schema.json
+++ b/test/valid-data/interface-single/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/namespace-deep-1/schema.json
+++ b/test/valid-data/namespace-deep-1/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "RootNamespace.Def": {
             "type": "object",

--- a/test/valid-data/namespace-deep-2/schema.json
+++ b/test/valid-data/namespace-deep-2/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "RootNamespace.SubNamespace.HelperA": {
             "type": "object",

--- a/test/valid-data/namespace-deep-3/schema.json
+++ b/test/valid-data/namespace-deep-3/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "RootNamespace.SubNamespace.HelperB": {
             "type": "object",

--- a/test/valid-data/nullable-null/schema.json
+++ b/test/valid-data/nullable-null/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/simple-object/schema.json
+++ b/test/valid-data/simple-object/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "SimpleObject": {
             "type": "object",

--- a/test/valid-data/string-literals-inline/schema.json
+++ b/test/valid-data/string-literals-inline/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/string-literals-null/schema.json
+++ b/test/valid-data/string-literals-null/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/string-literals/schema.json
+++ b/test/valid-data/string-literals/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/structure-anonymous/schema.json
+++ b/test/valid-data/structure-anonymous/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/structure-extra-props/schema.json
+++ b/test/valid-data/structure-extra-props/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/structure-private/schema.json
+++ b/test/valid-data/structure-private/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/structure-recursion/schema.json
+++ b/test/valid-data/structure-recursion/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/type-aliases-anonymous/schema.json
+++ b/test/valid-data/type-aliases-anonymous/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/type-aliases-local-namespace/schema.json
+++ b/test/valid-data/type-aliases-local-namespace/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/type-aliases-mixed/schema.json
+++ b/test/valid-data/type-aliases-mixed/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/type-aliases-object/schema.json
+++ b/test/valid-data/type-aliases-object/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyAlias": {
             "$ref": "#/definitions/MyObject"

--- a/test/valid-data/type-aliases-primitive/schema.json
+++ b/test/valid-data/type-aliases-primitive/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyString": {
             "type": "string"

--- a/test/valid-data/type-aliases-recursive-anonymous/schema.json
+++ b/test/valid-data/type-aliases-recursive-anonymous/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyAlias": {
             "type": "object",

--- a/test/valid-data/type-aliases-recursive-export/schema.json
+++ b/test/valid-data/type-aliases-recursive-export/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/type-aliases-tuple-empty/schema.json
+++ b/test/valid-data/type-aliases-tuple-empty/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyTuple": {
             "type": "array",

--- a/test/valid-data/type-aliases-tuple-only-rest/schema.json
+++ b/test/valid-data/type-aliases-tuple-only-rest/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyTuple": {
             "type": "array",

--- a/test/valid-data/type-aliases-tuple-optional-items/schema.json
+++ b/test/valid-data/type-aliases-tuple-optional-items/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyTuple": {
             "type": "array",

--- a/test/valid-data/type-aliases-tuple-rest/schema.json
+++ b/test/valid-data/type-aliases-tuple-rest/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyTuple": {
             "type": "array",

--- a/test/valid-data/type-aliases-tuple/schema.json
+++ b/test/valid-data/type-aliases-tuple/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyTuple": {
             "type": "array",

--- a/test/valid-data/type-aliases-union-namespace/schema.json
+++ b/test/valid-data/type-aliases-union-namespace/schema.json
@@ -19,5 +19,5 @@
             "type": "string"
         }
     },
-    "$schema": "http://json-schema.org/draft-06/schema#"
+    "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/test/valid-data/type-aliases-union/schema.json
+++ b/test/valid-data/type-aliases-union/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyUnion": {
             "type": "array",

--- a/test/valid-data/type-indexed-access-object-1/schema.json
+++ b/test/valid-data/type-indexed-access-object-1/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyType": {
             "type": "string",

--- a/test/valid-data/type-indexed-access-object-2/schema.json
+++ b/test/valid-data/type-indexed-access-object-2/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyType": {
             "type": "string",

--- a/test/valid-data/type-indexed-access-tuple-1/schema.json
+++ b/test/valid-data/type-indexed-access-tuple-1/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyType": {
             "type": "string",

--- a/test/valid-data/type-indexed-access-tuple-2/schema.json
+++ b/test/valid-data/type-indexed-access-tuple-2/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyType": {
             "type": "string",

--- a/test/valid-data/type-intersection-additional-props/schema.json
+++ b/test/valid-data/type-intersection-additional-props/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/type-intersection/schema.json
+++ b/test/valid-data/type-intersection/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/type-keyof-object/schema.json
+++ b/test/valid-data/type-keyof-object/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyType": {
             "type": "string",

--- a/test/valid-data/type-keyof-tuple/schema.json
+++ b/test/valid-data/type-keyof-tuple/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyType": {
             "type": "number",

--- a/test/valid-data/type-mapped-generic/schema.json
+++ b/test/valid-data/type-mapped-generic/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "$ref": "#/definitions/NullableAndPartial<SomeInterface>"

--- a/test/valid-data/type-mapped-index/schema.json
+++ b/test/valid-data/type-mapped-index/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/type-mapped-literal/schema.json
+++ b/test/valid-data/type-mapped-literal/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/type-mapped-native-single-literal/schema.json
+++ b/test/valid-data/type-mapped-native-single-literal/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/type-mapped-native/schema.json
+++ b/test/valid-data/type-mapped-native/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/type-mapped-simple/schema.json
+++ b/test/valid-data/type-mapped-simple/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/type-mapped-widened/schema.json
+++ b/test/valid-data/type-mapped-widened/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/type-maps/schema.json
+++ b/test/valid-data/type-maps/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/type-primitives/schema.json
+++ b/test/valid-data/type-primitives/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyObject": {
             "type": "object",

--- a/test/valid-data/type-typeof-value/schema.json
+++ b/test/valid-data/type-typeof-value/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyType": {
             "type": "string",

--- a/test/valid-data/type-typeof/schema.json
+++ b/test/valid-data/type-typeof/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyType": {
             "type": [

--- a/test/valid-data/type-union-tagged/schema.json
+++ b/test/valid-data/type-union-tagged/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "Shape": {
             "anyOf": [

--- a/test/valid-data/type-union/schema.json
+++ b/test/valid-data/type-union/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "TypeUnion": {
             "type": "object",

--- a/test/valid-data/undefined-alias/schema.json
+++ b/test/valid-data/undefined-alias/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyType": {
             "not": {}

--- a/test/valid-data/undefined-property/schema.json
+++ b/test/valid-data/undefined-property/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyType": {
             "type": "object",

--- a/test/valid-data/undefined-union/schema.json
+++ b/test/valid-data/undefined-union/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyType": {
             "anyOf": [


### PR DESCRIPTION
This PR updates the project to JSON schema draft-07.

Changes:

* Changed the URL which is written to the generated schema.
* Changed all the URLs in the test files.
* Changed the imports from "json-schema" (JSONSchema6 to JSONSchema7 and so on)
* Added new keywords to annotation reader
* Throwing exception in `typeName.ts` for unsupported type instead of returning "any" because "any" is no longer an allowed value for `JSONSchema7TypeName`. In theory this shouldn't happen because all valid types are already handled.

Fixes #110 