### PR TITLE
Support types extending Array and ReadonlyArray

### DIFF
--- a/src/NodeParser/InterfaceAndClassNodeParser.ts
+++ b/src/NodeParser/InterfaceAndClassNodeParser.ts
@@ -1,6 +1,7 @@
 import * as ts from "typescript";
 import { Context, NodeParser } from "../NodeParser";
 import { SubNodeParser } from "../SubNodeParser";
+import { ArrayType } from "../Type/ArrayType";
 import { BaseType } from "../Type/BaseType";
 import { ObjectProperty, ObjectType } from "../Type/ObjectType";
 import { ReferenceType } from "../Type/ReferenceType";
@@ -37,12 +38,48 @@ export class InterfaceAndClassNodeParser implements SubNodeParser {
             reference.setId(id);
             reference.setName(id);
         }
+
+        const properties = this.getProperties(node, context);
+        const additionalProperties = this.getAdditionalProperties(node, context);
+
+        // When type only extends Array or ReadonlyArray then create an array type instead of an object type
+        if (properties.length === 0 && additionalProperties === false) {
+            const arrayItemType = this.getArrayItemType(node);
+            if (arrayItemType) {
+                return new ArrayType(this.childNodeParser.createType(arrayItemType, context));
+            }
+        }
+
         return new ObjectType(
             id,
             this.getBaseTypes(node, context),
-            this.getProperties(node, context),
-            this.getAdditionalProperties(node, context),
+            properties,
+            additionalProperties,
         );
+    }
+
+    /**
+     * If specified node extends Array or ReadonlyArray and nothing else then this method returns the
+     * array item type. In all other cases null is returned to indicate that the node is not a simple array.
+     *
+     * @param node - The interface or class to check.
+     * @return The array item type if node is an array, null otherwise.
+     */
+    private getArrayItemType(node: ts.InterfaceDeclaration | ts.ClassDeclaration): ts.TypeNode | null {
+        if (node.heritageClauses && node.heritageClauses.length === 1) {
+            const clause = node.heritageClauses[0];
+            if (clause.types.length === 1) {
+                const type = clause.types[0];
+                const symbol = this.typeChecker.getSymbolAtLocation(type.expression);
+                if (symbol && (symbol.name === "Array" || symbol.name === "ReadonlyArray")) {
+                    const typeArguments = type.typeArguments;
+                    if (typeArguments && typeArguments.length === 1) {
+                        return typeArguments[0];
+                    }
+                }
+            }
+        }
+        return null;
     }
 
     private getBaseTypes(node: ts.InterfaceDeclaration | ts.ClassDeclaration, context: Context): BaseType[] {

--- a/test/valid-data.test.ts
+++ b/test/valid-data.test.ts
@@ -55,6 +55,7 @@ describe("valid-data", () => {
     it("interface-multi", assertSchema("interface-multi", "MyObject"));
     it("interface-recursion", assertSchema("interface-recursion", "MyObject"));
     it("interface-extra-props", assertSchema("interface-extra-props", "MyObject"));
+    it("interface-array", assertSchema("interface-array", "TagArray"));
 
     it("class-single", assertSchema("class-single", "MyObject"));
     it("class-multi", assertSchema("class-multi", "MyObject"));

--- a/test/valid-data/interface-array/main.ts
+++ b/test/valid-data/interface-array/main.ts
@@ -1,0 +1,3 @@
+export type Tag = TagPrimitive | TagArray;
+export type TagPrimitive = string | number | boolean | null;
+export interface TagArray extends Array<Tag> {}

--- a/test/valid-data/interface-array/schema.json
+++ b/test/valid-data/interface-array/schema.json
@@ -1,0 +1,30 @@
+{
+    "$ref": "#/definitions/TagArray",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "Tag": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/TagPrimitive"
+                },
+                {
+                    "$ref": "#/definitions/TagArray"
+                }
+            ]
+        },
+        "TagArray": {
+            "items": {
+                "$ref": "#/definitions/Tag"
+            },
+            "type": "array"
+        },
+        "TagPrimitive": {
+            "type": [
+                "string",
+                "number",
+                "boolean",
+                "null"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
This is actually a pretty special handling of a specific type of code. When an interface or a class extends Array or ReadonlyArray and nothing else and also does not add any properties then the type is parsed into an array instead of an object.

Fixes #83 