### PR TITLE
#325 Adds support for interface-extended-extra-props

### DIFF
--- a/src/Utils/allOfDefinition.ts
+++ b/src/Utils/allOfDefinition.ts
@@ -98,6 +98,13 @@ export function getAllOfDefinitionReducer(childTypeFormatter: TypeFormatter, con
             definition.required = uniqueArray((definition.required || []).concat(other.required)).sort();
         }
 
+        if (
+            (other.additionalProperties || other.additionalProperties === undefined) &&
+            definition.additionalProperties == false
+        ) {
+            delete definition.additionalProperties;
+        }
+
         return definition;
     };
 }

--- a/test/valid-data.test.ts
+++ b/test/valid-data.test.ts
@@ -63,6 +63,7 @@ describe("valid-data", () => {
     it("interface-multi", assertSchema("interface-multi", "MyObject"));
     it("interface-recursion", assertSchema("interface-recursion", "MyObject"));
     it("interface-extra-props", assertSchema("interface-extra-props", "MyObject"));
+    it("interface-extended-extra-props", assertSchema("interface-extended-extra-props", "MyObject"));
     it("interface-array", assertSchema("interface-array", "TagArray"));
     it("interface-property-dash", assertSchema("interface-property-dash", "MyObject"));
 

--- a/test/valid-data/interface-extended-extra-props/main.ts
+++ b/test/valid-data/interface-extended-extra-props/main.ts
@@ -1,0 +1,7 @@
+export interface MyObject extends StringMap {
+    param: string
+}
+
+export interface StringMap {
+    [key: string]: any
+}

--- a/test/valid-data/interface-extended-extra-props/schema.json
+++ b/test/valid-data/interface-extended-extra-props/schema.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$ref": "#/definitions/MyObject",
+    "definitions": {
+        "MyObject": {
+            "properties": {
+                "param": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "param"
+            ],
+            "type": "object"
+        }
+    }
+}


### PR DESCRIPTION
Fixes #325 

```
export interface MyObject extends StringMap {
    param: string
}

export interface StringMap {
    [key: string]: any
}
```

Will allow additionalProps