### PR TITLE
fix: correctly support indexed union

### DIFF
--- a/src/NodeParser/IntersectionNodeParser.ts
+++ b/src/NodeParser/IntersectionNodeParser.ts
@@ -3,10 +3,11 @@ import { Context, NodeParser } from "../NodeParser";
 import { SubNodeParser } from "../SubNodeParser";
 import { BaseType } from "../Type/BaseType";
 import { IntersectionType } from "../Type/IntersectionType";
+import { PrimitiveType } from "../Type/PrimitiveType";
 import { UnionType } from "../Type/UnionType";
 import { derefType } from "../Utils/derefType";
 import { uniqueTypeArray } from "../Utils/uniqueTypeArray";
-import { PrimitiveType } from "../Type/PrimitiveType";
+import { UndefinedType } from "./../Type/UndefinedType";
 
 export class IntersectionNodeParser implements SubNodeParser {
     public constructor(private typeChecker: ts.TypeChecker, private childNodeParser: NodeParser) {}
@@ -16,49 +17,51 @@ export class IntersectionNodeParser implements SubNodeParser {
     }
 
     public createType(node: ts.IntersectionTypeNode, context: Context): BaseType | undefined {
-        let types = node.types.map((subnode) => this.childNodeParser.createType(subnode, context));
+        const types = node.types.map((subnode) => this.childNodeParser.createType(subnode, context));
 
         // if any type is undefined (never), an intersection type should be undefined (never)
         if (types.filter((t) => t === undefined).length) {
             return undefined;
         }
 
-        types = uniqueTypeArray(types as BaseType[]);
+        return translate(types as BaseType[]);
+    }
+}
 
