### PR TITLE
fix: definition encoding

### DIFF
--- a/src/ExposeNodeParser.ts
+++ b/src/ExposeNodeParser.ts
@@ -41,7 +41,6 @@ export class ExposeNodeParser implements SubNodeParser {
         const fullName = this.typeChecker.getFullyQualifiedName(symbol).replace(/^".*"\./, "");
         const argumentIds = context.getArguments().map(arg => arg.getName());
 
-        const definitionName = argumentIds.length ? `${fullName}<${argumentIds.join(",")}>` : fullName;
-        return encodeURIComponent(definitionName);
+        return argumentIds.length ? `${fullName}<${argumentIds.join(",")}>` : fullName;
     }
 }

--- a/src/TypeFormatter/DefinitionTypeFormatter.ts
+++ b/src/TypeFormatter/DefinitionTypeFormatter.ts
@@ -12,7 +12,7 @@ export class DefinitionTypeFormatter implements SubTypeFormatter {
         return type instanceof DefinitionType;
     }
     public getDefinition(type: DefinitionType): Definition {
-        return { $ref: "#/definitions/" + type.getName() };
+        return { $ref: "#/definitions/" + encodeURIComponent(type.getName()) };
     }
     public getChildren(type: DefinitionType): BaseType[] {
         return uniqueArray([type, ...this.childTypeFormatter.getChildren(type.getType())]);

--- a/src/TypeFormatter/ReferenceTypeFormatter.ts
+++ b/src/TypeFormatter/ReferenceTypeFormatter.ts
@@ -12,7 +12,7 @@ export class ReferenceTypeFormatter implements SubTypeFormatter {
         return type instanceof ReferenceType;
     }
     public getDefinition(type: ReferenceType): Definition {
-        return { $ref: "#/definitions/" + type.getName() };
+        return { $ref: "#/definitions/" + encodeURIComponent(type.getName()) };
     }
     public getChildren(type: ReferenceType): BaseType[] {
         if (type.getType() instanceof DefinitionType) {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -44,6 +44,7 @@ function assertSchema(name: string, userConfig: Config & { type: string }, tscon
 
         validator.validateSchema(actual);
         expect(validator.errors).toBeNull();
+        validator.compile(actual); // Will find MissingRef errors
     };
 }
 

--- a/test/config/jsdoc-complex-basic/schema.json
+++ b/test/config/jsdoc-complex-basic/schema.json
@@ -26,7 +26,9 @@
         "exportString": {
           "$ref": "#/definitions/MyExportString",
           "description": "Export field description",
-          "default": { "length": 10 }
+          "default": {
+            "length": 10
+          }
         },
         "numberArray": {
           "$ref": "#/definitions/MyNonEmptyArray%3Cnumber%3E",
@@ -36,7 +38,14 @@
           "type": "number"
         }
       },
-      "required": ["stringValue", "numberValue", "exportString", "privateString", "numberArray", "number"],
+      "required": [
+        "stringValue",
+        "numberValue",
+        "exportString",
+        "privateString",
+        "numberArray",
+        "number"
+      ],
       "additionalProperties": false,
       "description": "Some description here",
       "title": "Some title here"
@@ -45,7 +54,7 @@
       "type": "string",
       "title": "My export string"
     },
