### PR TITLE
add $id support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ fs.writeFile(output_path, schemaString, (err) => {
     The type the generated schema will represent. If omitted, the generated schema will contain all
     types found in the files matching path. The same is true if '*' is specified.
 
+-i, --id 'generatedSchemaId'
+    The `$id` of the generated schema. If omitted, there will be no `$id`.
+
 -e, --expose <all|none|export>
     all: Create shared $ref definitions for all types.
     none: Do not create shared $ref definitions.

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -1,6 +1,7 @@
 export interface Config {
     path?: string;
     type?: string;
+    schemaId?: string;
     tsconfig?: string;
     expose?: "all" | "none" | "export";
     topRef?: boolean;
@@ -13,7 +14,7 @@ export interface Config {
     additionalProperties?: boolean;
 }
 
-export const DEFAULT_CONFIG: Omit<Required<Config>, "path" | "type" | "tsconfig"> = {
+export const DEFAULT_CONFIG: Omit<Required<Config>, "path" | "type" | "schemaId" | "tsconfig"> = {
     expose: "export",
     topRef: true,
     jsDoc: "extended",

--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -38,11 +38,15 @@ export class SchemaGenerator {
 
         const reachableDefinitions = removeUnreachable(rootTypeDefinition, definitions);
 
-        return {
+        const jsonSchema = {
             $schema: "http://json-schema.org/draft-07/schema#",
             ...(rootTypeDefinition ?? {}),
             definitions: reachableDefinitions,
         };
+        if (this.config?.schemaId) {
+            jsonSchema.$id = this.config.schemaId;
+        }
+        return jsonSchema;
     }
 
     private getRootNodes(fullName: string | undefined) {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -20,7 +20,6 @@ export function assertValidSchema(
     jsDoc: Config["jsDoc"] = "none",
     extraTags?: Config["extraTags"],
     schemaId?: Config["schemaId"]
-
 ) {
     return (): void => {
         const config: Config = {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -18,7 +18,9 @@ export function assertValidSchema(
     relativePath: string,
     type?: string,
     jsDoc: Config["jsDoc"] = "none",
-    extraTags?: Config["extraTags"]
+    extraTags?: Config["extraTags"],
+    schemaId?: Config["schemaId"]
+
 ) {
     return (): void => {
         const config: Config = {
@@ -29,11 +31,16 @@ export function assertValidSchema(
             skipTypeCheck: !!process.env.FAST_TEST,
         };
 
+        if (schemaId) {
+            config.schemaId = schemaId;
+        }
+
         const program: ts.Program = createProgram(config);
         const generator: SchemaGenerator = new SchemaGenerator(
             program,
             createParser(program, config),
-            createFormatter(config)
+            createFormatter(config),
+            config
         );
 
         const schema = generator.createSchema(type);

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -2,7 +2,10 @@ import { assertValidSchema } from "./utils";
 
 describe("valid-data-type", () => {
     it("type-aliases-primitive", assertValidSchema("type-aliases-primitive", "MyString"));
-    it("type-aliases-primitive-with-id", assertValidSchema("type-aliases-primitive-with-id", "MyString", "none", undefined, "testId"));
+    it(
+        "type-aliases-primitive-with-id",
+        assertValidSchema("type-aliases-primitive-with-id", "MyString", "none", undefined, "testId")
+    );
     it("type-aliases-object", assertValidSchema("type-aliases-object", "MyAlias"));
     it("type-aliases-mixed", assertValidSchema("type-aliases-mixed", "MyObject"));
     it("type-aliases-union", assertValidSchema("type-aliases-union", "MyUnion"));

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -2,6 +2,7 @@ import { assertValidSchema } from "./utils";
 
 describe("valid-data-type", () => {
     it("type-aliases-primitive", assertValidSchema("type-aliases-primitive", "MyString"));
+    it("type-aliases-primitive-with-id", assertValidSchema("type-aliases-primitive-with-id", "MyString", "none", undefined, "testId"));
     it("type-aliases-object", assertValidSchema("type-aliases-object", "MyAlias"));
     it("type-aliases-mixed", assertValidSchema("type-aliases-mixed", "MyObject"));
     it("type-aliases-union", assertValidSchema("type-aliases-union", "MyUnion"));

--- a/test/valid-data/type-aliases-primitive-with-id/main.ts
+++ b/test/valid-data/type-aliases-primitive-with-id/main.ts
@@ -1,0 +1,1 @@
+export type MyString = string;

--- a/test/valid-data/type-aliases-primitive-with-id/schema.json
+++ b/test/valid-data/type-aliases-primitive-with-id/schema.json
@@ -1,0 +1,10 @@
+{
+    "$id": "testId",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "MyString": {
+            "type": "string"
+        }
+    },
+    "$ref": "#/definitions/MyString"
+}

--- a/ts-json-schema-generator.ts
+++ b/ts-json-schema-generator.ts
@@ -9,6 +9,7 @@ import { formatError } from "./src/Utils/formatError";
 const args = commander
     .option("-p, --path <path>", "Source file path")
     .option("-t, --type <name>", "Type name")
+    .option("-i, --id <name>", "$id for generated schema")
     .option("-f, --tsconfig <path>", "Custom tsconfig.json path")
     .option("-e, --expose <expose>", "Type exposing", /^(all|none|export)$/, "export")
     .option("-j, --jsDoc <extended>", "Read JsDoc annotations", /^(none|basic|extended)$/, "extended")
@@ -36,6 +37,7 @@ const config: Config = {
     path: args.path,
     tsconfig: args.tsconfig,
     type: args.type,
+    schemaId: args.id,
     expose: args.expose,
     topRef: args.topRef,
     jsDoc: args.jsDoc,


### PR DESCRIPTION
Currently all schemas are generated without `$id`. This means if multiple of them are generated and used with `ajv`, there will be an error as `ajv` expects unique `$id` for each schema.

This adds an option to pass the id using CLI