### PR TITLE
Support additional properties in mapped types

### DIFF
--- a/src/NodeParser/IndexedAccessTypeNodeParser.ts
+++ b/src/NodeParser/IndexedAccessTypeNodeParser.ts
@@ -4,6 +4,7 @@ import { Context, NodeParser } from "../NodeParser";
 import { SubNodeParser } from "../SubNodeParser";
 import { BaseType } from "../Type/BaseType";
 import { LiteralType } from "../Type/LiteralType";
+import { NumberType } from "../Type/NumberType";
 import { StringType } from "../Type/StringType";
 import { getTypeByKey } from "../Utils/typeKeys";
 
@@ -18,8 +19,9 @@ export class IndexedAccessTypeNodeParser implements SubNodeParser {
     }
     public createType(node: ts.IndexedAccessTypeNode, context: Context): BaseType {
         const indexType = this.childNodeParser.createType(node.indexType, context);
-        if (!(indexType instanceof LiteralType || indexType instanceof StringType)) {
-            throw new LogicError(`Unexpected type "${indexType.getId()}" (expected "LiteralType" or "StringType")`);
+        if (!(indexType instanceof LiteralType || indexType instanceof StringType || indexType instanceof NumberType)) {
+            throw new LogicError(`Unexpected type "${indexType.getId()}" (expected "LiteralType" or "StringType" ` +
+                `or "NumberType")`);
         }
 
         const objectType = this.childNodeParser.createType(node.objectType, context);

--- a/src/NodeParser/MappedTypeNodeParser.ts
+++ b/src/NodeParser/MappedTypeNodeParser.ts
@@ -2,8 +2,10 @@ import * as ts from "typescript";
 import { LogicError } from "../Error/LogicError";
 import { Context, NodeParser } from "../NodeParser";
 import { SubNodeParser } from "../SubNodeParser";
+import { ArrayType } from "../Type/ArrayType";
 import { BaseType } from "../Type/BaseType";
 import { LiteralType } from "../Type/LiteralType";
+import { NumberType } from "../Type/NumberType";
 import { ObjectProperty, ObjectType } from "../Type/ObjectType";
 import { StringType } from "../Type/StringType";
 import { UnionType } from "../Type/UnionType";
@@ -35,6 +37,9 @@ export class MappedTypeNodeParser implements SubNodeParser {
         } else if (keyListType instanceof StringType) {
             // Key type widens to `string`
             return new ObjectType(id, [], [], this.childNodeParser.createType(node.type!, context));
+        } else if (keyListType instanceof NumberType) {
+            return new ArrayType(this.childNodeParser.createType(node.type!,
+                this.createSubContext(node, keyListType, context)));
         } else {
             throw new LogicError(
                 // tslint:disable-next-line:max-line-length

--- a/src/NodeParser/TypeOperatorNodeParser.ts
+++ b/src/NodeParser/TypeOperatorNodeParser.ts
@@ -2,7 +2,10 @@ import * as ts from "typescript";
 import { Context, NodeParser } from "../NodeParser";
 import { SubNodeParser } from "../SubNodeParser";
 import { BaseType } from "../Type/BaseType";
+import { ObjectType } from "../Type/ObjectType";
+import { StringType } from "../Type/StringType";
 import { UnionType } from "../Type/UnionType";
+import { derefType } from "../Utils/derefType";
 import { getTypeKeys } from "../Utils/typeKeys";
 
 export class TypeOperatorNodeParser implements SubNodeParser {
@@ -18,7 +21,10 @@ export class TypeOperatorNodeParser implements SubNodeParser {
     public createType(node: ts.TypeOperatorNode, context: Context): BaseType {
         const type = this.childNodeParser.createType(node.type, context);
         const keys = getTypeKeys(type);
-
+        const derefed = derefType(type);
+        if (derefed instanceof ObjectType && derefed.getAdditionalProperties()) {
+            return new UnionType([ ...keys, new StringType() ] );
+        }
         return new UnionType(keys);
     }
 }

--- a/src/NodeParser/TypeOperatorNodeParser.ts
+++ b/src/NodeParser/TypeOperatorNodeParser.ts
@@ -1,7 +1,9 @@
 import * as ts from "typescript";
 import { Context, NodeParser } from "../NodeParser";
 import { SubNodeParser } from "../SubNodeParser";
+import { ArrayType } from "../Type/ArrayType";
 import { BaseType } from "../Type/BaseType";
+import { NumberType } from "../Type/NumberType";
 import { ObjectType } from "../Type/ObjectType";
 import { StringType } from "../Type/StringType";
 import { UnionType } from "../Type/UnionType";
@@ -20,8 +22,11 @@ export class TypeOperatorNodeParser implements SubNodeParser {
 
     public createType(node: ts.TypeOperatorNode, context: Context): BaseType {
         const type = this.childNodeParser.createType(node.type, context);
-        const keys = getTypeKeys(type);
         const derefed = derefType(type);
+        if (derefed instanceof ArrayType) {
+            return new NumberType();
+        }
+        const keys = getTypeKeys(type);
         if (derefed instanceof ObjectType && derefed.getAdditionalProperties()) {
             return new UnionType([ ...keys, new StringType() ] );
         }

--- a/src/Utils/typeKeys.ts
+++ b/src/Utils/typeKeys.ts
@@ -1,7 +1,9 @@
 import { AnyType } from "../Type/AnyType";
+import { ArrayType } from "../Type/ArrayType";
 import { BaseType } from "../Type/BaseType";
 import { IntersectionType } from "../Type/IntersectionType";
 import { LiteralType } from "../Type/LiteralType";
+import { NumberType } from "../Type/NumberType";
 import { ObjectType } from "../Type/ObjectType";
 import { StringType } from "../Type/StringType";
 import { TupleType } from "../Type/TupleType";
@@ -61,6 +63,9 @@ export function getTypeByKey(type: BaseType, index: LiteralType | StringType): B
 
     if (type instanceof TupleType && index instanceof LiteralType) {
         return type.getTypes().find((it, idx) => idx === index.getValue());
+    }
+    if (type instanceof ArrayType && index instanceof NumberType) {
+        return type.getItem();
     }
     if (type instanceof ObjectType) {
         if (index instanceof LiteralType) {

--- a/test/valid-data.test.ts
+++ b/test/valid-data.test.ts
@@ -133,6 +133,7 @@ describe("valid-data", () => {
     it("type-mapped-widened", assertSchema("type-mapped-widened", "MyObject"));
     it("type-mapped-optional", assertSchema("type-mapped-optional", "MyObject"));
     it("type-mapped-additional-props", assertSchema("type-mapped-additional-props", "MyObject"));
+    it("type-mapped-array", assertSchema("type-mapped-array", "MyObject"));
 
     it("generic-simple", assertSchema("generic-simple", "MyObject"));
     it("generic-arrays", assertSchema("generic-arrays", "MyObject"));

--- a/test/valid-data.test.ts
+++ b/test/valid-data.test.ts
@@ -132,6 +132,7 @@ describe("valid-data", () => {
     it("type-mapped-native-single-literal", assertSchema("type-mapped-native-single-literal", "MyObject"));
     it("type-mapped-widened", assertSchema("type-mapped-widened", "MyObject"));
     it("type-mapped-optional", assertSchema("type-mapped-optional", "MyObject"));
+    it("type-mapped-additional-props", assertSchema("type-mapped-additional-props", "MyObject"));
 
     it("generic-simple", assertSchema("generic-simple", "MyObject"));
     it("generic-arrays", assertSchema("generic-arrays", "MyObject"));

--- a/test/valid-data/type-mapped-additional-props/main.ts
+++ b/test/valid-data/type-mapped-additional-props/main.ts
@@ -1,0 +1,8 @@
+export interface Test {
+    [ name: string ]: string;
+}
+
+export type WithNumbers<T> = {
+    [P in keyof T]: T[P] | number;
+};
+export type MyObject = WithNumbers<Test>;

--- a/test/valid-data/type-mapped-additional-props/schema.json
+++ b/test/valid-data/type-mapped-additional-props/schema.json
@@ -1,0 +1,18 @@
+{
+    "$ref": "#/definitions/MyObject",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "MyObject": {
+            "$ref": "#/definitions/WithNumbers<Test>"
+        },
+        "WithNumbers<Test>": {
+            "additionalProperties": {
+                "type": [
+                    "string",
+                    "number"
+                ]
+            },
+            "type": "object"
+        }
+    }
+}

--- a/test/valid-data/type-mapped-array/main.ts
+++ b/test/valid-data/type-mapped-array/main.ts
@@ -1,0 +1,7 @@
+type Test = string[];
+
+type WithNumbers<T> = {
+    [P in keyof T]: T[P] | number;
+};
+
+export type MyObject = WithNumbers<Test>;

--- a/test/valid-data/type-mapped-array/schema.json
+++ b/test/valid-data/type-mapped-array/schema.json
@@ -1,0 +1,15 @@
+{
+    "$ref": "#/definitions/MyObject",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "MyObject": {
+            "items": {
+                "type": [
+                    "string",
+                    "number"
+                ]
+            },
+            "type": "array"
+        }
+    }
+}


### PR DESCRIPTION
Example:

```typescript
export interface Test {
    [ name: string ]: string;
}

type WithNumbers<T> = {
    [P in keyof T]: T[P] | number;
};

export type MyObject = WithNumbers<Test>;
```

Before this change the generated schema just described an empty object because the additional properties where ignored and not mapped. Now with this change the additional properties (if present) are also correctly mapped.