### PR TITLE
feat:: configurable formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ export class MyFunctionTypeFormatter implements SubTypeFormatter {
 }
 ```
 
-2. Then we add the formatter as a child to the core formatter using the configuration callback:
+2. Then we add the formatter as a child to the core formatter using the augmentation callback:
 
 ```ts
 import { createProgram, createParser, SchemaGenerator, createFormatter } from 'ts-json-schema-generator';

--- a/README.md
+++ b/README.md
@@ -51,6 +51,69 @@ fs.writeFile(output_path, schemaString, (err) => {
 
 Run the schema generator via `node main.js`.
 
+### Custom formatting
+
+Extending the built-in formatting is possible by creating a custom formatter and adding it to the main formatter:
+
+1. First we create a formatter, in this case for formatting function types:
+
+```ts
+// my-function-formatter.ts
+import { BaseType, Definition, FunctionType, SubTypeFormatter } from 'ts-json-schema-generator';
+
+export class MyFunctionTypeFormatter implements SubTypeFormatter {
+
+    public supportsType(type: FunctionType): boolean {
+        return type instanceof FunctionType;
+    }
+
+    public getDefinition(_type: FunctionType): Definition {
+        // Return a custom schema for the function property.
+        return {
+            type: "object",
+            properties: {
+                isFunction: {
+                    type: "boolean",
+                    const: true,
+                },
+            },
+        };
+    }
+
+    public getChildren(_type: FunctionType): BaseType[] {
+        return [];
+    }
+}
+```
+
+2. Then we add the formatter as a child to the core formatter using the configuration callback:
+
+```ts
+import { createProgram, createParser, SchemaGenerator, createFormatter } from 'ts-json-schema-generator';
+import { MyFunctionTypeFormatter } from './my-function-formatter.ts';
+import fs from 'fs'
+
+const config = {
+    path: "path/to/source/file",
+    tsconfig: "path/to/tsconfig.json",
+    type: "*", // Or <type-name> if you want to generate schema for that one type only
+};
+
+// We configure the formatter an add our custom formatter to it.
+const formatter = createFormatter(config, fmt => {
+    fmt.addTypeFormatter(new MyFunctionTypeFormatter());
+});
+
+const program = createProgram(config);
+const generator = new SchemaGenerator(program, parser, formatter, config);
+const schema = generator.createSchema(config.type);
+
+const schemaString = JSON.stringify(schema, null, 2);
+fs.writeFile(output_path, schemaString, (err) => {
+    if (err) throw err;
+});
+```
+
 ## Options
 
 ```

--- a/factory/formatter.ts
+++ b/factory/formatter.ts
@@ -29,7 +29,7 @@ import { MutableTypeFormatter } from "../src/MutableTypeFormatter";
 
 export type FormatterAugmentor = (formatter: MutableTypeFormatter) => void;
 
-export function createFormatter(config: Config, configurator?: FormatterAugmentor): TypeFormatter {
+export function createFormatter(config: Config, augmentor?: FormatterAugmentor): TypeFormatter {
     const chainTypeFormatter = new ChainTypeFormatter([]);
     const circularReferenceTypeFormatter = new CircularReferenceTypeFormatter(chainTypeFormatter);
 
@@ -65,8 +65,8 @@ export function createFormatter(config: Config, configurator?: FormatterAugmento
         .addTypeFormatter(new UnionTypeFormatter(circularReferenceTypeFormatter))
         .addTypeFormatter(new IntersectionTypeFormatter(circularReferenceTypeFormatter));
 
-    if (configurator) {
-        configurator(chainTypeFormatter);
+    if (augmentor) {
+        augmentor(chainTypeFormatter);
     }
 
     return circularReferenceTypeFormatter;

--- a/factory/formatter.ts
+++ b/factory/formatter.ts
@@ -25,8 +25,11 @@ import { UndefinedTypeFormatter } from "../src/TypeFormatter/UndefinedTypeFormat
 import { UnionTypeFormatter } from "../src/TypeFormatter/UnionTypeFormatter";
 import { UnknownTypeFormatter } from "../src/TypeFormatter/UnknownTypeFormatter";
 import { VoidTypeFormatter } from "../src/TypeFormatter/VoidTypeFormatter";
+import { MutableTypeFormatter } from "../src/MutableTypeFormatter";
 
-export function createFormatter(config: Config): TypeFormatter {
+export type FormatterConfigurator = (formatter: MutableTypeFormatter) => void;
+
+export function createFormatter(config: Config, configurator?: FormatterConfigurator): TypeFormatter {
     const chainTypeFormatter = new ChainTypeFormatter([]);
     const circularReferenceTypeFormatter = new CircularReferenceTypeFormatter(chainTypeFormatter);
 
@@ -61,6 +64,10 @@ export function createFormatter(config: Config): TypeFormatter {
         .addTypeFormatter(new TupleTypeFormatter(circularReferenceTypeFormatter))
         .addTypeFormatter(new UnionTypeFormatter(circularReferenceTypeFormatter))
         .addTypeFormatter(new IntersectionTypeFormatter(circularReferenceTypeFormatter));
+
+    if (configurator) {
+        configurator(chainTypeFormatter);
+    }
 
     return circularReferenceTypeFormatter;
 }

--- a/factory/formatter.ts
+++ b/factory/formatter.ts
@@ -27,9 +27,9 @@ import { UnknownTypeFormatter } from "../src/TypeFormatter/UnknownTypeFormatter"
 import { VoidTypeFormatter } from "../src/TypeFormatter/VoidTypeFormatter";
 import { MutableTypeFormatter } from "../src/MutableTypeFormatter";
 
-export type FormatterConfigurator = (formatter: MutableTypeFormatter) => void;
+export type FormatterAugmentor = (formatter: MutableTypeFormatter) => void;
 
-export function createFormatter(config: Config, configurator?: FormatterConfigurator): TypeFormatter {
+export function createFormatter(config: Config, configurator?: FormatterAugmentor): TypeFormatter {
     const chainTypeFormatter = new ChainTypeFormatter([]);
     const circularReferenceTypeFormatter = new CircularReferenceTypeFormatter(chainTypeFormatter);
 

--- a/index.ts
+++ b/index.ts
@@ -35,6 +35,7 @@ export * from "./src/Type/AliasType";
 export * from "./src/Type/ReferenceType";
 export * from "./src/Type/DefinitionType";
 export * from "./src/Type/AnnotatedType";
+export * from "./src/Type/FunctionType";
 
 export * from "./src/AnnotationsReader";
 export * from "./src/AnnotationsReader/BasicAnnotationsReader";
@@ -43,6 +44,7 @@ export * from "./src/AnnotationsReader/ExtendedAnnotationsReader";
 export * from "./src/TypeFormatter";
 export * from "./src/SubTypeFormatter";
 export * from "./src/ChainTypeFormatter";
+export * from "./src/MutableTypeFormatter";
 export * from "./src/CircularReferenceTypeFormatter";
 export * from "./src/TypeFormatter/AnyTypeFormatter";
 export * from "./src/TypeFormatter/UnknownTypeFormatter";

--- a/src/ChainTypeFormatter.ts
+++ b/src/ChainTypeFormatter.ts
@@ -1,9 +1,10 @@
 import { UnknownTypeError } from "./Error/UnknownTypeError";
+import { MutableTypeFormatter } from "./MutableTypeFormatter";
 import { Definition } from "./Schema/Definition";
 import { SubTypeFormatter } from "./SubTypeFormatter";
 import { BaseType } from "./Type/BaseType";
 
-export class ChainTypeFormatter implements SubTypeFormatter {
+export class ChainTypeFormatter implements SubTypeFormatter, MutableTypeFormatter {
     public constructor(private typeFormatters: SubTypeFormatter[]) {}
 
     public addTypeFormatter(typeFormatter: SubTypeFormatter): this {

--- a/src/MutableTypeFormatter.ts
+++ b/src/MutableTypeFormatter.ts
@@ -1,0 +1,5 @@
+import { SubTypeFormatter } from "./SubTypeFormatter";
+
+export interface MutableTypeFormatter {
+    addTypeFormatter(formatter: SubTypeFormatter): MutableTypeFormatter;
+}

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "fs";
 import { resolve } from "path";
 import ts from "typescript";
 
-import { createFormatter, FormatterConfigurator } from "../factory/formatter";
+import { createFormatter, FormatterAugmentor } from "../factory/formatter";
 import { createParser } from "../factory/parser";
 import { createProgram } from "../factory/program";
 import { Config, DEFAULT_CONFIG } from "../src/Config";
@@ -19,7 +19,7 @@ function assertSchema(
     name: string,
     userConfig: Config & { type: string },
     tsconfig?: boolean,
-    formatterConfigurator?: FormatterConfigurator
+    formatterAugmentor?: FormatterAugmentor
 ) {
     return () => {
         const config: Config = {
@@ -37,7 +37,7 @@ function assertSchema(
         const generator: SchemaGenerator = new SchemaGenerator(
             program,
             createParser(program, config),
-            createFormatter(config, formatterConfigurator),
+            createFormatter(config, formatterAugmentor),
             config
         );
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -3,15 +3,24 @@ import { readFileSync } from "fs";
 import { resolve } from "path";
 import ts from "typescript";
 
-import { createFormatter } from "../factory/formatter";
+import { createFormatter, FormatterConfigurator } from "../factory/formatter";
 import { createParser } from "../factory/parser";
 import { createProgram } from "../factory/program";
 import { Config, DEFAULT_CONFIG } from "../src/Config";
+import { Definition } from "../src/Schema/Definition";
 import { SchemaGenerator } from "../src/SchemaGenerator";
+import { SubTypeFormatter } from "../src/SubTypeFormatter";
+import { BaseType } from "../src/Type/BaseType";
+import { FunctionType } from "../src/Type/FunctionType";
 
 const basePath = "test/config";
 
-function assertSchema(name: string, userConfig: Config & { type: string }, tsconfig?: boolean) {
+function assertSchema(
+    name: string,
+    userConfig: Config & { type: string },
+    tsconfig?: boolean,
+    formatterConfigurator?: FormatterConfigurator
+) {
     return () => {
         const config: Config = {
             ...DEFAULT_CONFIG,
@@ -28,7 +37,7 @@ function assertSchema(name: string, userConfig: Config & { type: string }, tscon
         const generator: SchemaGenerator = new SchemaGenerator(
             program,
             createParser(program, config),
-            createFormatter(config),
+            createFormatter(config, formatterConfigurator),
             config
         );
 
@@ -49,6 +58,26 @@ function assertSchema(name: string, userConfig: Config & { type: string }, tscon
 
         validator.compile(actual); // Will find MissingRef errors
     };
+}
+
+export class ExampleFunctionTypeFormatter implements SubTypeFormatter {
+    public supportsType(type: FunctionType): boolean {
+        return type instanceof FunctionType;
+    }
+    public getDefinition(_type: FunctionType): Definition {
+        return {
+            type: "object",
+            properties: {
+                isFunction: {
+                    type: "boolean",
+                    const: true,
+                },
+            },
+        };
+    }
+    public getChildren(_type: FunctionType): BaseType[] {
+        return [];
+    }
 }
 
 describe("config", () => {
@@ -247,5 +276,17 @@ describe("config", () => {
             type: "MyObject",
             additionalProperties: true,
         })
+    );
+
+    it(
+        "custom-formatter-configuration",
+        assertSchema(
+            "custom-formatter-configuration",
+            {
+                type: "MyObject",
+            },
+            false,
+            (formatter) => formatter.addTypeFormatter(new ExampleFunctionTypeFormatter())
+        )
     );
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -19,7 +19,7 @@ function assertSchema(
     name: string,
     userConfig: Config & { type: string },
     tsconfig?: boolean,
-    formatterAugmentor?: FormatterAugmentor
+    augmentor?: FormatterAugmentor
 ) {
     return () => {
         const config: Config = {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -37,7 +37,7 @@ function assertSchema(
         const generator: SchemaGenerator = new SchemaGenerator(
             program,
             createParser(program, config),
-            createFormatter(config, formatterAugmentor),
+            createFormatter(config, augmentor),
             config
         );
 

--- a/test/config/custom-formatter-configuration/main.ts
+++ b/test/config/custom-formatter-configuration/main.ts
@@ -1,0 +1,39 @@
+export interface ExportInterface {
+    exportValue: string;
+}
+export type ExportAlias = ExportInterface;
+
+interface PrivateInterface {
+    privateValue: string;
+}
+type PrivateAlias = PrivateInterface;
+
+interface MixedInterface {
+    mixedValue: ExportAlias;
+}
+export type MixedAlias = PrivateInterface;
+
+
+export type PublicAnonymousTypeLiteral = {
+    publicValue: string;
+};
+
+type PrivateAnonymousTypeLiteral = {
+    privateValue: string;
+};
+
+export interface MyObject {
+    exportInterface: ExportInterface;
+    exportAlias: ExportAlias;
+
+    privateInterface: PrivateInterface;
+    privateAlias: PrivateAlias;
+
+    mixedInterface: MixedInterface;
+    mixedAlias: MixedAlias;
+
+    publicAnonymousTypeLiteral: PublicAnonymousTypeLiteral;
+    privateAnonymousTypeLiteral: PrivateAnonymousTypeLiteral;
+
+    exportedFunction: () => void;
+}

--- a/test/config/custom-formatter-configuration/schema.json
+++ b/test/config/custom-formatter-configuration/schema.json
@@ -1,0 +1,131 @@
+{
+    "$ref": "#/definitions/MyObject",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "ExportInterface": {
+            "type": "object",
+            "properties": {
+                "exportValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "exportValue"
+            ],
+            "additionalProperties": false
+        },
+        "ExportAlias": {
+            "$ref": "#/definitions/ExportInterface"
+        },
+        "MixedAlias": {
+            "type": "object",
+            "properties": {
+                "privateValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "privateValue"
+            ],
+            "additionalProperties": false
+        },
+        "PublicAnonymousTypeLiteral": {
+            "type": "object",
+            "properties": {
+                "publicValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "publicValue"
+            ],
+            "additionalProperties": false
+        },
+        "MyObject": {
+            "type": "object",
+            "properties": {
+                "exportInterface": {
+                    "$ref": "#/definitions/ExportInterface"
+                },
+                "exportAlias": {
+                    "$ref": "#/definitions/ExportAlias"
+                },
+                "privateInterface": {
+                    "type": "object",
+                    "properties": {
+                        "privateValue": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "privateValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "privateAlias": {
+                    "type": "object",
+                    "properties": {
+                        "privateValue": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "privateValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "mixedInterface": {
+                    "type": "object",
+                    "properties": {
+                        "mixedValue": {
+                            "$ref": "#/definitions/ExportAlias"
+                        }
+                    },
+                    "required": [
+                        "mixedValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "mixedAlias": {
+                    "$ref": "#/definitions/MixedAlias"
+                },
+                "publicAnonymousTypeLiteral": {
+                    "$ref": "#/definitions/PublicAnonymousTypeLiteral"
+                },
+                "privateAnonymousTypeLiteral": {
+                    "type": "object",
+                    "properties": {
+                        "privateValue": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "privateValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "exportedFunction": {
+                    "type": "object",
+                    "properties": {
+                        "isFunction": {
+                            "type": "boolean",
+                            "const": true
+                        }
+                    }
+                }
+            },
+            "required": [
+                "exportInterface",
+                "exportAlias",
+                "privateInterface",
+                "privateAlias",
+                "mixedInterface",
+                "mixedAlias",
+                "publicAnonymousTypeLiteral",
+                "privateAnonymousTypeLiteral",
+                "exportedFunction"
+            ],
+            "additionalProperties": false
+        }
+    }
+}


### PR DESCRIPTION
Hi! 👋 

This is a proposal on how to enable customisation of the formatting step by adding the ability to add additional formatters programatically. In the example included in the test, a function type is formatted as a custom object defined by the consumer.

Example:
```ts
createFormatter(configuration, (formatter) => {
    formatter.addTypeFormatter(new MyFunctionTypeFormatter())
})
```

I'm looking forward to your feedback!