### PR TITLE
Cache created types for better speed

### DIFF
--- a/src/NodeParser.ts
+++ b/src/NodeParser.ts
@@ -4,6 +4,7 @@ import { BaseType } from "./Type/BaseType";
 import { ReferenceType } from "./Type/ReferenceType";
 
 export class Context {
+    private cacheKey: string | null = null;
     private arguments: BaseType[] = [];
     private parameters: string[] = [];
     private reference?: ts.Node;
@@ -15,13 +16,31 @@ export class Context {
 
     public pushArgument(argumentType: BaseType): void {
         this.arguments.push(argumentType);
+        this.cacheKey = null;
     }
+
     public pushParameter(parameterName: string): void {
         this.parameters.push(parameterName);
+        this.cacheKey = null;
     }
 
     public setDefault(parameterName: string, argumentType: BaseType) {
         this.defaultArgument.set(parameterName, argumentType);
+        this.cacheKey = null;
+    }
+
+    public getCacheKey() {
+        if (this.cacheKey == null) {
+            this.cacheKey = JSON.stringify([
+                this.arguments.map(argument => argument.getId()),
+                this.parameters,
+                Array.from(this.defaultArgument.entries()).reduce((object, [ name, type ]) => {
+                    object[name] = type.getId();
+                    return object;
+                }, <Record<string, string>>{}),
+            ]);
+        }
+        return this.cacheKey;
     }
 
     public getArgument(parameterName: string): BaseType {

--- a/src/NodeParser.ts
+++ b/src/NodeParser.ts
@@ -2,6 +2,7 @@ import * as ts from "typescript";
 import { LogicError } from "./Error/LogicError";
 import { BaseType } from "./Type/BaseType";
 import { ReferenceType } from "./Type/ReferenceType";
+import { getKey } from "./Utils/nodeKey";
 
 export class Context {
     private cacheKey: string | null = null;
@@ -21,23 +22,17 @@ export class Context {
 
     public pushParameter(parameterName: string): void {
         this.parameters.push(parameterName);
-        this.cacheKey = null;
     }
 
     public setDefault(parameterName: string, argumentType: BaseType) {
         this.defaultArgument.set(parameterName, argumentType);
-        this.cacheKey = null;
     }
 
     public getCacheKey() {
         if (this.cacheKey == null) {
             this.cacheKey = JSON.stringify([
+                this.reference ? getKey(this.reference, this) : "",
                 this.arguments.map(argument => argument.getId()),
-                this.parameters,
-                Array.from(this.defaultArgument.entries()).reduce((object, [ name, type ]) => {
-                    object[name] = type.getId();
-                    return object;
-                }, <Record<string, string>>{}),
             ]);
         }
         return this.cacheKey;


### PR DESCRIPTION
This PR implements a cache for the types created by the ChainedNodeParser. Cache key is the ts.Node reference plus the current context state.

@domoritz With this change the vega-lite schema is created in 4 seconds on my system, no matter if Exclude-Types are used or not. But there is one strange problem: The generated JSON schema misses the type `RepeatSpec`. Everything else is exactly the same as before but this single type is missing. Do you know if there is something special about this type?