### PR TITLE
Allow for Config.type to be undefined

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -11,7 +11,7 @@ export interface PartialConfig {
 
 export interface Config extends PartialConfig {
     path: string;
-    type: string;
+    type: string | undefined;
 }
 
 export const DEFAULT_CONFIG: PartialConfig = {

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -11,7 +11,7 @@ export interface PartialConfig {
 
 export interface Config extends PartialConfig {
     path: string;
-    type: string | undefined;
+    type?: string;
 }
 
 export const DEFAULT_CONFIG: PartialConfig = {

--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -69,7 +69,8 @@ export class SchemaGenerator {
         const children = this
             .typeFormatter.getChildren(rootType)
             .filter((child) => child instanceof DefinitionType)
-            .filter((child: DefinitionType) => {
+            .map(child => child as DefinitionType)
+            .filter((child) => {
                 if (!seen.has(child.getId())) {
                     seen.add(child.getId());
                     return true;

--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -68,15 +68,14 @@ export class SchemaGenerator {
 
         const children = this
             .typeFormatter.getChildren(rootType)
-            .filter((child) => child instanceof DefinitionType)
-            .map(child => child as DefinitionType)
+            .filter((child): child is DefinitionType => child instanceof DefinitionType)
             .filter((child) => {
                 if (!seen.has(child.getId())) {
                     seen.add(child.getId());
                     return true;
                 }
                 return false;
-            }) as DefinitionType[];
+            });
 
         children
             .reduce((definitions, child) => {

--- a/src/TopRefNodeParser.ts
+++ b/src/TopRefNodeParser.ts
@@ -6,7 +6,7 @@ import { DefinitionType } from "./Type/DefinitionType";
 export class TopRefNodeParser implements NodeParser {
     public constructor(
         private childNodeParser: NodeParser,
-        private fullName: string,
+        private fullName: string | undefined,
         private topRef: boolean,
     ) {
     }

--- a/src/Type/DefinitionType.ts
+++ b/src/Type/DefinitionType.ts
@@ -2,7 +2,7 @@ import { BaseType } from "./BaseType";
 
 export class DefinitionType extends BaseType {
     public constructor(
-        private name: string,
+        private name: string | undefined,
         private type: BaseType,
     ) {
         super();
@@ -13,7 +13,7 @@ export class DefinitionType extends BaseType {
     }
 
     public getName() {
-        return this.name;
+        return this.name || super.getName();
     }
 
     public getType(): BaseType {

--- a/test/valid-data.test.ts
+++ b/test/valid-data.test.ts
@@ -164,4 +164,5 @@ describe("valid-data", () => {
     it("any-unknown", assertSchema("any-unknown", "MyObject"));
 
     it("multiple-roots1", assertSchema("multiple-roots1"));
+    it("multiple-roots1", assertSchema("multiple-roots1", "*"));
 });

--- a/test/valid-data.test.ts
+++ b/test/valid-data.test.ts
@@ -12,10 +12,12 @@ const validator = new Ajv();
 
 const basePath = "test/valid-data";
 
-function assertSchema(name: string, type?: string, jsDoc: Config["jsDoc"] = "none", extra?: Config["extraJsonTags"]) {
+function assertSchema(
+    relativePath: string, type?: string, jsDoc: Config["jsDoc"] = "none", extra?: Config["extraJsonTags"],
+) {
     return () => {
         const config: Config = {
-            path: resolve(`${basePath}/${name}/*.ts`),
+            path: resolve(`${basePath}/${relativePath}/*.ts`),
             type: type,
 
             expose: "export",
@@ -33,7 +35,7 @@ function assertSchema(name: string, type?: string, jsDoc: Config["jsDoc"] = "non
         );
 
         const schema = generator.createSchema(type);
-        const expected: any = JSON.parse(readFileSync(resolve(`${basePath}/${name}/schema.json`), "utf8"));
+        const expected: any = JSON.parse(readFileSync(resolve(`${basePath}/${relativePath}/schema.json`), "utf8"));
         const actual: any = JSON.parse(JSON.stringify(schema));
 
         // uncomment to write test files
@@ -164,5 +166,6 @@ describe("valid-data", () => {
     it("any-unknown", assertSchema("any-unknown", "MyObject"));
 
     it("multiple-roots1", assertSchema("multiple-roots1"));
-    it("multiple-roots1", assertSchema("multiple-roots1", "*"));
+    it("multiple-roots1-star", assertSchema("multiple-roots1", "*"));
+    it("multiple-roots2", assertSchema("multiple-roots2/schema"));
 });

--- a/test/valid-data.test.ts
+++ b/test/valid-data.test.ts
@@ -12,7 +12,7 @@ const validator = new Ajv();
 
 const basePath = "test/valid-data";
 
-function assertSchema(name: string, type: string, jsDoc: Config["jsDoc"] = "none", extra?: Config["extraJsonTags"]) {
+function assertSchema(name: string, type?: string, jsDoc: Config["jsDoc"] = "none", extra?: Config["extraJsonTags"]) {
     return () => {
         const config: Config = {
             path: resolve(`${basePath}/${name}/*.ts`),
@@ -162,4 +162,6 @@ describe("valid-data", () => {
     it("undefined-property", assertSchema("undefined-property", "MyType"));
 
     it("any-unknown", assertSchema("any-unknown", "MyObject"));
+
+    it("multiple-roots1", assertSchema("multiple-roots1"));
 });

--- a/test/valid-data/multiple-roots1/main.ts
+++ b/test/valid-data/multiple-roots1/main.ts
@@ -1,0 +1,11 @@
+export interface MyObject1 {
+    propA: number;
+}
+
+export interface MyObject2 {
+    propB: string;
+}
+
+export interface MyObject3 {
+    propC: boolean;
+}

--- a/test/valid-data/multiple-roots1/schema.json
+++ b/test/valid-data/multiple-roots1/schema.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "MyObject1": {
+            "type": "object",
+            "properties": {
+                "propA": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "propA"
+            ],
+            "additionalProperties": false
+        },
+        "MyObject2": {
+            "type": "object",
+            "properties": {
+                "propB": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "propB"
+            ],
+            "additionalProperties": false
+        },
+        "MyObject3": {
+            "type": "object",
+            "properties": {
+                "propC": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "propC"
+            ],
+            "additionalProperties": false
+        }
+    }
+}

--- a/test/valid-data/multiple-roots2/Asset.ts
+++ b/test/valid-data/multiple-roots2/Asset.ts
@@ -1,0 +1,3 @@
+export interface Asset {
+    readonly type: "One" | "Two";
+}

--- a/test/valid-data/multiple-roots2/schema/AssetType.ts
+++ b/test/valid-data/multiple-roots2/schema/AssetType.ts
@@ -1,0 +1,3 @@
+import { Asset } from "../Asset";
+
+export type AssetType = Asset["type"];

--- a/test/valid-data/multiple-roots2/schema/AssetType.ts
+++ b/test/valid-data/multiple-roots2/schema/AssetType.ts
@@ -1,3 +1,4 @@
 import { Asset } from "../Asset";
 
-export type AssetType = Asset["type"];
+const asset: Asset = { type: "One" };
+export type AssetType = typeof asset.type;

--- a/test/valid-data/multiple-roots2/schema/MyAsset.ts
+++ b/test/valid-data/multiple-roots2/schema/MyAsset.ts
@@ -1,3 +1,35 @@
 import { Asset } from "../Asset";
 
+// TODO: The schema currently produced for this is wrong, it is expected to look more like the following:
+// {
+//     "$schema": "http://json-schema.org/draft-07/schema#",
+//     "definitions": {
+//         "Asset": {
+//             "type": "object",
+//             "properties": {
+//                 "type": {
+//                     "enum": [
+//                         "One",
+//                         "Two"
+//                     ],
+//                     "type": "string"
+//                 }
+//             },
+//             "required": [
+//                 "type"
+//             ],
+//             "additionalProperties": false
+//         },
+//         "AssetType": {
+//             "enum": [
+//                 "One",
+//                 "Two"
+//             ],
+//             "type": "string"
+//         },
+//         "MyAsset": {
+//             "$ref": "#/definitions/Asset"
+//         }
+//     }
+// }
 export type MyAsset = Asset;

--- a/test/valid-data/multiple-roots2/schema/MyAsset.ts
+++ b/test/valid-data/multiple-roots2/schema/MyAsset.ts
@@ -1,0 +1,3 @@
+import { Asset } from "../Asset";
+
+export type MyAsset = Asset;

--- a/test/valid-data/multiple-roots2/schema/schema.json
+++ b/test/valid-data/multiple-roots2/schema/schema.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "Asset": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "enum": [
+                        "One",
+                        "Two"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type"
+            ],
+            "additionalProperties": false
+        },
+        "AssetType": {
+            "enum": [
+                "One",
+                "Two"
+            ],
+            "type": "string"
+        },
+        "MyAsset": {
+            "$ref": "#/definitions/Asset"
+        }
+    }
+}

--- a/test/valid-data/multiple-roots2/schema/schema.json
+++ b/test/valid-data/multiple-roots2/schema/schema.json
@@ -3,18 +3,6 @@
     "definitions": {
         "Asset": {
             "type": "object",
-            "properties": {
-                "type": {
-                    "enum": [
-                        "One",
-                        "Two"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "type"
-            ],
             "additionalProperties": false
         },
         "AssetType": {


### PR DESCRIPTION
This adapts the types to the reality that `Config.type` can be `undefined` for the implementation of https://github.com/vega/ts-json-schema-generator/issues/117