### PR TITLE
Improve typing for `createSchema()`

### DIFF
--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -18,7 +18,7 @@ export class SchemaGenerator {
         private readonly typeFormatter: TypeFormatter
     ) {}
 
-    public createSchema(fullName: string | undefined): Schema {
+    public createSchema(fullName?: string): Schema {
         const rootNodes = this.getRootNodes(fullName);
         return this.createSchemaFromNodes(rootNodes);
     }


### PR DESCRIPTION
Hi! Thanks for this useful tool.

This small change makes it possible to invoke `.createSchema()` with no arguments, whereas before omitting the argument required passing `.createSchema(undefined)`. This makes it more ergonomic.