### PR TITLE
Improve exceptions

### DIFF
--- a/src/Error/BaseError.ts
+++ b/src/Error/BaseError.ts
@@ -1,14 +1,5 @@
-export abstract class BaseError implements Error {
-    private callStack: any;
-
-    public constructor() {
-        this.callStack = new Error().stack;
+export abstract class BaseError extends Error {
+    public constructor(message?: string) {
+        super(message);
     }
-
-    public get stack(): string {
-        return this.callStack;
-    }
-
-    public abstract get name(): string;
-    public abstract get message(): string;
 }

--- a/src/Error/DiagnosticError.ts
+++ b/src/Error/DiagnosticError.ts
@@ -3,16 +3,9 @@ import { BaseError } from "./BaseError";
 
 export class DiagnosticError extends BaseError {
     public constructor(private diagnostics: ReadonlyArray<ts.Diagnostic>) {
-        super();
-    }
-
-    public get name(): string {
-        return "DiagnosticError";
-    }
-    public get message(): string {
-        return this.diagnostics
+        super(diagnostics
             .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))
-            .join("\n\n");
+            .join("\n\n"));
     }
 
     public getDiagnostics() {

--- a/src/Error/LogicError.ts
+++ b/src/Error/LogicError.ts
@@ -2,13 +2,6 @@ import { BaseError } from "./BaseError";
 
 export class LogicError extends BaseError {
     public constructor(private msg: string) {
-        super();
-    }
-
-    public get name(): string {
-        return "LogicError";
-    }
-    public get message(): string {
-        return this.msg;
+        super(msg);
     }
 }

--- a/src/Error/NoRootTypeError.ts
+++ b/src/Error/NoRootTypeError.ts
@@ -2,14 +2,7 @@ import { BaseError } from "./BaseError";
 
 export class NoRootTypeError extends BaseError {
     public constructor(private type: string) {
-        super();
-    }
-
-    public get name(): string {
-        return "NoRootTypeError";
-    }
-    public get message(): string {
-        return `No root type "${this.type}" found`;
+        super(`No root type "${type}" found`);
     }
 
     public getType(): string {

--- a/src/Error/UnknownNodeError.ts
+++ b/src/Error/UnknownNodeError.ts
@@ -3,19 +3,13 @@ import { BaseError } from "./BaseError";
 
 export class UnknownNodeError extends BaseError {
     public constructor(private node: ts.Node, private reference?: ts.Node) {
-        super();
-    }
-
-    public get name(): string {
-        return "UnknownNodeError";
-    }
-    public get message(): string {
-        return `Unknown node "${this.node.getFullText()}`;
+        super(`Unknown node "${node.getFullText()}`);
     }
 
     public getNode(): ts.Node {
         return this.node;
     }
+
     public getReference(): ts.Node | undefined {
         return this.reference;
     }

--- a/src/Error/UnknownTypeError.ts
+++ b/src/Error/UnknownTypeError.ts
@@ -3,14 +3,7 @@ import { BaseError } from "./BaseError";
 
 export class UnknownTypeError extends BaseError {
     public constructor(private type: BaseType) {
-        super();
-    }
-
-    public get name(): string {
-        return "UnknownTypeError";
-    }
-    public get message(): string {
-        return `Unknown type "${this.type.getId()}"`;
+        super(`Unknown type "${type.getId()}"`);
     }
 
     public getType(): BaseType {


### PR DESCRIPTION
Project is targeting ES2017 so Error can be extended directly instead of faking error objects. As a result exceptions thrown in tests now yield the correct error message and stack trace.

To test this you could temporarily add this code to the top of  `TypeReferenceNodeParser#createType` for example:

```typescript
if (2 > 1) {
    throw new LogicError("What the heck?");
}
```

Without the changes in this PR you get ugly errors like this:

```
valid-data › import-anonymous



      3 | 
      4 |     public constructor() {
    > 5 |         this.callStack = new Error().stack;
        |                          ^
      6 |     }
      7 | 
      8 |     public get stack(): string {

      at new BaseError (src/Error/BaseError.ts:5:26)
      at new LogicError (src/Error/LogicError.ts:5:9)
      at TypeReferenceNodeParser.createType (src/NodeParser/TypeReferenceNodeParser.ts:25:19)
```

With the changes of this PR you get this:

```
valid-data › import-anonymous

    What the heck?

      23 |     public createType(node: ts.TypeReferenceNode, context: Context): BaseType {
      24 |         if (2 > 1) {
    > 25 |             throw new LogicError("What the heck?");
         |                   ^
      26 |         }
      27 |         const typeSymbol = this.typeChecker.getSymbolAtLocation(node.typeName)!;
      28 |         if (typeSymbol.flags & ts.SymbolFlags.Alias) {

      at TypeReferenceNodeParser.createType (src/NodeParser/TypeReferenceNodeParser.ts:25:19)
```

So this makes finding problems during development much easier.