### PR TITLE
Add support for types Date and RegExp

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Run the schema generator via `node main.js`.
 -   `interface` types
 -   `enum` types
 -   `union`, `tuple`, `type[]` types
+-   `Date` type
 -   `string`, `boolean`, `number` types
 -   `"value"`, `123`, `true`, `false`, `null`, `undefined` literals
 -   type aliases

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Run the schema generator via `node main.js`.
 -   `interface` types
 -   `enum` types
 -   `union`, `tuple`, `type[]` types
--   `Date` type
+-   `Date`, `RegExp` types
 -   `string`, `boolean`, `number` types
 -   `"value"`, `123`, `true`, `false`, `null`, `undefined` literals
 -   type aliases

--- a/src/NodeParser/TypeReferenceNodeParser.ts
+++ b/src/NodeParser/TypeReferenceNodeParser.ts
@@ -1,8 +1,10 @@
 import * as ts from "typescript";
 import { Context, NodeParser } from "../NodeParser";
 import { SubNodeParser } from "../SubNodeParser";
+import { AnnotatedType } from "../Type/AnnotatedType";
 import { ArrayType } from "../Type/ArrayType";
 import { BaseType } from "../Type/BaseType";
+import { StringType } from "../Type/StringType";
 
 const invlidTypes: { [index: number]: boolean } = {
     [ts.SyntaxKind.ModuleDeclaration]: true,
@@ -32,6 +34,8 @@ export class TypeReferenceNodeParser implements SubNodeParser {
                 return undefined;
             }
             return new ArrayType(type);
+        } else if (typeSymbol.name === "Date") {
+            return new AnnotatedType(new StringType(), { format: "date-time" }, false);
         } else {
             return this.childNodeParser.createType(
                 typeSymbol.declarations!.filter((n: ts.Declaration) => !invlidTypes[n.kind])[0],

--- a/src/NodeParser/TypeReferenceNodeParser.ts
+++ b/src/NodeParser/TypeReferenceNodeParser.ts
@@ -36,6 +36,8 @@ export class TypeReferenceNodeParser implements SubNodeParser {
             return new ArrayType(type);
         } else if (typeSymbol.name === "Date") {
             return new AnnotatedType(new StringType(), { format: "date-time" }, false);
+        } else if (typeSymbol.name === "RegExp") {
+            return new AnnotatedType(new StringType(), { format: "regex" }, false);
         } else {
             return this.childNodeParser.createType(
                 typeSymbol.declarations!.filter((n: ts.Declaration) => !invlidTypes[n.kind])[0],

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -28,6 +28,7 @@ describe("valid-data-type", () => {
     it("type-primitives", assertValidSchema("type-primitives", "MyObject"));
     it("type-date", assertValidSchema("type-date", "MyObject"));
     it("type-date-annotation", assertValidSchema("type-date", "MyObject", "basic"));
+    it("type-regexp", assertValidSchema("type-regexp", "MyObject"));
     it("type-union", assertValidSchema("type-union", "TypeUnion"));
     it("type-union-tagged", assertValidSchema("type-union-tagged", "Shape"));
     it("type-intersection", assertValidSchema("type-intersection", "MyObject"));

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -26,6 +26,8 @@ describe("valid-data-type", () => {
 
     it("type-maps", assertValidSchema("type-maps", "MyObject"));
     it("type-primitives", assertValidSchema("type-primitives", "MyObject"));
+    it("type-date", assertValidSchema("type-date", "MyObject"));
+    it("type-date-annotation", assertValidSchema("type-date", "MyObject", "basic"));
     it("type-union", assertValidSchema("type-union", "TypeUnion"));
     it("type-union-tagged", assertValidSchema("type-union-tagged", "Shape"));
     it("type-intersection", assertValidSchema("type-intersection", "MyObject"));

--- a/test/valid-data/type-date-annotation/main.ts
+++ b/test/valid-data/type-date-annotation/main.ts
@@ -1,0 +1,15 @@
+export interface MyObject {
+    /**
+     * @examples ["2020-01-01T00:00:00.000Z"]
+     */
+    defaultFormat: Date
+    /**
+     * @format time
+     * @examples ["12:00:00"]
+     */
+    time: Date
+    /**
+     * @format date
+     */
+    dateOnly: Date;
+}

--- a/test/valid-data/type-date-annotation/schema.json
+++ b/test/valid-data/type-date-annotation/schema.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "MyObject": {
+            "type": "object",
+            "properties": {
+                "defaultFormat": {
+                    "type": "string",
+                    "format": "date-time",
+                    "examples": [
+                        "2020-01-01T00:00:00.000Z"
+                    ]
+                },
+                "time": {
+                    "type": "string",
+                    "format": "time",
+                    "examples": [
+                        "12:00:00"
+                    ]
+                },
+                "dateOnly": {
+                    "type": "string",
+                    "format": "date"
+                }
+            },
+            "required": [
+                "defaultFormat",
+                "dateAlias",
+                "dateOnly"
+            ],
+            "additionalProperties": false
+        }
+    },
+    "$ref": "#/definitions/MyObject"
+}

--- a/test/valid-data/type-date/main.ts
+++ b/test/valid-data/type-date/main.ts
@@ -1,0 +1,6 @@
+type MyDate = Date
+
+export interface MyObject {
+    date: Date;
+    dateAlias: MyDate;
+}

--- a/test/valid-data/type-date/schema.json
+++ b/test/valid-data/type-date/schema.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "MyObject": {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "dateAlias": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            },
+            "required": [
+                "date",
+                "dateAlias"
+            ],
+            "additionalProperties": false
+        }
+    },
+    "$ref": "#/definitions/MyObject"
+}

--- a/test/valid-data/type-regexp/main.ts
+++ b/test/valid-data/type-regexp/main.ts
@@ -1,0 +1,6 @@
+type MyRegExp = RegExp
+
+export interface MyObject {
+    regexp: RegExp;
+    regexpAlias: MyRegExp;
+}

--- a/test/valid-data/type-regexp/schema.json
+++ b/test/valid-data/type-regexp/schema.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "MyObject": {
+            "type": "object",
+            "properties": {
+                "regexp": {
+                    "type": "string",
+                    "format": "regex"
+                },
+                "regexpAlias": {
+                    "type": "string",
+                    "format": "regex"
+                }
+            },
+            "required": [
+                "regexp",
+                "regexpAlias"
+            ],
+            "additionalProperties": false
+        }
+    },
+    "$ref": "#/definitions/MyObject"
+}


### PR DESCRIPTION
JS `Date` is represented as `{ "type": "string", "format": "date-time" }` in JSON Schema.

JS `RegExp` is represented as `{ "type": "string", "format": regex" }` in JSON Schema. 

Resolves #260