### PR TITLE
Correct getTypeByKey()  for optional properties

### DIFF
--- a/src/Utils/typeKeys.ts
+++ b/src/Utils/typeKeys.ts
@@ -4,6 +4,7 @@ import { IntersectionType } from "../Type/IntersectionType";
 import { LiteralType } from "../Type/LiteralType";
 import { ObjectType } from "../Type/ObjectType";
 import { TupleType } from "../Type/TupleType";
+import { UndefinedType } from "../Type/UndefinedType";
 import { UnionType } from "../Type/UnionType";
 import { derefType } from "./derefType";
 import { uniqueArray } from "./uniqueArray";
@@ -63,7 +64,12 @@ export function getTypeByKey(type: BaseType, index: LiteralType): BaseType | und
     if (type instanceof ObjectType) {
         const property = type.getProperties().find((it) => it.getName() === index.getValue());
         if (property) {
-            return property.getType();
+            const propertyType = property.getType();
+            if (!property.isRequired() && !(propertyType instanceof UnionType &&
+                    propertyType.getTypes().some(subType => subType instanceof UndefinedType))) {
+                return new UnionType([propertyType, new UndefinedType() ]);
+            }
+            return propertyType;
         }
 
         const additionalProperty = type.getAdditionalProperties();

--- a/test/valid-data.test.ts
+++ b/test/valid-data.test.ts
@@ -130,6 +130,7 @@ describe("valid-data", () => {
     it("type-mapped-native", assertSchema("type-mapped-native", "MyObject"));
     it("type-mapped-native-single-literal", assertSchema("type-mapped-native-single-literal", "MyObject"));
     it("type-mapped-widened", assertSchema("type-mapped-widened", "MyObject"));
+    it("type-mapped-optional", assertSchema("type-mapped-optional", "MyObject"));
 
     it("generic-simple", assertSchema("generic-simple", "MyObject"));
     it("generic-arrays", assertSchema("generic-arrays", "MyObject"));

--- a/test/valid-data/type-indexed-access-object-2/schema.json
+++ b/test/valid-data/type-indexed-access-object-2/schema.json
@@ -1,12 +1,19 @@
 {
+    "$ref": "#/definitions/MyType",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "MyType": {
-            "type": "string",
-            "enum": [
-                "bar"
+            "anyOf": [
+                {
+                    "enum": [
+                        "bar"
+                    ],
+                    "type": "string"
+                },
+                {
+                    "not": {}
+                }
             ]
         }
-    },
-    "$ref": "#/definitions/MyType"
+    }
 }

--- a/test/valid-data/type-mapped-optional/main.ts
+++ b/test/valid-data/type-mapped-optional/main.ts
@@ -1,0 +1,8 @@
+interface SomeInterface {
+    foo?: 123;
+    bar: "baz";
+}
+
+export type MyObject = {
+    [K in keyof SomeInterface]: SomeInterface[K];
+};

--- a/test/valid-data/type-mapped-optional/schema.json
+++ b/test/valid-data/type-mapped-optional/schema.json
@@ -1,0 +1,27 @@
+{
+    "$ref": "#/definitions/MyObject",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "MyObject": {
+            "additionalProperties": false,
+            "properties": {
+                "bar": {
+                    "enum": [
+                        "baz"
+                    ],
+                    "type": "string"
+                },
+                "foo": {
+                    "enum": [
+                        123
+                    ],
+                    "type": "number"
+                }
+            },
+            "required": [
+                "bar"
+            ],
+            "type": "object"
+        }
+    }
+}


### PR DESCRIPTION
When property is optional then returned type must also allow undefined. So if not already a union type containing undefined a corresponding union type is now created and returned.

This fixes a problem with mapped types where the required-flag (when false) of an object property got lost (See unit test)

Also had to fix result of type-indexed-access-object-2 test. The output doesn't make much sense because it isn't possible to use undefined in JSON anyway but then the test itself may not make any sense because it actually uses an optional value as JSON root type.