### PR TITLE
Handle parameter property declarations

### DIFF
--- a/src/NodeParser/AnnotatedNodeParser.ts
+++ b/src/NodeParser/AnnotatedNodeParser.ts
@@ -36,6 +36,8 @@ export class AnnotatedNodeParser implements SubNodeParser {
             return node.parent;
         } else if (node.parent.kind === ts.SyntaxKind.IndexSignature) {
             return node.parent;
+        } else if (node.parent.kind === ts.SyntaxKind.Parameter) {
+            return node.parent;
         } else {
             return node;
         }

--- a/src/Utils/modifiers.ts
+++ b/src/Utils/modifiers.ts
@@ -1,0 +1,37 @@
+import * as ts from "typescript";
+
+/**
+ * Checks if given node has the given modifier.
+ *
+ * @param node     - The node to check.
+ * @param modifier - The modifier to look for.
+ * @return True if node has the modifier, false if not.
+ */
+export function hasModifier(node: ts.Node, modifier: ts.SyntaxKind): boolean {
+    const nodeModifiers = node.modifiers;
+    if (nodeModifiers == null) {
+        return false;
+    } else {
+        return nodeModifiers.some(nodeModifier => nodeModifier.kind === modifier);
+    }
+}
+
+/**
+ * Checks if given node is public. A node is public if it has the public modifier or has no modifiers at all.
+ *
+ * @param node - The node to check.
+ * @return True if node is public, false if not.
+ */
+export function isPublic(node: ts.Node): boolean {
+    return node.modifiers == null || hasModifier(node, ts.SyntaxKind.PublicKeyword);
+}
+
+/**
+ * Checks if given node has the static modifier.
+ *
+ * @param node - The node to check.
+ * @return True if node is static, false if not.
+ */
+export function isStatic(node: ts.Node): boolean {
+    return hasModifier(node, ts.SyntaxKind.StaticKeyword);
+}

--- a/test/valid-data/class-jsdoc/main.ts
+++ b/test/valid-data/class-jsdoc/main.ts
@@ -9,4 +9,10 @@ export class MyObject {
      * @pattern /abc/
      */
     public y: string;
+
+    /**
+     * @param a Parameter a description
+     * @param b Parameter b description
+     */
+    public constructor(public a: string, public b: number) {}
 }

--- a/test/valid-data/class-jsdoc/schema.json
+++ b/test/valid-data/class-jsdoc/schema.json
@@ -6,6 +6,14 @@
             "additionalProperties": false,
             "description": "Class Description",
             "properties": {
+                "a": {
+                    "description": "Parameter a description",
+                    "type": "string"
+                },
+                "b": {
+                    "description": "Parameter b description",
+                    "type": "number"
+                },
                 "x": {
                     "description": "Property x description",
                     "type": "string"
@@ -18,7 +26,9 @@
             },
             "required": [
                 "x",
-                "y"
+                "y",
+                "a",
+                "b"
             ],
             "type": "object"
         }

--- a/test/valid-data/class-single/main.ts
+++ b/test/valid-data/class-single/main.ts
@@ -15,7 +15,8 @@ export class MyObject {
     private privateProp: boolean;
 
     // Constructors must be ignored
-    public constructor() {
+    public constructor(protected a: number, private b: number, c: number, public propC: number,
+            public propD?: string) {
         this.privateProp = false;
     }
 

--- a/test/valid-data/class-single/schema.json
+++ b/test/valid-data/class-single/schema.json
@@ -10,11 +10,18 @@
                 },
                 "propB": {
                     "type": "number"
+                },
+                "propC": {
+                    "type": "number"
+                },
+                "propD": {
+                    "type": "string"
                 }
             },
             "required": [
                 "propA",
-                "propB"
+                "propB",
+                "propC"
             ],
             "type": "object"
         }


### PR DESCRIPTION
Handling parameter property declarations pretty much works the same as handling properties so with this change I first merge these parameters and the properties into a single array before they are filtered by the various criterias and then converted into ObjectProperty instances.

I also simplified this whole process a little bit by adding a few new utility functions.

Fixes #134 