-    "MyNonEmptyArray%3Cnumber%3E": {
+    "MyNonEmptyArray<number>": {
       "type": "array",
       "items": {
         "type": "number"

--- a/test/config/jsdoc-complex-extended/schema.json
+++ b/test/config/jsdoc-complex-extended/schema.json
@@ -26,7 +26,9 @@
         },
         "exportString": {
           "description": "Export field description",
-          "default": { "length": 10 },
+          "default": {
+            "length": 10
+          },
           "anyOf": [
             {
               "$ref": "#/definitions/MyExportString"
@@ -41,10 +43,20 @@
           "title": "Non empty array"
         },
         "number": {
-          "type": ["number", "null"]
+          "type": [
+            "number",
+            "null"
+          ]
         }
       },
-      "required": ["stringValue", "numberValue", "exportString", "privateString", "numberArray", "number"],
+      "required": [
+        "stringValue",
+        "numberValue",
+        "exportString",
+        "privateString",
+        "numberArray",
+        "number"
+      ],
       "additionalProperties": false,
       "description": "Some description here",
       "title": "Some title here"
@@ -53,7 +65,7 @@
       "type": "string",
       "title": "My export string"
     },
-    "MyNonEmptyArray%3Cnumber%3E": {
+    "MyNonEmptyArray<number>": {
       "type": "array",
       "items": {
         "type": "number"

--- a/test/config/jsdoc-complex-none/schema.json
+++ b/test/config/jsdoc-complex-none/schema.json
@@ -23,13 +23,20 @@
           "type": "number"
         }
       },
-      "required": ["stringValue", "numberValue", "exportString", "privateString", "numberArray", "number"],
+      "required": [
+        "stringValue",
+        "numberValue",
+        "exportString",
+        "privateString",
+        "numberArray",
+        "number"
+      ],
       "additionalProperties": false
     },
     "MyExportString": {
       "type": "string"
     },
-    "MyNonEmptyArray%3Cnumber%3E": {
+    "MyNonEmptyArray<number>": {
       "type": "array",
       "items": {
         "type": "number"

--- a/test/valid-data.test.ts
+++ b/test/valid-data.test.ts
@@ -51,6 +51,7 @@ function assertSchema(
 
         validator.validateSchema(actual);
         expect(validator.errors).toBeNull();
+        validator.compile(actual); // Will find MissingRef errors
     };
 }
 

--- a/test/valid-data/class-generics/schema.json
+++ b/test/valid-data/class-generics/schema.json
@@ -2,24 +2,28 @@
   "$ref": "#/definitions/MyObject",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "Base%3Cboolean%3E": {
+    "Base<boolean>": {
       "additionalProperties": false,
       "properties": {
         "a": {
           "type": "boolean"
         }
       },
-      "required": ["a"],
+      "required": [
+        "a"
+      ],
       "type": "object"
     },
-    "Base%3Cstring%3E": {
+    "Base<string>": {
       "additionalProperties": false,
       "properties": {
         "a": {
           "type": "string"
         }
       },
-      "required": ["a"],
+      "required": [
+        "a"
+      ],
       "type": "object"
     },
     "MyObject": {
@@ -38,7 +42,12 @@
           "$ref": "#/definitions/Base%3Cboolean%3E"
         }
       },
-      "required": ["a", "b", "c", "d"],
+      "required": [
+        "a",
+        "b",
+        "c",
+        "d"
+      ],
       "type": "object"
     }
   }

--- a/test/valid-data/generic-hell/schema.json
+++ b/test/valid-data/generic-hell/schema.json
@@ -8,7 +8,7 @@
           "type": "number"
         },
         "c": {
-          "$ref": "#/definitions/GenericC%3CGenericC%253CGenericA%25253Cstring%25253E%253E%3E"
+          "$ref": "#/definitions/GenericC%3CGenericC%3CGenericA%3Cstring%3E%3E%3E"
         },
         "someGeneric": {
           "$ref": "#/definitions/SomeGeneric%3C1%2C2%3E"
@@ -17,49 +17,64 @@
           "$ref": "#/definitions/SomeAlias%3C%22alias%22%3E"
         }
       },
-      "required": ["b", "c", "someAlias", "someGeneric"],
+      "required": [
+        "b",
+        "c",
+        "someAlias",
+        "someGeneric"
+      ],
       "additionalProperties": false
     },
