### PR TITLE
Hide hidden types in format phase

### DIFF
--- a/factory/parser.ts
+++ b/factory/parser.ts
@@ -15,6 +15,7 @@ import { CallExpressionParser } from "../src/NodeParser/CallExpressionParser";
 import { ConditionalTypeNodeParser } from "../src/NodeParser/ConditionalTypeNodeParser";
 import { EnumNodeParser } from "../src/NodeParser/EnumNodeParser";
 import { ExpressionWithTypeArgumentsNodeParser } from "../src/NodeParser/ExpressionWithTypeArgumentsNodeParser";
+import { HiddenNodeParser } from "../src/NodeParser/HiddenTypeNodeParser";
 import { IndexedAccessTypeNodeParser } from "../src/NodeParser/IndexedAccessTypeNodeParser";
 import { InterfaceAndClassNodeParser } from "../src/NodeParser/InterfaceAndClassNodeParser";
 import { IntersectionNodeParser } from "../src/NodeParser/IntersectionNodeParser";
@@ -70,6 +71,7 @@ export function createParser(program: ts.Program, config: Config): NodeParser {
     }
 
     chainNodeParser
+        .addNodeParser(new HiddenNodeParser(typeChecker))
         .addNodeParser(new StringTypeNodeParser())
         .addNodeParser(new NumberTypeNodeParser())
         .addNodeParser(new BooleanTypeNodeParser())