-        if (types.length == 1) {
-            return types[0];
-        }
+/**
+ * Translates the given intersection type into a union type if necessary so `A & (B | C)` becomes
+ * `(A & B) | (A & C)`. If no translation is needed then the original intersection type is returned.
+ */
+export function translate(types: BaseType[]): BaseType | undefined {
+    types = uniqueTypeArray(types as BaseType[]);
 
-        return this.translate(types as BaseType[]);
+    if (types.length == 1) {
+        return types[0];
     }
 
-    /**
-     * Translates the given intersection type into a union type if necessary so `A & (B | C)` becomes
-     * `(A & B) | (A & C)`. If no translation is needed then the original intersection type is returned.
-     */
-    private translate(types: BaseType[]): BaseType | undefined {
-        const unions = types.map((type) => {
-            const derefed = derefType(type);
-            return derefed instanceof UnionType ? derefed.getTypes() : [type];
-        });
-        const result: BaseType[] = [];
-        function process(i: number, t: BaseType[] = []) {
-            for (const type of unions[i]) {
-                let currentTypes = [...t, type];
-                if (i < unions.length - 1) {
-                    process(i + 1, currentTypes);
-                } else {
-                    currentTypes = uniqueTypeArray(currentTypes);
+    const unions = types.map((type) => {
+        const derefed = derefType(type);
+        return derefed instanceof UnionType ? derefed.getTypes() : [type];
+    });
+    const result: BaseType[] = [];
+    function process(i: number, t: BaseType[] = []) {
+        for (const type of unions[i]) {
+            let currentTypes = [...t, type];
+            if (i < unions.length - 1) {
+                process(i + 1, currentTypes);
+            } else {
+                currentTypes = uniqueTypeArray(currentTypes);
 
+                if (currentTypes.some((c) => c instanceof UndefinedType)) {
+                    // never
+                    result.push(new UndefinedType());
+                } else {
                     const primitives = currentTypes.filter((c) => c instanceof PrimitiveType);
                     if (primitives.length === 1) {
                         result.push(primitives[0]);
                     } else if (primitives.length > 1) {
-                        // never
-                        continue;
-                    }
-
-                    if (currentTypes.length === 1) {
+                        // conflict -> ignore
+                    } else if (currentTypes.length === 1) {
                         result.push(currentTypes[0]);
                     } else {
                         result.push(new IntersectionType(currentTypes));
@@ -66,8 +69,14 @@ export class IntersectionNodeParser implements SubNodeParser {
                 }
             }
         }
-        process(0);
-
-        return result.length > 1 ? new UnionType(result) : new IntersectionType(types);
     }
+    process(0);
+
+    if (result.length === 1) {
+        return result[0];
+    } else if (result.length > 1) {
+        return new UnionType(result);
+    }
+
+    return undefined;
 }

--- a/src/NodeParser/IntersectionNodeParser.ts
+++ b/src/NodeParser/IntersectionNodeParser.ts
@@ -5,6 +5,8 @@ import { BaseType } from "../Type/BaseType";
 import { IntersectionType } from "../Type/IntersectionType";
 import { UnionType } from "../Type/UnionType";
 import { derefType } from "../Utils/derefType";
+import { uniqueTypeArray } from "../Utils/uniqueTypeArray";
+import { PrimitiveType } from "../Type/PrimitiveType";
 
 export class IntersectionNodeParser implements SubNodeParser {
     public constructor(private typeChecker: ts.TypeChecker, private childNodeParser: NodeParser) {}
@@ -14,41 +16,58 @@ export class IntersectionNodeParser implements SubNodeParser {
     }
 
     public createType(node: ts.IntersectionTypeNode, context: Context): BaseType | undefined {
-        const types = node.types.map((subnode) => this.childNodeParser.createType(subnode, context));
+        let types = node.types.map((subnode) => this.childNodeParser.createType(subnode, context));
 
         // if any type is undefined (never), an intersection type should be undefined (never)
         if (types.filter((t) => t === undefined).length) {
             return undefined;
         }
 
-        return this.translate(new IntersectionType(types as BaseType[]));
+        types = uniqueTypeArray(types as BaseType[]);
+
+        if (types.length == 1) {
+            return types[0];
+        }
+
+        return this.translate(types as BaseType[]);
     }
 
     /**
      * Translates the given intersection type into a union type if necessary so `A & (B | C)` becomes
      * `(A & B) | (A & C)`. If no translation is needed then the original intersection type is returned.
-     *
-     * @param intersection - The intersection type to translate.
-     * @return Either the union type into which the intersection type was translated or the original intersection type
-     *         if no translation is needed.
      */
-    private translate(intersection: IntersectionType): IntersectionType | UnionType {
-        const unions = intersection.getTypes().map((type) => {
+    private translate(types: BaseType[]): BaseType | undefined {
+        const unions = types.map((type) => {
             const derefed = derefType(type);
             return derefed instanceof UnionType ? derefed.getTypes() : [type];
         });
-        const result: IntersectionType[] = [];
-        function process(i: number, types: BaseType[] = []) {
+        const result: BaseType[] = [];
+        function process(i: number, t: BaseType[] = []) {
             for (const type of unions[i]) {
-                const currentTypes = [...types, type];
+                let currentTypes = [...t, type];
                 if (i < unions.length - 1) {
                     process(i + 1, currentTypes);
                 } else {
-                    result.push(new IntersectionType(currentTypes));
+                    currentTypes = uniqueTypeArray(currentTypes);
+
+                    const primitives = currentTypes.filter((c) => c instanceof PrimitiveType);
+                    if (primitives.length === 1) {
+                        result.push(primitives[0]);
+                    } else if (primitives.length > 1) {
+                        // never
+                        continue;
+                    }
+
+                    if (currentTypes.length === 1) {
+                        result.push(currentTypes[0]);
+                    } else {
+                        result.push(new IntersectionType(currentTypes));
+                    }
                 }
             }
         }
         process(0);
-        return result.length > 1 ? new UnionType(result) : intersection;
+
+        return result.length > 1 ? new UnionType(result) : new IntersectionType(types);
     }
 }

--- a/src/NodeParser/TypeOperatorNodeParser.ts
+++ b/src/NodeParser/TypeOperatorNodeParser.ts
@@ -27,6 +27,11 @@ export class TypeOperatorNodeParser implements SubNodeParser {
         if (derefed instanceof ObjectType && derefed.getAdditionalProperties()) {
             return new UnionType([...keys, new StringType()]);
         }
+
+        if (keys.length === 1) {
+            return keys[0];
+        }
+
         return new UnionType(keys);
     }
 }

--- a/src/Type/IntersectionType.ts
+++ b/src/Type/IntersectionType.ts
@@ -1,15 +1,20 @@
 import { BaseType } from "./BaseType";
+import { uniqueTypeArray } from "../Utils/uniqueTypeArray";
 
 export class IntersectionType extends BaseType {
-    public constructor(private types: BaseType[]) {
+    readonly #types: BaseType[];
+
+    public constructor(types: BaseType[]) {
         super();
+
+        this.#types = uniqueTypeArray(types);
     }
 
     public getId(): string {
-        return "(" + this.types.map((type) => type.getId()).join("&") + ")";
+        return "(" + this.#types.map((type) => type.getId()).join("&") + ")";
     }
 
     public getTypes(): BaseType[] {
-        return this.types;
+        return this.#types;
     }
 }

--- a/src/Type/IntersectionType.ts
+++ b/src/Type/IntersectionType.ts
@@ -1,20 +1,15 @@
 import { BaseType } from "./BaseType";
-import { uniqueTypeArray } from "../Utils/uniqueTypeArray";
 
 export class IntersectionType extends BaseType {
-    readonly #types: BaseType[];
-
-    public constructor(types: BaseType[]) {
+    public constructor(private types: BaseType[]) {
         super();
-
-        this.#types = uniqueTypeArray(types);
     }
 
     public getId(): string {
-        return "(" + this.#types.map((type) => type.getId()).join("&") + ")";
+        return "(" + this.types.map((type) => type.getId()).join("&") + ")";
     }
 
     public getTypes(): BaseType[] {
-        return this.#types;
+        return this.types;
     }
 }

--- a/src/Type/UnionType.ts
+++ b/src/Type/UnionType.ts
@@ -2,11 +2,11 @@ import { BaseType } from "./BaseType";
 import { uniqueTypeArray } from "../Utils/uniqueTypeArray";
 
 export class UnionType extends BaseType {
-    readonly #types: BaseType[];
+    private readonly types: BaseType[];
 
     public constructor(types: readonly BaseType[]) {
         super();
-        this.#types = uniqueTypeArray(
+        this.types = uniqueTypeArray(
             types.reduce((flatTypes, type) => {
                 if (type instanceof UnionType) {
                     flatTypes.push(...type.getTypes());
@@ -19,22 +19,22 @@ export class UnionType extends BaseType {
     }
 
     public getId(): string {
-        return "(" + this.#types.map((type) => type.getId()).join("|") + ")";
+        return "(" + this.types.map((type) => type.getId()).join("|") + ")";
     }
 
     public getName(): string {
-        return "(" + this.#types.map((type) => type.getName()).join("|") + ")";
+        return "(" + this.types.map((type) => type.getName()).join("|") + ")";
     }
 
     public getTypes(): BaseType[] {
-        return this.#types;
+        return this.types;
     }
 
     public normalize(): BaseType | undefined {
-        if (this.#types.length === 0) {
+        if (this.types.length === 0) {
             return undefined;
-        } else if (this.#types.length === 1) {
-            return this.#types[0];
+        } else if (this.types.length === 1) {
+            return this.types[0];
         } else {
             return this;
         }

--- a/src/Utils/preserveAnnotation.ts
+++ b/src/Utils/preserveAnnotation.ts
@@ -7,7 +7,7 @@ import { AnnotatedType } from "./../Type/AnnotatedType";
  *      then the returned type will be wrapped with the same annotations.
  * @param newType The type to be wrapped.
  */
-export function preserveAnnotation(originalType: BaseType, newType: BaseType) {
+export function preserveAnnotation(originalType: BaseType, newType: BaseType): BaseType {
     if (originalType instanceof AnnotatedType) {
         return new AnnotatedType(newType, originalType.getAnnotations(), originalType.isNullable());
     }

--- a/src/Utils/removeUndefined.ts
+++ b/src/Utils/removeUndefined.ts
@@ -8,7 +8,7 @@ import { preserveAnnotation } from "./preserveAnnotation";
  * Remove undefined types from union type. Returns the number of non-undefined properties.
  */
 export function removeUndefined(propertyType: UnionType): { numRemoved: number; newType: BaseType } {
-    const types = [];
+    const types: BaseType[] = [];
     let numRemoved = 0;
 
     for (const type of propertyType.getTypes()) {

--- a/src/Utils/typeKeys.ts
+++ b/src/Utils/typeKeys.ts
@@ -1,3 +1,4 @@
+import { translate } from "../NodeParser/IntersectionNodeParser";
 import { AnyType } from "../Type/AnyType";
 import { ArrayType } from "../Type/ArrayType";
 import { BaseType } from "../Type/BaseType";
@@ -12,6 +13,7 @@ import { UnionType } from "../Type/UnionType";
 import { derefAnnotatedType, derefType } from "./derefType";
 import { preserveAnnotation } from "./preserveAnnotation";
 import { uniqueArray } from "./uniqueArray";
+import { uniqueTypeArray } from "./uniqueTypeArray";
 
 function uniqueLiterals(types: LiteralType[]): LiteralType[] {
     const values = types.map((type) => type.getValue());
@@ -49,24 +51,42 @@ export function getTypeByKey(type: BaseType | undefined, index: LiteralType | St
     type = derefType(type);
 
     if (type instanceof IntersectionType || type instanceof UnionType) {
-        const subTypes: BaseType[] = [];
+        let subTypes: BaseType[] = [];
+
+        // we use the annotation from the first type so we need to get a reference to it
+        let firstType: BaseType | undefined;
+
         for (const subType of type.getTypes()) {
             const subKeyType = getTypeByKey(subType, index);
             if (subKeyType) {
                 subTypes.push(subKeyType);
-            }
-        }
-        if (subTypes.length == 1) {
-            return subTypes[0];
-        } else if (subTypes.length > 1) {
-            if (type instanceof UnionType) {
-                return new UnionType(subTypes);
-            } else {
-                return new IntersectionType(subTypes);
+                if (!firstType) {
+                    firstType = subKeyType;
+                }
             }
         }
 
-        return undefined;
+        subTypes = uniqueTypeArray(subTypes);
+        let returnType: BaseType | undefined = undefined;
+
+        if (subTypes.length == 1) {
+            return firstType;
+        } else if (subTypes.length > 1) {
+            if (type instanceof UnionType) {
+                returnType = new UnionType(subTypes);
+            } else {
+                returnType = translate(subTypes);
+            }
+        }
+
+        if (!returnType) {
+            return undefined;
+        }
+        if (!firstType) {
+            return returnType;
+        }
+
+        return preserveAnnotation(firstType, returnType);
     }
 
     if (type instanceof TupleType && index instanceof LiteralType) {

--- a/src/Utils/typeKeys.ts
+++ b/src/Utils/typeKeys.ts
@@ -49,10 +49,20 @@ export function getTypeByKey(type: BaseType | undefined, index: LiteralType | St
     type = derefType(type);
 
     if (type instanceof IntersectionType || type instanceof UnionType) {
+        const subTypes: BaseType[] = [];
         for (const subType of type.getTypes()) {
             const subKeyType = getTypeByKey(subType, index);
             if (subKeyType) {
-                return subKeyType;
+                subTypes.push(subKeyType);
+            }
+        }
+        if (subTypes.length == 1) {
+            return subTypes[0];
+        } else if (subTypes.length > 1) {
+            if (type instanceof UnionType) {
+                return new UnionType(subTypes);
+            } else {
+                return new IntersectionType(subTypes);
             }
         }
 

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -33,6 +33,7 @@ describe("valid-data-type", () => {
     it("type-intersection-partial-conflict", assertValidSchema("type-intersection-partial-conflict", "MyType"));
     it("type-intersection-partial-conflict-ref", assertValidSchema("type-intersection-partial-conflict", "MyType"));
     it("type-intersection-union", assertValidSchema("type-intersection-union", "MyObject"));
+    it("type-intersection-union-primitive", assertValidSchema("type-intersection-union", "MyObject"));
     it("type-intersection-additional-props", assertValidSchema("type-intersection-additional-props", "MyObject"));
     it("type-extend", assertValidSchema("type-extend", "MyObject"));
     it("type-extend-circular", assertValidSchema("type-extend-circular", "MyType"));

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -45,6 +45,7 @@ describe("valid-data-type", () => {
     it("type-indexed-access-tuple-1", assertValidSchema("type-indexed-access-tuple-1", "MyType"));
     it("type-indexed-access-tuple-2", assertValidSchema("type-indexed-access-tuple-2", "MyType"));
     it("type-indexed-access-tuple-union", assertValidSchema("type-indexed-access-tuple-union", "FormLayout"));
+    it("type-indexed-access-type-union", assertValidSchema("type-indexed-access-type-union", "MyType"));
     it("type-indexed-access-object-1", assertValidSchema("type-indexed-access-object-1", "MyType"));
     it("type-indexed-access-object-2", assertValidSchema("type-indexed-access-object-2", "MyType"));
     it("type-indexed-access-keyof", assertValidSchema("type-indexed-access-keyof", "MyType"));

--- a/test/valid-data/type-indexed-access-type-union/main.ts
+++ b/test/valid-data/type-indexed-access-type-union/main.ts
@@ -1,0 +1,3 @@
+export type Foo = { foo: number } | { foo: boolean };
+
+export type MyType = Partial<Foo>;

--- a/test/valid-data/type-indexed-access-type-union/schema.json
+++ b/test/valid-data/type-indexed-access-type-union/schema.json
@@ -1,0 +1,15 @@
+{
+  "$ref": "#/definitions/MyType",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyType": {
+      "additionalProperties": false,
+      "properties": {
+        "foo": {
+          "type": ["number", "boolean"]
+        }
+      },
+      "type": "object"
+    }
+  }
+}

--- a/test/valid-data/type-intersection-union-primitive/main.ts
+++ b/test/valid-data/type-intersection-union-primitive/main.ts
@@ -1,0 +1,1 @@
+export type MyType = (number | string) & (number | boolean);

--- a/test/valid-data/type-intersection-union-primitive/schema.json
+++ b/test/valid-data/type-intersection-union-primitive/schema.json
@@ -1,0 +1,9 @@
+{
+  "$ref": "#/definitions/MyType",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyType": {
+      "type": ["number"]
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/vega/ts-json-schema-generator/issues/446

`MyType` and `T` product correct types now. 

```ts
export type Foo = { foo: string } | { foo: number };

export type Bar = {
    [P in keyof Foo]: Foo[P];
};

export type X = Bar & Foo;

export type MyType = X["foo"];

export type T = string & (number | string);
```