### PR TITLE
feat: allow overriding built-in formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ const formatter = createFormatter(config, fmt => {
 });
 
 const program = createProgram(config);
+const parser = createParser(program, config);
 const generator = new SchemaGenerator(program, parser, formatter, config);
 const schema = generator.createSchema(config.type);
 

--- a/factory/formatter.ts
+++ b/factory/formatter.ts
@@ -33,6 +33,10 @@ export function createFormatter(config: Config, augmentor?: FormatterAugmentor):
     const chainTypeFormatter = new ChainTypeFormatter([]);
     const circularReferenceTypeFormatter = new CircularReferenceTypeFormatter(chainTypeFormatter);
 
+    if (augmentor) {
+        augmentor(chainTypeFormatter);
+    }
+
     chainTypeFormatter
         .addTypeFormatter(new AnnotatedTypeFormatter(circularReferenceTypeFormatter))
 
@@ -64,10 +68,6 @@ export function createFormatter(config: Config, augmentor?: FormatterAugmentor):
         .addTypeFormatter(new TupleTypeFormatter(circularReferenceTypeFormatter))
         .addTypeFormatter(new UnionTypeFormatter(circularReferenceTypeFormatter))
         .addTypeFormatter(new IntersectionTypeFormatter(circularReferenceTypeFormatter));
-
-    if (augmentor) {
-        augmentor(chainTypeFormatter);
-    }
 
     return circularReferenceTypeFormatter;
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -11,7 +11,10 @@ import { Definition } from "../src/Schema/Definition";
 import { SchemaGenerator } from "../src/SchemaGenerator";
 import { SubTypeFormatter } from "../src/SubTypeFormatter";
 import { BaseType } from "../src/Type/BaseType";
+import { EnumType } from "../src/Type/EnumType";
 import { FunctionType } from "../src/Type/FunctionType";
+import { typeName } from "../src/Utils/typeName";
+import { uniqueArray } from "../src/Utils/uniqueArray";
 
 const basePath = "test/config";
 
@@ -76,6 +79,30 @@ export class ExampleFunctionTypeFormatter implements SubTypeFormatter {
         };
     }
     public getChildren(_type: FunctionType): BaseType[] {
+        return [];
+    }
+}
+
+export class ExampleEnumTypeFormatter implements SubTypeFormatter {
+    public supportsType(type: EnumType): boolean {
+        return type instanceof EnumType;
+    }
+    public getDefinition(type: EnumType): Definition {
+        return {
+            type: 'object',
+            properties: {
+                isEnum: {
+                    type: 'boolean',
+                    const: true
+                },
+                enumLength: {
+                    type: 'number',
+                    const: type.getValues().length
+                }
+            }
+        };
+    }
+    public getChildren(_type: EnumType): BaseType[] {
         return [];
     }
 }
@@ -287,6 +314,18 @@ describe("config", () => {
             },
             false,
             (formatter) => formatter.addTypeFormatter(new ExampleFunctionTypeFormatter())
+        )
+    );
+
+    it(
+        "custom-formatter-configuration-override",
+        assertSchema(
+            "custom-formatter-configuration-override",
+            {
+                type: "MyObject",
+            },
+            false,
+            (formatter) => formatter.addTypeFormatter(new ExampleEnumTypeFormatter())
         )
     );
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -13,8 +13,6 @@ import { SubTypeFormatter } from "../src/SubTypeFormatter";
 import { BaseType } from "../src/Type/BaseType";
 import { EnumType } from "../src/Type/EnumType";
 import { FunctionType } from "../src/Type/FunctionType";
-import { typeName } from "../src/Utils/typeName";
-import { uniqueArray } from "../src/Utils/uniqueArray";
 
 const basePath = "test/config";
 
