### PR TITLE
Make more of createParser’s config optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,6 @@ const config = {
     path: "path/to/source/file",
     tsconfig: "path/to/tsconfig.json",
     type: "*", // Or <type-name> if you want to generate schema for that one type only
-    expose: "export",
-    jsDoc: "extended",
-    topRef: true
 };
 
 const output_path = "path/to/output/file";

--- a/factory/parser.ts
+++ b/factory/parser.ts
@@ -3,7 +3,7 @@ import { BasicAnnotationsReader } from "../src/AnnotationsReader/BasicAnnotation
 import { ExtendedAnnotationsReader } from "../src/AnnotationsReader/ExtendedAnnotationsReader";
 import { ChainNodeParser } from "../src/ChainNodeParser";
 import { CircularReferenceNodeParser } from "../src/CircularReferenceNodeParser";
-import { Config } from "../src/Config";
+import { Config, DEFAULT_CONFIG } from "../src/Config";
 import { ExposeNodeParser } from "../src/ExposeNodeParser";
 import { NodeParser } from "../src/NodeParser";
 import { AnnotatedNodeParser } from "../src/NodeParser/AnnotatedNodeParser";
@@ -50,17 +50,19 @@ export function createParser(program: ts.Program, config: Config): NodeParser {
     const typeChecker = program.getTypeChecker();
     const chainNodeParser = new ChainNodeParser(typeChecker, []);
 
+    const mergedConfig = { ...DEFAULT_CONFIG, ...config };
+
     function withExpose(nodeParser: SubNodeParser): SubNodeParser {
-        return new ExposeNodeParser(typeChecker, nodeParser, config.expose);
+        return new ExposeNodeParser(typeChecker, nodeParser, mergedConfig.expose);
     }
     function withTopRef(nodeParser: NodeParser): NodeParser {
-        return new TopRefNodeParser(chainNodeParser, config.type, config.topRef);
+        return new TopRefNodeParser(chainNodeParser, mergedConfig.type, mergedConfig.topRef);
     }
     function withJsDoc(nodeParser: SubNodeParser): SubNodeParser {
-        const extraTags = new Set(config.extraTags);
-        if (config.jsDoc === "extended") {
+        const extraTags = new Set(mergedConfig.extraTags);
+        if (mergedConfig.jsDoc === "extended") {
             return new AnnotatedNodeParser(nodeParser, new ExtendedAnnotationsReader(typeChecker, extraTags));
-        } else if (config.jsDoc === "basic") {
+        } else if (mergedConfig.jsDoc === "basic") {
             return new AnnotatedNodeParser(nodeParser, new BasicAnnotationsReader(extraTags));
         } else {
             return nodeParser;

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -1,10 +1,13 @@
+export type ExposeOption = "all" | "none" | "export";
+export type JSDocOption = "none" | "extended" | "basic";
+
 export interface Config {
     path?: string;
     type?: string;
     tsconfig?: string;
-    expose: "all" | "none" | "export";
-    topRef: boolean;
-    jsDoc: "none" | "extended" | "basic";
+    expose?: ExposeOption;
+    topRef?: boolean;
+    jsDoc?: JSDocOption;
     sortProps?: boolean;
     strictTuples?: boolean;
     skipTypeCheck?: boolean;
@@ -12,10 +15,10 @@ export interface Config {
     extraTags?: string[];
 }
 
-export const DEFAULT_CONFIG: Config = {
-    expose: "export",
+export const DEFAULT_CONFIG = {
+    expose: "export" as ExposeOption,
     topRef: true,
-    jsDoc: "extended",
+    jsDoc: "extended" as JSDocOption,
     sortProps: true,
     strictTuples: false,
     skipTypeCheck: false,

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -1,13 +1,10 @@
-export type ExposeOption = "all" | "none" | "export";
-export type JSDocOption = "none" | "extended" | "basic";
-
 export interface Config {
     path?: string;
     type?: string;
     tsconfig?: string;
-    expose?: ExposeOption;
+    expose?: "all" | "none" | "export";
     topRef?: boolean;
-    jsDoc?: JSDocOption;
+    jsDoc?: "none" | "extended" | "basic";
     sortProps?: boolean;
     strictTuples?: boolean;
     skipTypeCheck?: boolean;
@@ -15,10 +12,10 @@ export interface Config {
     extraTags?: string[];
 }
 
-export const DEFAULT_CONFIG = {
-    expose: "export" as ExposeOption,
+export const DEFAULT_CONFIG: Omit<Required<Config>, "path" | "type" | "tsconfig"> = {
+    expose: "export",
     topRef: true,
-    jsDoc: "extended" as JSDocOption,
+    jsDoc: "extended",
     sortProps: true,
     strictTuples: false,
     skipTypeCheck: false,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -13,7 +13,7 @@ const basePath = "test/config";
 
 function assertSchema(name: string, userConfig: Config & { type: string }, tsconfig?: boolean) {
     return () => {
-        const config = {
+        const config: Config = {
             ...DEFAULT_CONFIG,
             ...userConfig,
             skipTypeCheck: !!process.env.FAST_TEST,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -13,7 +13,7 @@ const basePath = "test/config";
 
 function assertSchema(name: string, userConfig: Config & { type: string }, tsconfig?: boolean) {
     return () => {
-        const config: Config = {
+        const config = {
             ...DEFAULT_CONFIG,
             ...userConfig,
             skipTypeCheck: !!process.env.FAST_TEST,

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -25,8 +25,6 @@ export function assertValidSchema(
         const config: Config = {
             path: resolve(`${basePath}/${relativePath}/*.ts`),
             type,
-            expose: "export",
-            topRef: true,
             jsDoc,
             extraTags,
             skipTypeCheck: !!process.env.FAST_TEST,


### PR DESCRIPTION
This is another PR along the lines of #385.

The CLI has a few defaults which the programmatic interface doesn’t. I think it makes sense to harmonize these. In my use case, I’m using the CLi to generate the typings, and a test to check that they’re up to date. It would be better not to have to pass in these arguments (which I wasn’t even aware of when I was using the CLI).

Another way to implement this would be to create a MergedConfig type; happy to go that route if you’d prefer.

Looking forward to your feedback!