### PR TITLE
Support union types for indexed access

### DIFF
--- a/src/NodeParser/IndexedAccessTypeNodeParser.ts
+++ b/src/NodeParser/IndexedAccessTypeNodeParser.ts
@@ -6,6 +6,7 @@ import { BaseType } from "../Type/BaseType";
 import { LiteralType } from "../Type/LiteralType";
 import { NumberType } from "../Type/NumberType";
 import { StringType } from "../Type/StringType";
+import { UnionType } from "../Type/UnionType";
 import { getTypeByKey } from "../Utils/typeKeys";
 
 export class IndexedAccessTypeNodeParser implements SubNodeParser {
@@ -17,23 +18,29 @@ export class IndexedAccessTypeNodeParser implements SubNodeParser {
     public supportsNode(node: ts.IndexedAccessTypeNode): boolean {
         return node.kind === ts.SyntaxKind.IndexedAccessType;
     }
+
     public createType(node: ts.IndexedAccessTypeNode, context: Context): BaseType {
-        const indexType = this.childNodeParser.createType(node.indexType, context);
-        if (!(indexType instanceof LiteralType || indexType instanceof StringType || indexType instanceof NumberType)) {
-            throw new LogicError(`Unexpected type "${indexType.getId()}" (expected "LiteralType" or "StringType" ` +
-                `or "NumberType")`);
-        }
-
         const objectType = this.childNodeParser.createType(node.objectType, context);
-        const propertyType = getTypeByKey(objectType, indexType);
-        if (!propertyType) {
-            if (indexType instanceof LiteralType) {
-                throw new LogicError(`Invalid index "${indexType.getValue()}" in type "${objectType.getId()}"`);
-            } else {
-                throw new LogicError(`No additional properties in type "${objectType.getId()}"`);
+        const indexType = this.childNodeParser.createType(node.indexType, context);
+        const indexTypes = indexType instanceof UnionType ? indexType.getTypes() : [ indexType ];
+        const propertyTypes = indexTypes.map(type => {
+            if (!(type instanceof LiteralType || type instanceof StringType
+                    || type instanceof NumberType)) {
+                throw new LogicError(`Unexpected type "${type.getId()}" (expected "LiteralType" or "StringType" ` +
+                    `or "NumberType")`);
             }
-        }
 
-        return propertyType;
+            const propertyType = getTypeByKey(objectType, type);
+            if (!propertyType) {
+                if (type instanceof LiteralType) {
+                    throw new LogicError(`Invalid index "${type.getValue()}" in type "${objectType.getId()}"`);
+                } else {
+                    throw new LogicError(`No additional properties in type "${objectType.getId()}"`);
+                }
+            }
+
+            return propertyType;
+        });
+        return propertyTypes.length === 1 ? propertyTypes[0] : new UnionType(propertyTypes);
     }
 }

--- a/test/valid-data.test.ts
+++ b/test/valid-data.test.ts
@@ -122,6 +122,7 @@ describe("valid-data", () => {
     it("type-indexed-access-tuple-2", assertSchema("type-indexed-access-tuple-2", "MyType"));
     it("type-indexed-access-object-1", assertSchema("type-indexed-access-object-1", "MyType"));
     it("type-indexed-access-object-2", assertSchema("type-indexed-access-object-2", "MyType"));
+    it("type-indexed-access-keyof", assertSchema("type-indexed-access-keyof", "MyType"));
     it("type-keyof-tuple", assertSchema("type-keyof-tuple", "MyType"));
     it("type-keyof-object", assertSchema("type-keyof-object", "MyType"));
     it("type-keyof-object-function", assertSchema("type-keyof-object-function", "MyType"));

--- a/test/valid-data/type-indexed-access-keyof/main.ts
+++ b/test/valid-data/type-indexed-access-keyof/main.ts
@@ -1,0 +1,13 @@
+interface Types1 {
+    String: string;
+}
+
+interface Types2 {
+    String: string;
+    Number: number;
+}
+
+export interface MyType {
+    types1: Types1[keyof Types1];
+    types2: Types2[keyof Types2];
+}

--- a/test/valid-data/type-indexed-access-keyof/schema.json
+++ b/test/valid-data/type-indexed-access-keyof/schema.json
@@ -1,0 +1,25 @@
+{
+    "$ref": "#/definitions/MyType",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "MyType": {
+            "additionalProperties": false,
+            "properties": {
+                "types1": {
+                    "type": "string"
+                },
+                "types2": {
+                    "type": [
+                        "string",
+                        "number"
+                    ]
+                }
+            },
+            "required": [
+                "types1",
+                "types2"
+            ],
+            "type": "object"
+        }
+    }
+}


### PR DESCRIPTION
An alternative to PR #132. Instead of implementing just a workaround for union types which only contain one type this solution actually handles union types.

Fixes #131 