### PR TITLE
Fix `@private` and do some refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Run the schema generator via `node main.js`.
 -e, --expose <all|none|export>
     all: Create shared $ref definitions for all types.
     none: Do not create shared $ref definitions.
-    export (default): Create shared $ref definitions only for exported types.
+    export (default): Create shared $ref definitions only for exported types (not tagged as `@private`).
 
 -f, --tsconfig 'my/project/tsconfig.json'
     Use a custom tsconfig file for processing typescript (see https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) instead of the default:

--- a/src/ExposeNodeParser.ts
+++ b/src/ExposeNodeParser.ts
@@ -4,6 +4,7 @@ import { SubNodeParser } from "./SubNodeParser";
 import { BaseType } from "./Type/BaseType";
 import { DefinitionType } from "./Type/DefinitionType";
 import { ReferenceType } from "./Type/ReferenceType";
+import { hasJsDocTag } from "./Utils/hasJsDocTag";
 import { symbolAtNode } from "./Utils/symbolAtNode";
 
 export class ExposeNodeParser implements SubNodeParser {
@@ -37,19 +38,12 @@ export class ExposeNodeParser implements SubNodeParser {
             return node.kind !== ts.SyntaxKind.TypeLiteral;
         } else if (this.expose === "none") {
             return false;
-        } else if (this.jsDoc !== "none" && this.isPrivateNode(node)) {
+        } else if (this.jsDoc !== "none" && hasJsDocTag(node, "private")) {
             return false;
         }
 
         const localSymbol: ts.Symbol = (node as any).localSymbol;
         return localSymbol ? "exportSymbol" in localSymbol : false;
-    }
-
-    private isPrivateNode(node: ts.Node): boolean {
-        const jsDocTags = symbolAtNode(node)?.getJsDocTags();
-        const privateTag = jsDocTags?.find((tag) => tag.name === "private");
-
-        return !!privateTag;
     }
 
     private getDefinitionName(node: ts.Node, context: Context): string {

--- a/src/NodeParser/EnumNodeParser.ts
+++ b/src/NodeParser/EnumNodeParser.ts
@@ -3,17 +3,8 @@ import { Context } from "../NodeParser";
 import { SubNodeParser } from "../SubNodeParser";
 import { BaseType } from "../Type/BaseType";
 import { EnumType, EnumValue } from "../Type/EnumType";
-import { isHidden } from "../Utils/isHidden";
+import { isNodeHidden } from "../Utils/isHidden";
 import { getKey } from "../Utils/nodeKey";
-
-function isMemberHidden(member: ts.EnumMember) {
-    if (!("symbol" in member)) {
-        return false;
-    }
-
-    const symbol: ts.Symbol = (member as any).symbol;
-    return isHidden(symbol);
-}
 
 export class EnumNodeParser implements SubNodeParser {
     public constructor(private typeChecker: ts.TypeChecker) {}
@@ -27,7 +18,7 @@ export class EnumNodeParser implements SubNodeParser {
         return new EnumType(
             `enum-${getKey(node, context)}`,
             members
-                .filter((member: ts.EnumMember) => !isMemberHidden(member))
+                .filter((member: ts.EnumMember) => !isNodeHidden(member))
                 .map((member, index) => this.getMemberValue(member, index))
         );
     }

--- a/src/NodeParser/HiddenTypeNodeParser.ts
+++ b/src/NodeParser/HiddenTypeNodeParser.ts
@@ -8,7 +8,7 @@ export class HiddenNodeParser implements SubNodeParser {
     public constructor(private typeChecker: ts.TypeChecker) {}
 
     public supportsNode(node: ts.KeywordTypeNode): boolean {
-        return !!isNodeHidden(node);
+        return isNodeHidden(node);
     }
 
     public createType(node: ts.KeywordTypeNode, context: Context): BaseType | undefined {

--- a/src/NodeParser/HiddenTypeNodeParser.ts
+++ b/src/NodeParser/HiddenTypeNodeParser.ts
@@ -2,18 +2,13 @@ import * as ts from "typescript";
 import { Context } from "../NodeParser";
 import { SubNodeParser } from "../SubNodeParser";
 import { BaseType } from "../Type/BaseType";
-import { isHidden } from "../Utils/isHidden";
-import { symbolAtNode } from "../Utils/symbolAtNode";
+import { isNodeHidden } from "../Utils/isHidden";
 
 export class HiddenNodeParser implements SubNodeParser {
     public constructor(private typeChecker: ts.TypeChecker) {}
 
     public supportsNode(node: ts.KeywordTypeNode): boolean {
-        const symbol = symbolAtNode(node);
-        if (symbol) {
-            return isHidden(symbol);
-        }
-        return false;
+        return !!isNodeHidden(node);
     }
 
     public createType(node: ts.KeywordTypeNode, context: Context): BaseType | undefined {

--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -151,8 +151,17 @@ export class SchemaGenerator {
         }
     }
     private isExportType(node: ts.Node): boolean {
+        if (this.config?.jsDoc !== "none" && this.isPrivateType(node)) {
+            return false;
+        }
         const localSymbol = localSymbolAtNode(node);
         return localSymbol ? "exportSymbol" in localSymbol : false;
+    }
+    private isPrivateType(node: ts.Node): boolean {
+        const jsDocTags = symbolAtNode(node)?.getJsDocTags();
+        const privateTag = jsDocTags?.find((tag) => tag.name === "private");
+
+        return !!privateTag;
     }
     private isGenericType(node: ts.TypeAliasDeclaration): boolean {
         return !!(node.typeParameters && node.typeParameters.length > 0);

--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -11,6 +11,7 @@ import { localSymbolAtNode, symbolAtNode } from "./Utils/symbolAtNode";
 import { notUndefined } from "./Utils/notUndefined";
 import { removeUnreachable } from "./Utils/removeUnreachable";
 import { Config } from "./Config";
+import { hasJsDocTag } from "./Utils/hasJsDocTag";
 
 export class SchemaGenerator {
     public constructor(
@@ -151,17 +152,11 @@ export class SchemaGenerator {
         }
     }
     private isExportType(node: ts.Node): boolean {
-        if (this.config?.jsDoc !== "none" && this.isPrivateType(node)) {
+        if (this.config?.jsDoc !== "none" && hasJsDocTag(node, "private")) {
             return false;
         }
         const localSymbol = localSymbolAtNode(node);
         return localSymbol ? "exportSymbol" in localSymbol : false;
-    }
-    private isPrivateType(node: ts.Node): boolean {
-        const jsDocTags = symbolAtNode(node)?.getJsDocTags();
-        const privateTag = jsDocTags?.find((tag) => tag.name === "private");
-
-        return !!privateTag;
     }
     private isGenericType(node: ts.TypeAliasDeclaration): boolean {
         return !!(node.typeParameters && node.typeParameters.length > 0);

--- a/src/Utils/hasJsDocTag.ts
+++ b/src/Utils/hasJsDocTag.ts
@@ -1,0 +1,7 @@
+import * as ts from "typescript";
+import { symbolAtNode } from "./symbolAtNode";
+
+export function hasJsDocTag(node: ts.Node, tagName: string): boolean {
+    const symbol = symbolAtNode(node);
+    return symbol ? symbol.getJsDocTags()?.some((tag) => tag.name === tagName) : false;
+}

--- a/src/Utils/isHidden.ts
+++ b/src/Utils/isHidden.ts
@@ -1,21 +1,6 @@
 import * as ts from "typescript";
-import { symbolAtNode } from "./symbolAtNode";
+import { hasJsDocTag } from "./hasJsDocTag";
 
-function isHidden(symbol: ts.Symbol): boolean {
-    const jsDocTags: ts.JSDocTagInfo[] = symbol.getJsDocTags();
-    if (!jsDocTags || !jsDocTags.length) {
-        return false;
-    }
-
-    const jsDocTag: ts.JSDocTagInfo | undefined = jsDocTags.find((tag: ts.JSDocTagInfo) => tag.name === "hidden");
-    return !!jsDocTag;
-}
-
-export function isNodeHidden(node: ts.Node): boolean | null {
-    const symbol = symbolAtNode(node);
-    if (!symbol) {
-        return null;
-    }
-
-    return isHidden(symbol);
+export function isNodeHidden(node: ts.Node): boolean {
+    return hasJsDocTag(node, "hidden");
 }

--- a/src/Utils/isHidden.ts
+++ b/src/Utils/isHidden.ts
@@ -1,7 +1,7 @@
 import * as ts from "typescript";
 import { symbolAtNode } from "./symbolAtNode";
 
-export function isHidden(symbol: ts.Symbol): boolean {
+function isHidden(symbol: ts.Symbol): boolean {
     const jsDocTags: ts.JSDocTagInfo[] = symbol.getJsDocTags();
     if (!jsDocTags || !jsDocTags.length) {
         return false;


### PR DESCRIPTION
Related to f716883

Currently, a type annotated as `@private` is inlined (i.e. it's not `$ref`erenced), but it's still included in the generated schema under a synthetic ID (e.g. `def-interface-1907173262-101-1186-1907173262-0-14381601989010`).