### PR TITLE
refactor: make EnumTypeFormatter cleaner and more typecheck friendly

### DIFF
--- a/src/TypeFormatter/EnumTypeFormatter.ts
+++ b/src/TypeFormatter/EnumTypeFormatter.ts
@@ -12,12 +12,14 @@ export class EnumTypeFormatter implements SubTypeFormatter {
     public getDefinition(type: EnumType): Definition {
         const values = uniqueArray(type.getValues());
         const types = uniqueArray(values.map(typeName));
-        const isSingle = values.length === 1;
 
-        return {
-            type: types.length === 1 ? types[0] : types,
-            [isSingle ? "const" : "enum"]: isSingle ? values[0] : values,
-        };
+        // NOTE: We want to use "const" when referencing an enum member.
+        // However, this formatter is used both for enum members and enum types,
+        // so the side effect is that an enum type that contains just a single
+        // value is represented as "const" too.
+        return values.length === 1
+            ? { type: types[0], const: values[0] }
+            : { type: types.length === 1 ? types[0] : types, enum: values };
     }
     public getChildren(type: EnumType): BaseType[] {
         return [];


### PR DESCRIPTION
I wanted to amend this change in #492 in last minute, but you were faster with merging.