### PR TITLE
Support typeof class

### DIFF
--- a/src/NodeParser/TypeofNodeParser.ts
+++ b/src/NodeParser/TypeofNodeParser.ts
@@ -30,7 +30,10 @@ export class TypeofNodeParser implements SubNodeParser {
             } else if (valueDec.initializer) {
                 return this.childNodeParser.createType(valueDec.initializer, context);
             }
+        } else if (ts.isClassDeclaration(valueDec)) {
+            return this.childNodeParser.createType(valueDec, context);
         }
+
         throw new LogicError(`Invalid type query "${valueDec.getFullText()}" (ts.SyntaxKind = ${valueDec.kind})`);
     }
 

--- a/test/valid-data.test.ts
+++ b/test/valid-data.test.ts
@@ -133,6 +133,7 @@ describe("valid-data", () => {
     it("type-typeof", assertSchema("type-typeof", "MyType"));
     it("type-typeof-value", assertSchema("type-typeof-value", "MyType"));
     it("type-typeof-enum", assertSchema("type-typeof-enum", "MyObject"));
+    it("type-typeof-class", assertSchema("type-typeof-class", "MyObject"));
 
     it("type-indexed-access-tuple-1", assertSchema("type-indexed-access-tuple-1", "MyType"));
     it("type-indexed-access-tuple-2", assertSchema("type-indexed-access-tuple-2", "MyType"));

--- a/test/valid-data/type-typeof-class/main.ts
+++ b/test/valid-data/type-typeof-class/main.ts
@@ -1,0 +1,7 @@
+class MyClass {
+    myValue: number;
+}
+
+export type MyObject = {
+    classType: typeof MyClass;
+};

--- a/test/valid-data/type-typeof-class/schema.json
+++ b/test/valid-data/type-typeof-class/schema.json
@@ -1,0 +1,23 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "classType": {
+          "additionalProperties": false,
+          "properties": {
+            "myValue": {
+              "type": "number"
+            }
+          },
+          "required": ["myValue"],
+          "type": "object"
+        }
+      },
+      "required": ["classType"],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
* Previously would error out if you had a `typeof class`.
* Added a small change to TypeofNodeParser to handle the case of `typeof class`. I am *far* from certain that this is the correct modification, since I'm very much not familiar with the code base, but it seems to produce valid output, and for my purposes it unblocks my use of `ts-json-schema-generator` with objects that inherit from `Sequelize.Model`.

I verified that the test fails (with a LogicError) if my TypeofNodeParser modification isn't made, and that it succeeds after the else clause is restored. The only thing I don't feel qualified to judge is whether the schema output is _correct_ in a more robust sense; it "looks good to me," but as I say, I'm not sure that it's right and would appreciate more critical eyes to validate the output.