### PR TITLE
ci: run test workflow on pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ on: [push, pull_request]
 
 jobs:
   test:
+    # We want to run on external PRs, but not on our own internal PRs as they'll be run
+    # by the push to the branch.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
     runs-on: ubuntu-latest
 
     name: Test


### PR DESCRIPTION
Re: https://github.com/vega/ts-json-schema-generator/commit/9672f35eef763e62e388a2947418d39b093a75c4#commitcomment-41689589

See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request

Note: I don’t use GitHub Actions, so I’m not 100% sure about this, but according to the documentation and a few search hits this should do the trick.