### PR TITLE
Improve condition type node parser

### DIFF
--- a/src/NodeParser/ConditionalTypeNodeParser.ts
+++ b/src/NodeParser/ConditionalTypeNodeParser.ts
@@ -33,7 +33,7 @@ export class ConditionalTypeNodeParser implements SubNodeParser {
         const falseCheckType = narrowType(checkType, type => !isAssignableTo(extendsType, type));
 
         // Follow the relevant branches and return the results from them
-        let results: BaseType[] = [];
+        const results: BaseType[] = [];
         if (!(trueCheckType instanceof NeverType)) {
             results.push(this.childNodeParser.createType(node.trueType,
                 this.createSubContext(node, checkTypeParameterName, trueCheckType, context)));
@@ -70,8 +70,10 @@ export class ConditionalTypeNodeParser implements SubNodeParser {
      * @param narrowedCheckType      - The narrowed down check type to use for the type parameter in sub parsers.
      * @return The created sub context.
      */
-    private createSubContext(node: ts.ConditionalTypeNode, checkTypeParameterName: string, narrowedCheckType: BaseType,
-            parentContext: Context): Context {
+    private createSubContext(
+        node: ts.ConditionalTypeNode, checkTypeParameterName: string,
+        narrowedCheckType: BaseType, parentContext: Context
+    ): Context {
         const subContext = new Context(node);
 
         // Set new narrowed type for check type parameter

--- a/src/NodeParser/ConditionalTypeNodeParser.ts
+++ b/src/NodeParser/ConditionalTypeNodeParser.ts
@@ -4,6 +4,8 @@ import { SubNodeParser } from "../SubNodeParser";
 import { BaseType } from "../Type/BaseType";
 import { isAssignableTo } from "../Utils/isAssignableTo";
 import { narrowType } from "../Utils/narrowType";
+import { NeverType } from "../Type/NeverType";
+import { UnionType } from "../Type/UnionType";
 
 export class ConditionalTypeNodeParser implements SubNodeParser {
     public constructor(
@@ -18,18 +20,29 @@ export class ConditionalTypeNodeParser implements SubNodeParser {
     public createType(node: ts.ConditionalTypeNode, context: Context): BaseType {
         const checkType = this.childNodeParser.createType(node.checkType, context);
         const extendsType = this.childNodeParser.createType(node.extendsType, context);
-        const result = isAssignableTo(extendsType, checkType);
-        const tsResultType = result ? node.trueType : node.falseType;
-        const resultType = this.childNodeParser.createType(tsResultType, context);
-
-        // If result type is the same type parameter as the check type then narrow down the result type
         const checkTypeParameterName = this.getTypeParameterName(node.checkType);
-        const resultTypeParameterName = this.getTypeParameterName(tsResultType);
-        if (resultTypeParameterName != null && resultTypeParameterName === checkTypeParameterName) {
-            return narrowType(resultType, type => isAssignableTo(extendsType, type) === result);
+
+        // If check-type is not a type parameter then condition is very simple, no type narrowing needed
+        if (checkTypeParameterName == null) {
+            const result = isAssignableTo(extendsType, checkType);
+            return this.childNodeParser.createType(result ? node.trueType : node.falseType, context);
         }
 
-        return resultType;
+        // Narrow down check type for both condition branches
+        const trueCheckType = narrowType(checkType, type => isAssignableTo(extendsType, type));
+        const falseCheckType = narrowType(checkType, type => !isAssignableTo(extendsType, type));
+
+        // Follow the relevant branches and return the results from them
+        let results: BaseType[] = [];
+        if (!(trueCheckType instanceof NeverType)) {
+            results.push(this.childNodeParser.createType(node.trueType,
+                this.createSubContext(node, checkTypeParameterName, trueCheckType, context)));
+        }
+        if (!(falseCheckType instanceof NeverType)) {
+            results.push(this.childNodeParser.createType(node.falseType,
+                this.createSubContext(node, checkTypeParameterName, falseCheckType, context)));
+        }
+        return new UnionType(results).normalize();
     }
 
     /**
@@ -47,4 +60,33 @@ export class ConditionalTypeNodeParser implements SubNodeParser {
         }
         return null;
     }
+
+    /**
+     * Creates a sub context for evaluating the sub types of the conditional type. A sub context is needed in case
+     * the check-type is a type parameter which is then narrowed down by the extends-type.
+     *
+     * @param node                   - The reference node for the new context.
+     * @param checkTypeParameterName - The type parameter name of the check-type.
+     * @param narrowedCheckType      - The narrowed down check type to use for the type parameter in sub parsers.
+     * @return The created sub context.
+     */
+    private createSubContext(node: ts.ConditionalTypeNode, checkTypeParameterName: string, narrowedCheckType: BaseType,
+            parentContext: Context): Context {
+        const subContext = new Context(node);
+
+        // Set new narrowed type for check type parameter
+        subContext.pushParameter(checkTypeParameterName);
+        subContext.pushArgument(narrowedCheckType);
+
+        // Copy all other type parameters from parent context
+        parentContext.getParameters().forEach((parentParameter) => {
+            if (parentParameter !== checkTypeParameterName) {
+                subContext.pushParameter(parentParameter);
+                subContext.pushArgument(parentContext.getArgument(parentParameter));
+            }
+        });
+
+        return subContext;
+    }
+
 }

--- a/src/Type/UnionType.ts
+++ b/src/Type/UnionType.ts
@@ -1,21 +1,20 @@
 import { BaseType } from "./BaseType";
-import { uniqueArray } from "../Utils/uniqueArray";
 import { uniqueTypeArray } from "../Utils/uniqueTypeArray";
 import { NeverType } from "./NeverType";
 
 export class UnionType extends BaseType {
-    private readonly types: ReadonlyArray<BaseType>;
+    private readonly types: BaseType[];
 
     public constructor(types: BaseType[]) {
         super();
-        this.types = uniqueTypeArray(types.reduce((types, type) => {
+        this.types = uniqueTypeArray(types.reduce((flatTypes, type) => {
             if (type instanceof UnionType) {
-                types.push(...type.getTypes());
+                flatTypes.push(...type.getTypes());
             } else if (!(type instanceof NeverType)) {
-                types.push(type);
+                flatTypes.push(type);
             }
-            return types;
-        }, <BaseType[]>[]));
+            return flatTypes;
+        }, [] as BaseType[]));
     }
 
     public getId(): string {
@@ -26,7 +25,7 @@ export class UnionType extends BaseType {
         return "(" + this.types.map((type) => type.getName()).join("|") + ")";
     }
 
-    public getTypes(): ReadonlyArray<BaseType> {
+    public getTypes(): BaseType[] {
         return this.types;
     }
 

--- a/src/Type/UnionType.ts
+++ b/src/Type/UnionType.ts
@@ -1,10 +1,21 @@
 import { BaseType } from "./BaseType";
+import { uniqueArray } from "../Utils/uniqueArray";
+import { uniqueTypeArray } from "../Utils/uniqueTypeArray";
+import { NeverType } from "./NeverType";
 
 export class UnionType extends BaseType {
-    public constructor(
-        private types: BaseType[],
-    ) {
+    private readonly types: ReadonlyArray<BaseType>;
+
+    public constructor(types: BaseType[]) {
         super();
+        this.types = uniqueTypeArray(types.reduce((types, type) => {
+            if (type instanceof UnionType) {
+                types.push(...type.getTypes());
+            } else if (!(type instanceof NeverType)) {
+                types.push(type);
+            }
+            return types;
+        }, <BaseType[]>[]));
     }
 
     public getId(): string {
@@ -15,7 +26,17 @@ export class UnionType extends BaseType {
         return "(" + this.types.map((type) => type.getName()).join("|") + ")";
     }
 
-    public getTypes(): BaseType[] {
+    public getTypes(): ReadonlyArray<BaseType> {
         return this.types;
+    }
+
+    public normalize(): BaseType {
+        if (this.types.length === 0) {
+            return new NeverType();
+        } else if (this.types.length === 1) {
+            return this.types[0];
+        } else {
+            return this;
+        }
     }
 }

--- a/src/Utils/uniqueTypeArray.ts
+++ b/src/Utils/uniqueTypeArray.ts
@@ -1,0 +1,9 @@
+import { BaseType } from "../Type/BaseType";
+
+export function uniqueTypeArray<T extends BaseType>(types: T[]): T[] {
+    let uniqueTypes = new Map<string, T>();
+    for (const type of types) {
+        uniqueTypes.set(type.getId(), type);
+    }
+    return Array.from(uniqueTypes.values());
+}

--- a/src/Utils/uniqueTypeArray.ts
+++ b/src/Utils/uniqueTypeArray.ts
@@ -1,7 +1,7 @@
 import { BaseType } from "../Type/BaseType";
 
 export function uniqueTypeArray<T extends BaseType>(types: T[]): T[] {
-    let uniqueTypes = new Map<string, T>();
+    const uniqueTypes = new Map<string, T>();
     for (const type of types) {
         uniqueTypes.set(type.getId(), type);
     }

--- a/test/valid-data.test.ts
+++ b/test/valid-data.test.ts
@@ -173,6 +173,7 @@ describe("valid-data", () => {
     it("type-conditional-exclude", assertSchema("type-conditional-exclude", "MyObject"));
     it("type-conditional-exclude-complex", assertSchema("type-conditional-exclude-complex", "BaseAxisNoSignals"));
     it("type-conditional-exclude-narrowing", assertSchema("type-conditional-exclude-narrowing", "MyObject"));
+    it("type-conditional-narrowing", assertSchema("type-conditional-narrowing", "MyObject"));
     it("type-conditional-omit", assertSchema("type-conditional-omit", "MyObject"));
     it("type-conditional-jsdoc", assertSchema("type-conditional-jsdoc", "MyObject", "extended"));
 });

--- a/test/valid-data/type-conditional-narrowing/main.ts
+++ b/test/valid-data/type-conditional-narrowing/main.ts
@@ -1,0 +1,13 @@
+type TypeName<T> =
+    T extends string ? "string" :
+    T extends number ? "number" :
+    "unknown";
+
+export type MyObject = {
+    string: TypeName<string>;
+    number?: TypeName<number>;
+    stringOrNumber: TypeName<string | number>;
+    unknown?: TypeName<boolean>;
+    stringOrUnknown?: TypeName<string | boolean>;
+    numberOrUnknown?: TypeName<number | boolean>;
+}

--- a/test/valid-data/type-conditional-narrowing/schema.json
+++ b/test/valid-data/type-conditional-narrowing/schema.json
@@ -1,0 +1,55 @@
+{
+    "$ref": "#/definitions/MyObject",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "MyObject": {
+            "additionalProperties": false,
+            "properties": {
+                "number": {
+                    "enum": [
+                        "number"
+                    ],
+                    "type": "string"
+                },
+                "numberOrUnknown": {
+                    "enum": [
+                        "number",
+                        "unknown"
+                    ],
+                    "type": "string"
+                },
+                "string": {
+                    "enum": [
+                        "string"
+                    ],
+                    "type": "string"
+                },
+                "stringOrNumber": {
+                    "enum": [
+                        "string",
+                        "number"
+                    ],
+                    "type": "string"
+                },
+                "stringOrUnknown": {
+                    "enum": [
+                        "string",
+                        "unknown"
+                    ],
+                    "type": "string"
+                },
+                "unknown": {
+                    "enum": [
+                        "unknown"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "string",
+                "stringOrNumber"
+            ],
+            "type": "object"
+        }
+    }
+}


### PR DESCRIPTION
When check-type is a type parameter then we actually have to follow both branches with the check-type narrowed down by the extends-type (And the inverse of it) and then create a union type of all results. At least I hope that this finally gets it right now...

To prevent useless duplications in the resulting type I also improved the union type itself so it automatically flattens itself if possible, removes duplicate types and Never types. The new normalize() method can be used to convert it to the single type when only one is present or Never type if union is empty.

Fixes #148 