-    "GenericC%3CGenericC%253CGenericA%25253Cstring%25253E%253E%3E": {
+    "GenericC<GenericC<GenericA<string>>>": {
       "type": "object",
       "properties": {
         "c": {
-          "$ref": "#/definitions/GenericC%3CGenericA%253Cstring%253E%3E"
+          "$ref": "#/definitions/GenericC%3CGenericA%3Cstring%3E%3E"
         }
       },
-      "required": ["c"],
+      "required": [
+        "c"
+      ],
       "additionalProperties": false
     },
-    "GenericC%3CGenericA%253Cstring%253E%3E": {
+    "GenericC<GenericA<string>>": {
       "type": "object",
       "properties": {
         "c": {
           "$ref": "#/definitions/GenericA%3Cstring%3E"
         }
       },
-      "required": ["c"],
+      "required": [
+        "c"
+      ],
       "additionalProperties": false
     },
-    "GenericA%3Cstring%3E": {
+    "GenericA<string>": {
       "type": "object",
       "properties": {
         "a": {
           "type": "string"
         }
       },
-      "required": ["a"],
+      "required": [
+        "a"
+      ],
       "additionalProperties": false
     },
-    "SomeGeneric%3C1%2C2%3E": {
+    "SomeGeneric<1,2>": {
       "type": "object",
       "properties": {
         "a": {
           "type": "number",
-          "enum": [1]
+          "enum": [
+            1
+          ]
         },
         "b": {
           "type": "number",
-          "enum": [2]
+          "enum": [
+            2
+          ]
         },
         "c": {
           "$ref": "#/definitions/GenericA%3C1%3E"
@@ -68,44 +83,61 @@
           "$ref": "#/definitions/GenericC%3C2%3E"
         }
       },
-      "required": ["a", "b", "c", "d"],
+      "required": [
+        "a",
+        "b",
+        "c",
+        "d"
+      ],
       "additionalProperties": false
     },
-    "GenericA%3C1%3E": {
+    "GenericA<1>": {
       "type": "object",
       "properties": {
         "a": {
           "type": "number",
-          "enum": [1]
+          "enum": [
+            1
+          ]
         }
       },
-      "required": ["a"],
+      "required": [
+        "a"
+      ],
       "additionalProperties": false
     },
-    "GenericC%3C2%3E": {
+    "GenericC<2>": {
       "type": "object",
       "properties": {
         "c": {
           "type": "number",
-          "enum": [2]
+          "enum": [
+            2
+          ]
         }
       },
-      "required": ["c"],
+      "required": [
+        "c"
+      ],
       "additionalProperties": false
     },
-    "SomeAlias%3C%22alias%22%3E": {
+    "SomeAlias<\"alias\">": {
       "$ref": "#/definitions/SomeGeneric%3C%22alias%22%2C%22alias%22%3E"
     },
-    "SomeGeneric%3C%22alias%22%2C%22alias%22%3E": {
+    "SomeGeneric<\"alias\",\"alias\">": {
       "type": "object",
       "properties": {
         "a": {
           "type": "string",
-          "enum": ["alias"]
+          "enum": [
+            "alias"
+          ]
         },
         "b": {
           "type": "string",
-          "enum": ["alias"]
+          "enum": [
+            "alias"
+          ]
         },
         "c": {
           "$ref": "#/definitions/GenericA%3C%22alias%22%3E"
@@ -114,29 +146,42 @@
           "$ref": "#/definitions/GenericC%3C%22alias%22%3E"
         }
       },
-      "required": ["a", "b", "c", "d"],
+      "required": [
+        "a",
+        "b",
+        "c",
+        "d"
+      ],
       "additionalProperties": false
     },
-    "GenericA%3C%22alias%22%3E": {
+    "GenericA<\"alias\">": {
       "type": "object",
       "properties": {
         "a": {
           "type": "string",
-          "enum": ["alias"]
+          "enum": [
+            "alias"
+          ]
         }
       },
-      "required": ["a"],
+      "required": [
+        "a"
+      ],
       "additionalProperties": false
     },
-    "GenericC%3C%22alias%22%3E": {
+    "GenericC<\"alias\">": {
       "type": "object",
       "properties": {
         "c": {
           "type": "string",
-          "enum": ["alias"]
+          "enum": [
+            "alias"
+          ]
         }
       },
-      "required": ["c"],
+      "required": [
+        "c"
+      ],
       "additionalProperties": false
     }
   },

--- a/test/valid-data/generic-multiargs/schema.json
+++ b/test/valid-data/generic-multiargs/schema.json
@@ -11,10 +11,13 @@
           "$ref": "#/definitions/MyGeneric%3Cnumber%2Cstring%3E"
         }
       },
-      "required": ["value1", "value2"],
+      "required": [
+        "value1",
+        "value2"
+      ],
       "additionalProperties": false
     },
-    "MyGeneric%3Cstring%2Cnumber%3E": {
+    "MyGeneric<string,number>": {
       "type": "object",
       "properties": {
         "a": {
@@ -24,10 +27,13 @@
           "type": "number"
         }
       },
-      "required": ["a", "b"],
+      "required": [
+        "a",
+        "b"
+      ],
       "additionalProperties": false
     },
-    "MyGeneric%3Cnumber%2Cstring%3E": {
+    "MyGeneric<number,string>": {
       "type": "object",
       "properties": {
         "a": {
@@ -37,7 +43,10 @@
           "type": "string"
         }
       },
-      "required": ["a", "b"],
+      "required": [
+        "a",
+        "b"
+      ],
       "additionalProperties": false
     }
   },

--- a/test/valid-data/generic-multiple/schema.json
+++ b/test/valid-data/generic-multiple/schema.json
@@ -11,27 +11,34 @@
           "$ref": "#/definitions/MyGeneric%3Cstring%3E"
         }
       },
-      "required": ["value1", "value2"],
+      "required": [
+        "value1",
+        "value2"
+      ],
       "additionalProperties": false
     },
-    "MyGeneric%3Cnumber%3E": {
+    "MyGeneric<number>": {
       "type": "object",
       "properties": {
         "field": {
           "type": "number"
         }
       },
-      "required": ["field"],
+      "required": [
+        "field"
+      ],
       "additionalProperties": false
     },
-    "MyGeneric%3Cstring%3E": {
+    "MyGeneric<string>": {
       "type": "object",
       "properties": {
         "field": {
           "type": "string"
         }
       },
-      "required": ["field"],
+      "required": [
+        "field"
+      ],
       "additionalProperties": false
     }
   },

--- a/test/valid-data/generic-prefixed-number/schema.json
+++ b/test/valid-data/generic-prefixed-number/schema.json
@@ -9,10 +9,12 @@
           "$ref": "#/definitions/Range%3C-180%2C180%3E"
         }
       },
-      "required": ["angle"],
+      "required": [
+        "angle"
+      ],
       "type": "object"
     },
-    "Range%3C-180%2C180%3E": {
+    "Range<-180,180>": {
       "type": "number"
     }
   }

--- a/test/valid-data/generic-recursive/schema.json
+++ b/test/valid-data/generic-recursive/schema.json
@@ -8,27 +8,33 @@
           "$ref": "#/definitions/MyGeneric%3Cstring%2Cnumber%3E"
         }
       },
