### PR TITLE
Add void type

### DIFF
--- a/factory/formatter.ts
+++ b/factory/formatter.ts
@@ -24,6 +24,7 @@ import { TupleTypeFormatter } from "../src/TypeFormatter/TupleTypeFormatter";
 import { UndefinedTypeFormatter } from "../src/TypeFormatter/UndefinedTypeFormatter";
 import { UnionTypeFormatter } from "../src/TypeFormatter/UnionTypeFormatter";
 import { UnknownTypeFormatter } from "../src/TypeFormatter/UnknownTypeFormatter";
+import { VoidTypeFormatter } from "../src/TypeFormatter/VoidTypeFormatter";
 
 export function createFormatter(): TypeFormatter {
     const chainTypeFormatter = new ChainTypeFormatter([]);
@@ -41,6 +42,7 @@ export function createFormatter(): TypeFormatter {
         .addTypeFormatter(new NeverTypeFormatter())
         .addTypeFormatter(new UndefinedTypeFormatter())
         .addTypeFormatter(new UnknownTypeFormatter())
+        .addTypeFormatter(new VoidTypeFormatter())
 
         .addTypeFormatter(new LiteralTypeFormatter())
         .addTypeFormatter(new EnumTypeFormatter())

--- a/factory/parser.ts
+++ b/factory/parser.ts
@@ -40,6 +40,7 @@ import { TypeReferenceNodeParser } from "../src/NodeParser/TypeReferenceNodePars
 import { UndefinedTypeNodeParser } from "../src/NodeParser/UndefinedTypeNodeParser";
 import { UnionNodeParser } from "../src/NodeParser/UnionNodeParser";
 import { UnknownTypeNodeParser } from "../src/NodeParser/UnknownTypeNodeParser";
+import { VoidTypeNodeParser } from "../src/NodeParser/VoidTypeNodeParser";
 import { SubNodeParser } from "../src/SubNodeParser";
 import { TopRefNodeParser } from "../src/TopRefNodeParser";
 import { FunctionNodeParser } from "./../src/NodeParser/FunctionNodeParser";
@@ -74,6 +75,7 @@ export function createParser(program: ts.Program, config: Config): NodeParser {
         .addNodeParser(new BooleanTypeNodeParser())
         .addNodeParser(new AnyTypeNodeParser())
         .addNodeParser(new UnknownTypeNodeParser())
+        .addNodeParser(new VoidTypeNodeParser())
         .addNodeParser(new UndefinedTypeNodeParser())
         .addNodeParser(new NeverTypeNodeParser())
         .addNodeParser(new ObjectTypeNodeParser())

--- a/src/NodeParser/VoidTypeNodeParser.ts
+++ b/src/NodeParser/VoidTypeNodeParser.ts
@@ -1,0 +1,14 @@
+import * as ts from "typescript";
+import { Context } from "../NodeParser";
+import { SubNodeParser } from "../SubNodeParser";
+import { BaseType } from "../Type/BaseType";
+import { VoidType } from "../Type/VoidType";
+
+export class VoidTypeNodeParser implements SubNodeParser {
+    public supportsNode(node: ts.KeywordTypeNode): boolean {
+        return node.kind === ts.SyntaxKind.VoidKeyword;
+    }
+    public createType(node: ts.KeywordTypeNode, context: Context): BaseType {
+        return new VoidType();
+    }
+}

--- a/src/Type/VoidType.ts
+++ b/src/Type/VoidType.ts
@@ -1,0 +1,7 @@
+import { BaseType } from "./BaseType";
+
+export class VoidType extends BaseType {
+    public getId(): string {
+        return "void";
+    }
+}

--- a/src/TypeFormatter/VoidTypeFormatter.ts
+++ b/src/TypeFormatter/VoidTypeFormatter.ts
@@ -8,7 +8,7 @@ export class VoidTypeFormatter implements SubTypeFormatter {
         return type instanceof VoidType;
     }
     public getDefinition(type: VoidType): Definition {
-        return {type: "null"};
+        return { type: "null" };
     }
     public getChildren(type: VoidType): BaseType[] {
         return [];

--- a/src/TypeFormatter/VoidTypeFormatter.ts
+++ b/src/TypeFormatter/VoidTypeFormatter.ts
@@ -1,0 +1,16 @@
+import { Definition } from "../Schema/Definition";
+import { SubTypeFormatter } from "../SubTypeFormatter";
+import { BaseType } from "../Type/BaseType";
+import { VoidType } from "../Type/VoidType";
+
+export class VoidTypeFormatter implements SubTypeFormatter {
+    public supportsType(type: VoidType): boolean {
+        return type instanceof VoidType;
+    }
+    public getDefinition(type: VoidType): Definition {
+        return {type: "null"};
+    }
+    public getChildren(type: VoidType): BaseType[] {
+        return [];
+    }
+}

--- a/src/Utils/isAssignableTo.ts
+++ b/src/Utils/isAssignableTo.ts
@@ -11,6 +11,7 @@ import { TupleType } from "../Type/TupleType";
 import { UndefinedType } from "../Type/UndefinedType";
 import { UnionType } from "../Type/UnionType";
 import { UnknownType } from "../Type/UnknownType";
+import { VoidType } from "../Type/VoidType";
 import { derefType } from "./derefType";
 import { LiteralType, LiteralValue } from "../Type/LiteralType";
 import { StringType } from "../Type/StringType";
@@ -116,6 +117,11 @@ export function isAssignableTo(target: BaseType, source: BaseType, insideTypes: 
     // Type "never" can be assigned to anything
     if (source instanceof NeverType) {
         return true;
+    }
+
+    // 'null', or 'undefined' can be assigned to the void
+    if (target instanceof VoidType) {
+        return source instanceof NullType || source instanceof UndefinedType;
     }
 
     // Union and enum type is assignable to target when all types in the union/enum are assignable to it

--- a/test/unit/isAssignableTo.test.ts
+++ b/test/unit/isAssignableTo.test.ts
@@ -17,6 +17,7 @@ import { TupleType } from "../../src/Type/TupleType";
 import { UndefinedType } from "../../src/Type/UndefinedType";
 import { UnionType } from "../../src/Type/UnionType";
 import { UnknownType } from "../../src/Type/UnknownType";
+import { VoidType } from "../../src/Type/VoidType";
 import { isAssignableTo } from "../../src/Utils/isAssignableTo";
 
 describe("isAssignableTo", () => {
@@ -27,6 +28,7 @@ describe("isAssignableTo", () => {
         expect(isAssignableTo(new BooleanType(), new BooleanType())).toBe(true);
         expect(isAssignableTo(new StringType(), new StringType())).toBe(true);
         expect(isAssignableTo(new UndefinedType(), new UndefinedType())).toBe(true);
+        expect(isAssignableTo(new VoidType(), new VoidType())).toBe(true);
     });
     it("returns false for different types", () => {
         expect(isAssignableTo(new BooleanType(), new NullType())).toBe(false);
@@ -200,6 +202,15 @@ describe("isAssignableTo", () => {
         expect(isAssignableTo(new TupleType([new StringType(), new NumberType()]), new UnknownType())).toBe(false);
         expect(isAssignableTo(new UndefinedType(), new UnknownType())).toBe(false);
     });
+
+    it("lets 'any', 'never', 'null', and 'undefined' be assigned to type 'void'", () => {
+        expect(isAssignableTo(new VoidType(), new AnyType())).toBe(true);
+        expect(isAssignableTo(new VoidType(), new NeverType())).toBe(true);
+        expect(isAssignableTo(new VoidType(), new NullType())).toBe(true);
+        expect(isAssignableTo(new VoidType(), new UndefinedType())).toBe(true);
+        expect(isAssignableTo(new VoidType(), new UnknownType())).toBe(false);
+    });
+
     it("lets union type to be assigned if all sub types are compatible to target type", () => {
         const typeA = new ObjectType("a", [], [new ObjectProperty("a", new StringType(), true)], true);
         const typeB = new ObjectType("b", [], [new ObjectProperty("b", new StringType(), true)], true);

--- a/test/valid-data.test.ts
+++ b/test/valid-data.test.ts
@@ -167,6 +167,7 @@ describe("valid-data", () => {
     it("generic-hell", assertSchema("generic-hell", "MyObject"));
     it("generic-default", assertSchema("generic-default", "MyObject"));
     it("generic-prefixed-number", assertSchema("generic-prefixed-number", "MyObject"));
+    it("generic-void", assertSchema("generic-void", "MyObject"));
 
     it(
         "annotation-custom",

--- a/test/valid-data/generic-void/main.ts
+++ b/test/valid-data/generic-void/main.ts
@@ -1,0 +1,7 @@
+export interface MyGeneric<T> {
+    field: T;
+}
+
+export interface MyObject {
+    value: MyGeneric<void>;
+}

--- a/test/valid-data/generic-void/schema.json
+++ b/test/valid-data/generic-void/schema.json
@@ -13,7 +13,7 @@
             ],
             "additionalProperties": false
         },
-        "MyGeneric<number>": {
+        "MyGeneric<void>": {
             "type": "object",
             "properties": {
                 "field": {

--- a/test/valid-data/generic-void/schema.json
+++ b/test/valid-data/generic-void/schema.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "MyObject": {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "$ref": "#/definitions/MyGeneric<void>"
+                }
+            },
+            "required": [
+                "value"
+            ],
+            "additionalProperties": false
+        },
+        "MyGeneric<number>": {
+            "type": "object",
+            "properties": {
+                "field": {
+                    "type": "null"
+                }
+            },
+            "required": [
+                "field"
+            ],
+            "additionalProperties": false
+        }
+    },
+    "$ref": "#/definitions/MyObject"
+}


### PR DESCRIPTION
Thanks for the great tool! 

This adds a `VoidType(|Formatter|Parser)`.

Some background: 

I'm looking into https://github.com/microsoft/language-server-protocol/issues/67, basically reconciling the [reference implementation](https://github.com/microsoft/vscode-languageserver-node/blob/master/protocol/src/protocol.ts) types with the (separately maintained) [specification](https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-14.md). The good news: tsjsg handles the `protocol.ts` without complaint. Hooray :tada:! 

But... I've been running into a fair number of things that aren't getting pulled in to fully describe/validate what's in the markdown spec, and am having to expand my `--paths`, thereby encountering new issues. I assume it's failing after the first problem, so this is no doubt going to be one of those epic yak shaves.

The very first one is an interesting [use of `void`](https://github.com/microsoft/vscode-languageserver-node/blob/master/protocol/src/protocol.configuration.ts#L37):
```ts
export namespace ConfigurationRequest {
	export const type = new RequestType<ConfigurationParams & PartialResultParams, any[], void, void>('workspace/configuration');
	export type HandlerSignature = RequestHandler<ConfigurationParams, any[], void>;
	export type MiddlewareSignature = (params: ConfigurationParams, token: CancellationToken, next: HandlerSignature) => HandlerResult<any[], void>;
}
```
which yields
```
Error: Unknown node "void" (ts.SyntaxKind = 107) at .../vscode-languageserver-node/protocol/src/protocol.configuration.ts(37,75)
```

This fixes the void problem (hooray)...

### Yak shave n+1:

...revealing the next thing:

```
Error: Unknown type "function"
```

Onward!

> note: i got this when trying to lint:
```
yarn run v1.15.2
$ eslint '{src,test,factory}/**/*.ts'

Oops! Something went wrong! :(

ESLint: 6.5.1.

ESLint couldn't find the config "@satazor/eslint-config/es5" to extend from. Please check that the name of the config is correct.

The config "@satazor/eslint-config/es5" was referenced from the config file in "/home/weg/Documents/projects/ts-json-schema-generator/envs/lsp-json-schema/lib/node_modules/npm/node_modules/err-code/.eslintrc.json".
```
> hopefully it all works out!