### PR TITLE
Bugfix/fix missing definitions in schema

### DIFF
--- a/src/TypeFormatter/IntersectionTypeFormatter.ts
+++ b/src/TypeFormatter/IntersectionTypeFormatter.ts
@@ -1,8 +1,8 @@
 import { Definition } from "../Schema/Definition";
 import { SubTypeFormatter } from "../SubTypeFormatter";
 import { BaseType } from "../Type/BaseType";
+import { DefinitionType } from "../Type/DefinitionType";
 import { IntersectionType } from "../Type/IntersectionType";
-import { ObjectType } from "../Type/ObjectType";
 import { TypeFormatter } from "../TypeFormatter";
 import { getAllOfDefinitionReducer } from "../Utils/allOfDefinition";
 
@@ -30,7 +30,7 @@ export class IntersectionTypeFormatter implements SubTypeFormatter {
         return type.getTypes().reduce((result: BaseType[], item) => {
             // Remove the first child, which is the definition of the child itself because we are merging objects.
             // However, if the child is just a reference, we cannot remove it.
-            const slice = item instanceof ObjectType ? 0 : 1;
+            const slice = item instanceof DefinitionType ? 1 : 0;
             return [
                 ...result,
                 ...this.childTypeFormatter.getChildren(item).slice(slice),

--- a/test/valid-data.test.ts
+++ b/test/valid-data.test.ts
@@ -134,6 +134,7 @@ describe("valid-data", () => {
     it("type-mapped-optional", assertSchema("type-mapped-optional", "MyObject"));
     it("type-mapped-additional-props", assertSchema("type-mapped-additional-props", "MyObject"));
     it("type-mapped-array", assertSchema("type-mapped-array", "MyObject"));
+    it("type-mapped-union-intersection", assertSchema("type-mapped-union-intersection", "MyObject"));
 
     it("generic-simple", assertSchema("generic-simple", "MyObject"));
     it("generic-arrays", assertSchema("generic-arrays", "MyObject"));

--- a/test/valid-data/type-mapped-union-intersection/main.ts
+++ b/test/valid-data/type-mapped-union-intersection/main.ts
@@ -1,0 +1,21 @@
+export interface A {
+    a: string;
+}
+
+export interface B {
+    b: string;
+}
+
+export interface C {
+    c: A | B;
+}
+
+export interface D {
+    d: string;
+}
+
+type MakeOptional<T> = {
+    [P in keyof T]?: T[P];
+};
+
+export type MyObject = MakeOptional<C> & D;

--- a/test/valid-data/type-mapped-union-intersection/schema.json
+++ b/test/valid-data/type-mapped-union-intersection/schema.json
@@ -1,0 +1,52 @@
+{
+    "$ref": "#/definitions/MyObject",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "A": {
+            "additionalProperties": false,
+            "properties": {
+                "a": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "a"
+            ],
+            "type": "object"
+        },
+        "B": {
+            "additionalProperties": false,
+            "properties": {
+                "b": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "b"
+            ],
+            "type": "object"
+        },
+        "MyObject": {
+            "additionalProperties": false,
+            "properties": {
+                "c": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/A"
+                        },
+                        {
+                            "$ref": "#/definitions/B"
+                        }
+                    ]
+                },
+                "d": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "d"
+            ],
+            "type": "object"
+        }
+    }
+}


### PR DESCRIPTION
I'm not really sure what I'm doing here but when I understand the comment correctly then looking explicitly for DefinitionType for this special handling looks more correct than looking for anything except ObjectType. 

Existing tests are still working and it fixes #126 for which I also added a new test