--- a/src/ChainTypeFormatter.ts
+++ b/src/ChainTypeFormatter.ts
@@ -14,7 +14,7 @@ export class ChainTypeFormatter implements SubTypeFormatter {
     public supportsType(type: BaseType): boolean {
         return this.typeFormatters.some(typeFormatter => typeFormatter.supportsType(type));
     }
-    public getDefinition(type: BaseType): Definition {
+    public getDefinition(type: BaseType): Definition | undefined {
         return this.getTypeFormatter(type).getDefinition(type);
     }
     public getChildren(type: BaseType): BaseType[] {

--- a/src/CircularReferenceTypeFormatter.ts
+++ b/src/CircularReferenceTypeFormatter.ts
@@ -1,4 +1,3 @@
-import { NeverType } from "./Type/NeverType";
 import { Definition } from "./Schema/Definition";
 import { SubTypeFormatter } from "./SubTypeFormatter";
 import { BaseType } from "./Type/BaseType";
@@ -21,10 +20,6 @@ export class CircularReferenceTypeFormatter implements SubTypeFormatter {
         if (this.neverTypes.has(type)) {
             return undefined;
         }
-        // if (type instanceof NeverType) {
-        //     this.neverTypes.add(type);
-        //     return undefined;
-        // }
 
         const definition: Definition = {};
         this.definition.set(type, definition);

--- a/src/NodeParser/HiddenTypeNodeParser.ts
+++ b/src/NodeParser/HiddenTypeNodeParser.ts
@@ -4,6 +4,7 @@ import { SubNodeParser } from "../SubNodeParser";
 import { BaseType } from "../Type/BaseType";
 import { NeverType } from "./../Type/NeverType";
 import { symbolAtNode } from "../Utils/symbolAtNode";
+import { isHidden } from "../Utils/isHidden";
 
 export class HiddenNodeParser implements SubNodeParser {
     public constructor(private typeChecker: ts.TypeChecker) {}
@@ -11,7 +12,7 @@ export class HiddenNodeParser implements SubNodeParser {
     public supportsNode(node: ts.KeywordTypeNode): boolean {
         const symbol = symbolAtNode(node);
         if (symbol) {
-            return symbol.getJsDocTags().filter(value => value.name === "hidden").length > 0;
+            return isHidden(symbol);
         }
         return false;
     }

--- a/src/NodeParser/HiddenTypeNodeParser.ts
+++ b/src/NodeParser/HiddenTypeNodeParser.ts
@@ -1,0 +1,22 @@
+import * as ts from "typescript";
+import { Context } from "../NodeParser";
+import { SubNodeParser } from "../SubNodeParser";
+import { BaseType } from "../Type/BaseType";
+import { NeverType } from "./../Type/NeverType";
+import { symbolAtNode } from "../Utils/symbolAtNode";
+
+export class HiddenNodeParser implements SubNodeParser {
+    public constructor(private typeChecker: ts.TypeChecker) {}
+
+    public supportsNode(node: ts.KeywordTypeNode): boolean {
+        const symbol = symbolAtNode(node);
+        if (symbol) {
+            return symbol.getJsDocTags().filter(value => value.name === "hidden").length > 0;
+        }
+        return false;
+    }
+
+    public createType(node: ts.KeywordTypeNode, context: Context): BaseType {
+        return new NeverType();
+    }
+}

--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -61,7 +61,7 @@ export class SchemaGenerator {
         throw new NoRootTypeError(fullName);
     }
     private getRootTypeDefinition(rootType: BaseType): Definition {
-        return this.typeFormatter.getDefinition(rootType);
+        return this.typeFormatter.getDefinition(rootType) || { not: {} };
     }
     private appendRootChildDefinitions(rootType: BaseType, childDefinitions: StringMap<Definition>): void {
         const seen = new Set<string>();
@@ -90,7 +90,10 @@ export class SchemaGenerator {
         children.reduce((definitions, child) => {
             const name = child.getName();
             if (!(name in definitions)) {
-                definitions[name] = this.typeFormatter.getDefinition(child.getType());
+                const definition = this.typeFormatter.getDefinition(child.getType());
+                if (definition) {
+                    definitions[name] = definition;
+                }
             }
             return definitions;
         }, childDefinitions);

--- a/src/TypeFormatter.ts
+++ b/src/TypeFormatter.ts
@@ -2,6 +2,6 @@ import { Definition } from "./Schema/Definition";
 import { BaseType } from "./Type/BaseType";
 
 export interface TypeFormatter {
-    getDefinition(type: BaseType): Definition;
+    getDefinition(type: BaseType): Definition | undefined;
     getChildren(type: BaseType): BaseType[];
 }

--- a/src/TypeFormatter/AliasTypeFormatter.ts
+++ b/src/TypeFormatter/AliasTypeFormatter.ts
@@ -10,9 +10,15 @@ export class AliasTypeFormatter implements SubTypeFormatter {
     public supportsType(type: AliasType): boolean {
         return type instanceof AliasType;
     }
-    public getDefinition(type: AliasType): Definition {
+
+    public getDefinition(type: AliasType): Definition | undefined {
+        // let reffedType = type.getType();
+        // while (reffedType instanceof AliasType) {
+        //     reffedType = reffedType.getType();
+        // }
         return this.childTypeFormatter.getDefinition(type.getType());
     }
+
     public getChildren(type: AliasType): BaseType[] {
         return this.childTypeFormatter.getChildren(type.getType());
     }

--- a/src/TypeFormatter/DefinitionTypeFormatter.ts
+++ b/src/TypeFormatter/DefinitionTypeFormatter.ts
@@ -1,3 +1,5 @@
+import { NeverType } from "./../Type/NeverType";
+import { AliasType } from "./../Type/AliasType";
 import { Definition } from "../Schema/Definition";
 import { SubTypeFormatter } from "../SubTypeFormatter";
 import { BaseType } from "../Type/BaseType";
@@ -11,7 +13,15 @@ export class DefinitionTypeFormatter implements SubTypeFormatter {
     public supportsType(type: DefinitionType): boolean {
         return type instanceof DefinitionType;
     }
-    public getDefinition(type: DefinitionType): Definition {
+    public getDefinition(type: DefinitionType): Definition | undefined {
+        let reffedType = type.getType();
+        while (reffedType instanceof AliasType) {
+            reffedType = reffedType.getType();
+        }
+        if (reffedType instanceof NeverType) {
+            return undefined;
+        }
+
         const ref = type.getName();
         return { $ref: `#/definitions/${this.encodeRefs ? encodeURIComponent(ref) : ref}` };
     }

--- a/src/TypeFormatter/IntersectionTypeFormatter.ts
+++ b/src/TypeFormatter/IntersectionTypeFormatter.ts
@@ -13,7 +13,7 @@ export class IntersectionTypeFormatter implements SubTypeFormatter {
     public supportsType(type: IntersectionType): boolean {
         return type instanceof IntersectionType;
     }
-    public getDefinition(type: IntersectionType): Definition {
+    public getDefinition(type: IntersectionType): Definition | undefined {
         const types = type.getTypes();
 
         // FIXME: when we have union types as children, we have to translate.

--- a/src/TypeFormatter/NeverTypeFormatter.ts
+++ b/src/TypeFormatter/NeverTypeFormatter.ts
@@ -7,8 +7,8 @@ export class NeverTypeFormatter implements SubTypeFormatter {
     public supportsType(type: NeverType): boolean {
         return type instanceof NeverType;
     }
-    public getDefinition(type: NeverType): Definition {
-        return { not: {} };
+    public getDefinition(type: NeverType): Definition | undefined {
+        return undefined;
     }
     public getChildren(type: NeverType): BaseType[] {
         return [];

--- a/src/TypeFormatter/OptionalTypeFormatter.ts
+++ b/src/TypeFormatter/OptionalTypeFormatter.ts
@@ -10,7 +10,7 @@ export class OptionalTypeFormatter implements SubTypeFormatter {
     public supportsType(type: OptionalType): boolean {
         return type instanceof OptionalType;
     }
-    public getDefinition(type: OptionalType): Definition {
+    public getDefinition(type: OptionalType): Definition | undefined {
         return this.childTypeFormatter.getDefinition(type.getType());
     }
     public getChildren(type: OptionalType): BaseType[] {

--- a/src/TypeFormatter/RestTypeFormatter.ts
+++ b/src/TypeFormatter/RestTypeFormatter.ts
@@ -10,7 +10,7 @@ export class RestTypeFormatter implements SubTypeFormatter {
     public supportsType(type: RestType): boolean {
         return type instanceof RestType;
     }
-    public getDefinition(type: RestType): Definition {
+    public getDefinition(type: RestType): Definition | undefined {
         return this.childTypeFormatter.getDefinition(type.getType());
     }
     public getChildren(type: RestType): BaseType[] {

--- a/src/TypeFormatter/TupleTypeFormatter.ts
+++ b/src/TypeFormatter/TupleTypeFormatter.ts
@@ -13,6 +13,7 @@ export class TupleTypeFormatter implements SubTypeFormatter {
     public supportsType(type: TupleType): boolean {
         return type instanceof TupleType;
     }
+
     public getDefinition(type: TupleType): Definition {
         const subTypes = type.getTypes();
 
@@ -20,8 +21,12 @@ export class TupleTypeFormatter implements SubTypeFormatter {
         const optionalElements = subTypes.filter(t => t instanceof OptionalType) as OptionalType[];
         const restElements = subTypes.filter(t => t instanceof RestType) as RestType[];
 
-        const requiredDefinitions = requiredElements.map(item => this.childTypeFormatter.getDefinition(item));
-        const optionalDefinitions = optionalElements.map(item => this.childTypeFormatter.getDefinition(item));
+        const requiredDefinitions = requiredElements.map(
+            item => this.childTypeFormatter.getDefinition(item) ?? { not: {} }
+        );
+        const optionalDefinitions = optionalElements.map(
+            item => this.childTypeFormatter.getDefinition(item) ?? { not: {} }
+        );
         const itemsTotal = requiredDefinitions.length + optionalDefinitions.length;
 
         const restType = restElements.length ? restElements[0].getType().getItem() : undefined;
@@ -37,6 +42,7 @@ export class TupleTypeFormatter implements SubTypeFormatter {
             ...(!restDefinition && itemsTotal ? { maxItems: itemsTotal } : {}), // without rest
         };
     }
+
     public getChildren(type: TupleType): BaseType[] {
         return uniqueArray(
             type

--- a/src/TypeFormatter/UnionTypeFormatter.ts
+++ b/src/TypeFormatter/UnionTypeFormatter.ts
@@ -13,7 +13,11 @@ export class UnionTypeFormatter implements SubTypeFormatter {
         return type instanceof UnionType;
     }
     public getDefinition(type: UnionType): Definition {
-        const definitions = type.getTypes().map(item => this.childTypeFormatter.getDefinition(item));
+        const definitions = type
+            .getTypes()
+            .map(item => this.childTypeFormatter.getDefinition(item))
+            // filter all never or hidden types
+            .filter(d => d !== undefined) as Definition[];
 
         // TODO: why is this not covered by LiteralUnionTypeFormatter?
         // special case for string literals | string -> string
@@ -36,7 +40,7 @@ export class UnionTypeFormatter implements SubTypeFormatter {
 
         const flattenedDefinitions: JSONSchema7[] = [];
 
-        // Flatten anOf inside anyOf unless the anyOf has an annotation
+        // Flatten anyOf inside anyOf unless the anyOf has an annotation
         for (const def of definitions) {
             if (Object.keys(def) === ["anyOf"]) {
                 flattenedDefinitions.push(...(def.anyOf as any));
@@ -51,6 +55,7 @@ export class UnionTypeFormatter implements SubTypeFormatter {
               }
             : flattenedDefinitions[0];
     }
+
     public getChildren(type: UnionType): BaseType[] {
         return uniqueArray(
             type

--- a/src/Utils/allOfDefinition.ts
+++ b/src/Utils/allOfDefinition.ts
@@ -29,6 +29,10 @@ export function getAllOfDefinitionReducer(childTypeFormatter: TypeFormatter, con
     return (definition: Definition, baseType: BaseType) => {
         const other = childTypeFormatter.getDefinition(getNonRefType(baseType));
 
+        if (other === undefined) {
+            return undefined;
+        }
+
         definition.properties = deepMerge(other.properties || {}, definition.properties || {}, concatArrays);
 
         function additionalPropsDefinition(props?: boolean | Definition): props is Definition {

--- a/test/config/jsdoc-hidden/main.ts
+++ b/test/config/jsdoc-hidden/main.ts
@@ -15,7 +15,11 @@ export enum Enum {
  */
 export type Hidden = "hidden";
 
+export type Hidden2 = Hidden;
+
 export type Options = Hidden | "up" | "down";
+
+export type Options2 = Hidden2 | "up" | "down";
 
 export interface MyObject {
     /**
@@ -33,4 +37,5 @@ export interface MyObject {
     bar: Enum;
 
     options: Options;
+    options2: Options2;
 }

--- a/test/config/jsdoc-hidden/schema.json
+++ b/test/config/jsdoc-hidden/schema.json
@@ -3,9 +3,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Enum": {
-      "enum": [
-        "y"
-      ],
+      "enum": ["y"],
       "type": "string"
     },
     "MyObject": {
@@ -20,20 +18,20 @@
         },
         "options": {
           "$ref": "#/definitions/Options"
+        },
+        "options2": {
+          "$ref": "#/definitions/Options2"
         }
       },
-      "required": [
-        "foo",
-        "bar",
-        "options"
-      ],
+      "required": ["foo", "bar", "options", "options2"],
       "type": "object"
     },
     "Options": {
-      "enum": [
-        "up",
-        "down"
-      ],
+      "enum": ["up", "down"],
+      "type": "string"
+    },
+    "Options2": {
+      "enum": ["up", "down"],
       "type": "string"
     }
   }

--- a/test/config/jsdoc-hidden/schema.json
+++ b/test/config/jsdoc-hidden/schema.json
@@ -31,8 +31,16 @@
       "type": "string"
     },
     "Options2": {
-      "enum": ["up", "down"],
-      "type": "string"
+      "anyOf": [
+        {
+          "enum": ["up"],
+          "type": "string"
+        },
+        {
+          "enum": ["down"],
+          "type": "string"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/vega/ts-json-schema-generator/issues/329

This implementation hides in the formatter (json generation phase). I think it's better to do this earlier. Alternative is in https://github.com/vega/ts-json-schema-generator/pull/330