### PR TITLE
Fix literal type handling in isAssignableTo

### DIFF
--- a/src/Utils/isAssignableTo.ts
+++ b/src/Utils/isAssignableTo.ts
@@ -12,6 +12,10 @@ import { UndefinedType } from "../Type/UndefinedType";
 import { UnionType } from "../Type/UnionType";
 import { UnknownType } from "../Type/UnknownType";
 import { derefType } from "./derefType";
+import { LiteralType } from "../Type/LiteralType";
+import { StringType } from "../Type/StringType";
+import { NumberType } from "../Type/NumberType";
+import { BooleanType } from "../Type/BooleanType";
 
 /**
  * Returns the combined types from the given intersection. Currently only object types are combined. Maybe more
@@ -135,6 +139,18 @@ export function isAssignableTo(target: BaseType, source: BaseType, insideTypes: 
     // types within the intersection must be combined first
     if (target instanceof IntersectionType) {
         return combineIntersectingTypes(target).every(type => isAssignableTo(type, source, insideTypes));
+    }
+
+    // Check literal types
+    if (source instanceof LiteralType) {
+        const value = source.getValue();
+        if (typeof value === "string") {
+            return isAssignableTo(target, new StringType());
+        } else if (typeof value === "number") {
+            return isAssignableTo(target, new NumberType());
+        } else if (typeof value === "boolean") {
+            return isAssignableTo(target, new BooleanType());
+        }
     }
 
     if (target instanceof ObjectType) {

--- a/test/unit/isAssignableTo.test.ts
+++ b/test/unit/isAssignableTo.test.ts
@@ -323,4 +323,27 @@ describe("isAssignableTo", () => {
         const def = new DefinitionType("NumericValueRef", objectType);
         expect(isAssignableTo(outerUnion, def)).toBe(true);
     });
+    it("correctly handles literal types", () => {
+        expect(isAssignableTo(new StringType(), new LiteralType("foo"))).toBe(true);
+        expect(isAssignableTo(new NumberType(), new LiteralType("foo"))).toBe(false);
+        expect(isAssignableTo(new BooleanType(), new LiteralType("foo"))).toBe(false);
+        expect(isAssignableTo(new StringType(), new LiteralType(1))).toBe(false);
+        expect(isAssignableTo(new NumberType(), new LiteralType(1))).toBe(true);
+        expect(isAssignableTo(new BooleanType(), new LiteralType(1))).toBe(false);
+        expect(isAssignableTo(new StringType(), new LiteralType(true))).toBe(false);
+        expect(isAssignableTo(new NumberType(), new LiteralType(true))).toBe(false);
+        expect(isAssignableTo(new BooleanType(), new LiteralType(true))).toBe(true);
+
+        expect(isAssignableTo(new LiteralType("foo"), new StringType())).toBe(false);
+        expect(isAssignableTo(new LiteralType(1), new NumberType())).toBe(false);
+        expect(isAssignableTo(new LiteralType(true), new BooleanType())).toBe(false);
+
+        expect(isAssignableTo(new LiteralType("foo"), new LiteralType("bar"))).toBe(false);
+        expect(isAssignableTo(new LiteralType(1), new LiteralType(2))).toBe(false);
+        expect(isAssignableTo(new LiteralType(true), new LiteralType(false))).toBe(false);
+
+        expect(isAssignableTo(new LiteralType("foo"), new LiteralType("foo"))).toBe(true);
+        expect(isAssignableTo(new LiteralType(1), new LiteralType(1))).toBe(true);
+        expect(isAssignableTo(new LiteralType(true), new LiteralType(true))).toBe(true);
+    });
 });


### PR DESCRIPTION
A last fix to finally get the schema in my own project fully working. Literal types were not properly supported in `isAssignableTo`