-      "required": ["value"],
+      "required": [
+        "value"
+      ],
       "additionalProperties": false
     },
-    "MyGeneric%3Cstring%2Cnumber%3E": {
+    "MyGeneric<string,number>": {
       "type": "object",
       "properties": {
         "field": {
           "$ref": "#/definitions/MyGeneric%3Cnumber%2Cstring%3E"
         }
       },
-      "required": ["field"],
+      "required": [
+        "field"
+      ],
       "additionalProperties": false
     },
-    "MyGeneric%3Cnumber%2Cstring%3E": {
+    "MyGeneric<number,string>": {
       "type": "object",
       "properties": {
         "field": {
           "$ref": "#/definitions/MyGeneric%3Cstring%2Cnumber%3E"
         }
       },
-      "required": ["field"],
+      "required": [
+        "field"
+      ],
       "additionalProperties": false
     }
   },

--- a/test/valid-data/generic-simple/schema.json
+++ b/test/valid-data/generic-simple/schema.json
@@ -8,17 +8,21 @@
           "$ref": "#/definitions/MyGeneric%3Cnumber%3E"
         }
       },
-      "required": ["value"],
+      "required": [
+        "value"
+      ],
       "additionalProperties": false
     },
-    "MyGeneric%3Cnumber%3E": {
+    "MyGeneric<number>": {
       "type": "object",
       "properties": {
         "field": {
           "type": "number"
         }
       },
-      "required": ["field"],
+      "required": [
+        "field"
+      ],
       "additionalProperties": false
     }
   },

--- a/test/valid-data/generic-void/schema.json
+++ b/test/valid-data/generic-void/schema.json
@@ -8,17 +8,21 @@
           "$ref": "#/definitions/MyGeneric%3Cvoid%3E"
         }
       },
-      "required": ["value"],
+      "required": [
+        "value"
+      ],
       "additionalProperties": false
     },
