### PR TITLE
Delete declarationDir and declarationMap from tsconfig

### DIFF
--- a/factory/program.ts
+++ b/factory/program.ts
@@ -31,6 +31,8 @@ function loadTsConfigFile(configFile: string) {
         delete parseResult.options.outDir;
         delete parseResult.options.outFile;
         delete parseResult.options.declaration;
+        delete parseResult.options.declarationDir;
+        delete parseResult.options.declarationMap;
 
         return parseResult;
     } else {


### PR DESCRIPTION
Resolves #483.

Existing code deletes `declaration` tsconfig option, but leaves behind `declarationDir` and `declarationMap` which depend on `declaration` and cause typescript compilation failure if present.