@@ -89,17 +87,17 @@ export class ExampleEnumTypeFormatter implements SubTypeFormatter {
     }
     public getDefinition(type: EnumType): Definition {
         return {
-            type: 'object',
+            type: "object",
             properties: {
                 isEnum: {
-                    type: 'boolean',
-                    const: true
+                    type: "boolean",
+                    const: true,
                 },
                 enumLength: {
-                    type: 'number',
-                    const: type.getValues().length
-                }
-            }
+                    type: "number",
+                    const: type.getValues().length,
+                },
+            },
         };
     }
     public getChildren(_type: EnumType): BaseType[] {

--- a/test/config/custom-formatter-configuration-override/main.ts
+++ b/test/config/custom-formatter-configuration-override/main.ts
@@ -1,0 +1,47 @@
+export interface ExportInterface {
+    exportValue: string;
+}
+export type ExportAlias = ExportInterface;
+
+interface PrivateInterface {
+    privateValue: string;
+}
+type PrivateAlias = PrivateInterface;
+
+interface MixedInterface {
+    mixedValue: ExportAlias;
+}
+export type MixedAlias = PrivateInterface;
+
+
+export type PublicAnonymousTypeLiteral = {
+    publicValue: string;
+};
+
+type PrivateAnonymousTypeLiteral = {
+    privateValue: string;
+};
+
+enum Direction {
+    Up,
+    Down,
+    Left,
+    Right,
+}
+
+export interface MyObject {
+    exportInterface: ExportInterface;
+    exportAlias: ExportAlias;
+
+    privateInterface: PrivateInterface;
+    privateAlias: PrivateAlias;
+
+    mixedInterface: MixedInterface;
+    mixedAlias: MixedAlias;
+
+    publicAnonymousTypeLiteral: PublicAnonymousTypeLiteral;
+    privateAnonymousTypeLiteral: PrivateAnonymousTypeLiteral;
+
+    exportedEnum: Direction
+}
+

--- a/test/config/custom-formatter-configuration-override/schema.json
+++ b/test/config/custom-formatter-configuration-override/schema.json
@@ -1,0 +1,135 @@
+{
+    "$ref": "#/definitions/MyObject",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "ExportInterface": {
+            "type": "object",
+            "properties": {
+                "exportValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "exportValue"
+            ],
+            "additionalProperties": false
+        },
+        "ExportAlias": {
+            "$ref": "#/definitions/ExportInterface"
+        },
+        "MixedAlias": {
+            "type": "object",
+            "properties": {
+                "privateValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "privateValue"
+            ],
+            "additionalProperties": false
+        },
+        "PublicAnonymousTypeLiteral": {
+            "type": "object",
+            "properties": {
+                "publicValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "publicValue"
+            ],
+            "additionalProperties": false
+        },
+        "MyObject": {
+            "type": "object",
+            "properties": {
+                "exportInterface": {
+                    "$ref": "#/definitions/ExportInterface"
+                },
+                "exportAlias": {
+                    "$ref": "#/definitions/ExportAlias"
+                },
+                "privateInterface": {
+                    "type": "object",
+                    "properties": {
+                        "privateValue": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "privateValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "privateAlias": {
+                    "type": "object",
+                    "properties": {
+                        "privateValue": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "privateValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "mixedInterface": {
+                    "type": "object",
+                    "properties": {
+                        "mixedValue": {
+                            "$ref": "#/definitions/ExportAlias"
+                        }
+                    },
+                    "required": [
+                        "mixedValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "mixedAlias": {
+                    "$ref": "#/definitions/MixedAlias"
+                },
+                "publicAnonymousTypeLiteral": {
+                    "$ref": "#/definitions/PublicAnonymousTypeLiteral"
+                },
+                "privateAnonymousTypeLiteral": {
+                    "type": "object",
+                    "properties": {
+                        "privateValue": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "privateValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "exportedEnum": {
+                    "type": "object",
+                    "properties": {
+                        "isEnum": {
+                            "type": "boolean",
+                            "const": true
+                        },
+                        "enumLength": {
+                            "type": "number",
+                            "const": 4
+                        }
+                    }
+                }
+            },
+            "required": [
+                "exportInterface",
+                "exportAlias",
+                "privateInterface",
+                "privateAlias",
+                "mixedInterface",
+                "mixedAlias",
+                "publicAnonymousTypeLiteral",
+                "privateAnonymousTypeLiteral",
+                "exportedEnum"
+            ],
+            "additionalProperties": false
+        }
+    }
+}


### PR DESCRIPTION
Allow overriding built-in formatters by running the augmentor first.
Also a line of code that was missing from the readme.

Fixes #596