-    "MyGeneric%3Cvoid%3E": {
+    "MyGeneric<void>": {
       "type": "object",
       "properties": {
         "field": {
           "type": "null"
         }
       },
-      "required": ["field"],
+      "required": [
+        "field"
+      ],
       "additionalProperties": false
     }
   },

--- a/test/valid-data/type-aliases-recursive-generics-export/schema.json
+++ b/test/valid-data/type-aliases-recursive-generics-export/schema.json
@@ -2,7 +2,7 @@
   "$ref": "#/definitions/MyAlias",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "Map%3Calias-1142561764-44-93-1142561764-0-94%3E": {
+    "Map<alias-1142561764-44-93-1142561764-0-94>": {
       "additionalProperties": {
         "$ref": "#/definitions/MyAlias"
       },
@@ -15,7 +15,9 @@
           "$ref": "#/definitions/Map%3Calias-1142561764-44-93-1142561764-0-94%3E"
         }
       },
-      "required": ["a"],
+      "required": [
+        "a"
+      ],
       "type": "object"
     }
   }

--- a/test/valid-data/type-conditional-inheritance/schema.json
+++ b/test/valid-data/type-conditional-inheritance/schema.json
@@ -2,28 +2,40 @@
   "$ref": "#/definitions/MyObject",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "Map%3CA%3E": {
-      "enum": ["a"],
+    "Map<A>": {
+      "enum": [
+        "a"
+      ],
       "type": "string"
     },
-    "Map%3CB%3E": {
-      "enum": ["a"],
+    "Map<B>": {
+      "enum": [
+        "a"
+      ],
       "type": "string"
     },
-    "Map%3CC%3E": {
-      "enum": ["a"],
+    "Map<C>": {
+      "enum": [
+        "a"
+      ],
       "type": "string"
     },
-    "Map%3CD%3E": {
-      "enum": ["d"],
+    "Map<D>": {
+      "enum": [
+        "d"
+      ],
       "type": "string"
     },
-    "Map%3CE%3E": {
-      "enum": ["d"],
+    "Map<E>": {
+      "enum": [
+        "d"
+      ],
       "type": "string"
     },
-    "Map%3CF%3E": {
-      "enum": ["f"],
+    "Map<F>": {
+      "enum": [
+        "f"
+      ],
       "type": "string"
     },
     "MyObject": {
@@ -48,7 +60,14 @@
           "$ref": "#/definitions/Map%3CF%3E"
         }
       },
-      "required": ["a", "b", "c", "d", "e", "f"],
+      "required": [
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f"
+      ],
       "type": "object"
     }
   }

--- a/test/valid-data/type-mapped-additional-props/schema.json
+++ b/test/valid-data/type-mapped-additional-props/schema.json
@@ -5,9 +5,12 @@
     "MyObject": {
       "$ref": "#/definitions/WithNumbers%3CTest%3E"
     },
-    "WithNumbers%3CTest%3E": {
+    "WithNumbers<Test>": {
       "additionalProperties": {
-        "type": ["string", "number"]
+        "type": [
+          "string",
+          "number"
+        ]
       },
       "type": "object"
     }

--- a/test/valid-data/type-mapped-generic/schema.json
+++ b/test/valid-data/type-mapped-generic/schema.json
@@ -5,16 +5,28 @@
     "MyObject": {
       "$ref": "#/definitions/NullableAndPartial%3CSomeInterface%3E"
     },
-    "NullableAndPartial%3CSomeInterface%3E": {
+    "NullableAndPartial<SomeInterface>": {
       "additionalProperties": false,
       "properties": {
         "bar": {
-          "enum": ["bar", null],
-          "type": ["string", "null"]
+          "enum": [
+            "bar",
+            null
+          ],
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "foo": {
-          "enum": [123, null],
-          "type": ["number", "null"]
+          "enum": [
+            123,
+            null
+          ],
+          "type": [
+            "number",
+            "null"
+          ]
         }
       },
       "type": "object"


### PR DESCRIPTION
This PR fixes an issue to a previous PR #277 that encoded the definition names as well as the URI references. AJV expects definition names to be unencoded.

This also adds an AJV compile step to tests to detect issues like this.

Closes #285 and #283 