### PR TITLE
feat: any adds additionalProperties=true

### DIFF
--- a/src/TypeFormatter/AnyTypeFormatter.ts
+++ b/src/TypeFormatter/AnyTypeFormatter.ts
@@ -8,7 +8,7 @@ export class AnyTypeFormatter implements SubTypeFormatter {
         return type instanceof AnyType;
     }
     public getDefinition(type: AnyType): Definition {
-        return {};
+        return { additionalProperties: true };
     }
     public getChildren(type: AnyType): BaseType[] {
         return [];

--- a/src/TypeFormatter/ObjectTypeFormatter.ts
+++ b/src/TypeFormatter/ObjectTypeFormatter.ts
@@ -14,7 +14,7 @@ import { StringMap } from "../Utils/StringMap";
 import { uniqueArray } from "../Utils/uniqueArray";
 
 export class ObjectTypeFormatter implements SubTypeFormatter {
-    public constructor(private childTypeFormatter: TypeFormatter) {}
+    public constructor(private childTypeFormatter: TypeFormatter) { }
 
     public supportsType(type: ObjectType): boolean {
         return type instanceof ObjectType;
@@ -80,13 +80,13 @@ export class ObjectTypeFormatter implements SubTypeFormatter {
             ...(Object.keys(properties).length > 0 ? { properties } : {}),
             ...(required.length > 0 ? { required } : {}),
             ...(additionalProperties === true || additionalProperties instanceof AnyType
-                ? {}
+                ? { additionalProperties: true }
                 : {
-                      additionalProperties:
-                          additionalProperties instanceof BaseType
-                              ? this.childTypeFormatter.getDefinition(additionalProperties)
-                              : additionalProperties,
-                  }),
+                    additionalProperties:
+                        additionalProperties instanceof BaseType
+                            ? this.childTypeFormatter.getDefinition(additionalProperties)
+                            : additionalProperties,
+                }),
         };
     }
 

--- a/src/TypeFormatter/ObjectTypeFormatter.ts
+++ b/src/TypeFormatter/ObjectTypeFormatter.ts
@@ -14,7 +14,7 @@ import { StringMap } from "../Utils/StringMap";
 import { uniqueArray } from "../Utils/uniqueArray";
 
 export class ObjectTypeFormatter implements SubTypeFormatter {
-    public constructor(private childTypeFormatter: TypeFormatter) { }
+    public constructor(private childTypeFormatter: TypeFormatter) {}
 
     public supportsType(type: ObjectType): boolean {
         return type instanceof ObjectType;
@@ -82,11 +82,11 @@ export class ObjectTypeFormatter implements SubTypeFormatter {
             ...(additionalProperties === true || additionalProperties instanceof AnyType
                 ? { additionalProperties: true }
                 : {
-                    additionalProperties:
-                        additionalProperties instanceof BaseType
-                            ? this.childTypeFormatter.getDefinition(additionalProperties)
-                            : additionalProperties,
-                }),
+                      additionalProperties:
+                          additionalProperties instanceof BaseType
+                              ? this.childTypeFormatter.getDefinition(additionalProperties)
+                              : additionalProperties,
+                  }),
         };
     }
 

--- a/test/valid-data/any-unknown/main.ts
+++ b/test/valid-data/any-unknown/main.ts
@@ -1,4 +1,5 @@
 export interface MyObject {
     value1: any;
     value2: unknown;
+    value3: { [id: string]: any }
 }

--- a/test/valid-data/any-unknown/schema.json
+++ b/test/valid-data/any-unknown/schema.json
@@ -4,12 +4,19 @@
         "MyObject": {
             "type": "object",
             "properties": {
-                "value1": {},
-                "value2": {}
+                "value1": {
+                    "additionalProperties": true
+                },
+                "value2": {},
+                "value3": {
+                    "additionalProperties": true,
+                    "type": "object"
+                }
             },
             "required": [
                 "value1",
-                "value2"
+                "value2",
+                "value3"
             ],
             "additionalProperties": false
         }

--- a/test/valid-data/generic-arrays/main.ts
+++ b/test/valid-data/generic-arrays/main.ts
@@ -1,4 +1,5 @@
 export interface MyObject {
     numberArray: Array<number>;
     stringArray: ReadonlyArray<string>;
+    anyArray: Array<any>;
 }

--- a/test/valid-data/generic-arrays/schema.json
+++ b/test/valid-data/generic-arrays/schema.json
@@ -15,11 +15,18 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "anyArray": {
+                    "type": "array",
+                    "items": {
+                        "additionalProperties": true
+                    }
                 }
             },
             "required": [
                 "numberArray",
-                "stringArray"
+                "stringArray",
+                "anyArray"
             ],
             "additionalProperties": false
         }

--- a/test/valid-data/type-aliases-local-namespace/schema.json
+++ b/test/valid-data/type-aliases-local-namespace/schema.json
@@ -28,7 +28,9 @@
         "B.B": {
             "type": "object",
             "properties": {
-                "b": {}
+                "b": {
+                    "additionalProperties": true
+                }
             },
             "required": [
                 "b"

--- a/test/valid-data/type-maps/schema.json
+++ b/test/valid-data/type-maps/schema.json
@@ -11,6 +11,7 @@
                     "$ref": "#/definitions/MyMap2"
                 },
                 "map3": {
+                    "additionalProperties": true,
                     "type": "object"
                 }
             },


### PR DESCRIPTION
This PR adds additionalProperties=true to any schema mapped from the any type.
It also fixes the issue where type of object did not have additionalProperties=true set.
Closes #240

```
interface AdditionalProperties {
    value1: any;
    value2: { [id:key]: any }
    value3: Array<any>
    value4: object
}
```

Will map to

```
{
    "$schema": "http://json-schema.org/draft-07/schema#",
    "definitions": {
        "MyObject": {
            "type": "object",
            "properties": {
                "value1": {
                    "additionalProperties": true
                },
                "value2": {
                    "additionalProperties": true,
                    "type": "object"
                },
               "value3": {
                    "type": "array",
                    "items": {
                        "additionalProperties": true
               },
               "value4": {
                    "additionalProperties": true,
                    "type": "object"
                }
            },
            "required": [
                "value1",
                "value2",
                "value3",
                "value4"
            ],
            "additionalProperties": false
        }
    },
    "$ref": "#/definitions/MyObject"
}
```