### PR TITLE
feat: better output for idiom [A, A, ...A[]]

### DIFF
--- a/src/TypeFormatter/TupleTypeFormatter.ts
+++ b/src/TypeFormatter/TupleTypeFormatter.ts
@@ -21,7 +21,8 @@ export class TupleTypeFormatter implements SubTypeFormatter {
         const restElements = subTypes.filter((t) => t instanceof RestType) as RestType[];
         const restType = restElements.length ? restElements[0].getType().getItem() : undefined;
 
-        // When the tuple is of the form [A, A, A] or [A, A, A, ...A[]], generate a simple array with minItems instead.
+        // When the tuple is of the form [A, A, A] or [A, A, A, ...A[]], generate a simple array
+        // with minItems (and possibly maxItems) instead.
         const isUniformArray =
             requiredElements.length > 0 &&
             optionalElements.length === 0 &&
@@ -32,16 +33,16 @@ export class TupleTypeFormatter implements SubTypeFormatter {
         if (isUniformArray) {
             return {
                 type: "array",
-                minItems: requiredElements.length,
                 items: this.childTypeFormatter.getDefinition(requiredElements[0]),
+                minItems: requiredElements.length,
                 ...(restType ? {} : { maxItems: requiredElements.length }),
             };
         }
 
         const requiredDefinitions = requiredElements.map((item) => this.childTypeFormatter.getDefinition(item));
         const optionalDefinitions = optionalElements.map((item) => this.childTypeFormatter.getDefinition(item));
-        const restDefinition = restType ? this.childTypeFormatter.getDefinition(restType) : undefined;
         const itemsTotal = requiredDefinitions.length + optionalDefinitions.length;
+        const restDefinition = restType ? this.childTypeFormatter.getDefinition(restType) : undefined;
 
         return {
             type: "array",

--- a/src/TypeFormatter/TupleTypeFormatter.ts
+++ b/src/TypeFormatter/TupleTypeFormatter.ts
@@ -20,12 +20,28 @@ export class TupleTypeFormatter implements SubTypeFormatter {
         const optionalElements = subTypes.filter((t) => t instanceof OptionalType) as OptionalType[];
         const restElements = subTypes.filter((t) => t instanceof RestType) as RestType[];
 
+        const restType = restElements.length ? restElements[0].getType().getItem() : undefined;
+        const restDefinition = restType ? this.childTypeFormatter.getDefinition(restType) : undefined;
+
+        // When the tuple is of the form [A, A, A, ...A[]], generate a simple array with minItems instead.
+        const isUniformArray =
+            requiredElements.length > 0 &&
+            optionalElements.length === 0 &&
+            restElements.length === 1 &&
+            requiredElements.slice(1).every((item) => item.getId() === requiredElements[0].getId()) &&
+            restType?.getId() === requiredElements[0].getId();
+
+        if (isUniformArray) {
+            return {
+                type: "array",
+                minItems: requiredElements.length,
+                items: restDefinition,
+            };
+        }
+
         const requiredDefinitions = requiredElements.map((item) => this.childTypeFormatter.getDefinition(item));
         const optionalDefinitions = optionalElements.map((item) => this.childTypeFormatter.getDefinition(item));
         const itemsTotal = requiredDefinitions.length + optionalDefinitions.length;
-
-        const restType = restElements.length ? restElements[0].getType().getItem() : undefined;
-        const restDefinition = restType ? this.childTypeFormatter.getDefinition(restType) : undefined;
 
         return {
             type: "array",

--- a/src/TypeFormatter/TupleTypeFormatter.ts
+++ b/src/TypeFormatter/TupleTypeFormatter.ts
@@ -21,12 +21,12 @@ export class TupleTypeFormatter implements SubTypeFormatter {
         const restElements = subTypes.filter((t) => t instanceof RestType) as RestType[];
         const restType = restElements.length ? restElements[0].getType().getItem() : undefined;
 
-        // When the tuple is of the form [A, A, A] or [A, A, A, ...A[]], generate a simple array
-        // with minItems (and possibly maxItems) instead.
+        // When the tuple is of the form [A, A, A], [A, A, A?], or [A, A, A, ...A[]],
+        // generate a simple array with minItems (and possibly maxItems) instead.
         const isUniformArray =
             requiredElements.length > 0 &&
-            optionalElements.length === 0 &&
             requiredElements.slice(1).every((item) => item.getId() === requiredElements[0].getId()) &&
+            optionalElements.every((item) => item.getType().getId() === requiredElements[0].getId()) &&
             (restElements.length === 0 ||
                 (restElements.length === 1 && restType?.getId() === requiredElements[0].getId()));
 
@@ -35,7 +35,7 @@ export class TupleTypeFormatter implements SubTypeFormatter {
                 type: "array",
                 items: this.childTypeFormatter.getDefinition(requiredElements[0]),
                 minItems: requiredElements.length,
-                ...(restType ? {} : { maxItems: requiredElements.length }),
+                ...(restType ? {} : { maxItems: requiredElements.length + optionalElements.length }),
             };
         }
 

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -63,4 +63,5 @@ describe("valid-data-other", () => {
     it("array-min-items-2", assertValidSchema("array-min-items-2", "MyType"));
     it("array-min-max-items", assertValidSchema("array-min-max-items", "MyType"));
     it("array-min-max-items-optional", assertValidSchema("array-min-max-items-optional", "MyType"));
+    it("array-max-items-optional", assertValidSchema("array-max-items-optional", "MyType"));
 });

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -62,4 +62,5 @@ describe("valid-data-other", () => {
     it("array-min-items-1", assertValidSchema("array-min-items-1", "MyType"));
     it("array-min-items-2", assertValidSchema("array-min-items-2", "MyType"));
     it("array-min-max-items", assertValidSchema("array-min-max-items", "MyType"));
+    it("array-min-max-items-optional", assertValidSchema("array-min-max-items-optional", "MyType"));
 });

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -58,4 +58,7 @@ describe("valid-data-other", () => {
     it("keyof-typeof-enum", assertValidSchema("keyof-typeof-enum", "MyObject"));
 
     it("symbol", assertValidSchema("symbol", "MyObject"));
+
+    it("array-min-items-1", assertValidSchema("array-min-items-1", "MyType"));
+    it("array-min-items-2", assertValidSchema("array-min-items-2", "MyType"));
 });

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -61,4 +61,5 @@ describe("valid-data-other", () => {
 
     it("array-min-items-1", assertValidSchema("array-min-items-1", "MyType"));
     it("array-min-items-2", assertValidSchema("array-min-items-2", "MyType"));
+    it("array-min-max-items", assertValidSchema("array-min-max-items", "MyType"));
 });

--- a/test/valid-data/array-max-items-optional/main.ts
+++ b/test/valid-data/array-max-items-optional/main.ts
@@ -1,0 +1,1 @@
+export type MyType = [string?, string?];

--- a/test/valid-data/array-max-items-optional/schema.json
+++ b/test/valid-data/array-max-items-optional/schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "MyType": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "minItems": 0,
+            "maxItems": 2
+        }
+    },
+    "$ref": "#/definitions/MyType"
+}

--- a/test/valid-data/array-min-items-1/main.ts
+++ b/test/valid-data/array-min-items-1/main.ts
@@ -1,0 +1,1 @@
+export type MyType = [string, ...string[]];

--- a/test/valid-data/array-min-items-1/schema.json
+++ b/test/valid-data/array-min-items-1/schema.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "MyType": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "minItems": 1
+        }
+    },
+    "$ref": "#/definitions/MyType"
+}

--- a/test/valid-data/array-min-items-2/main.ts
+++ b/test/valid-data/array-min-items-2/main.ts
@@ -1,0 +1,1 @@
+export type MyType = [string, string, ...string[]];

--- a/test/valid-data/array-min-items-2/schema.json
+++ b/test/valid-data/array-min-items-2/schema.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "MyType": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "minItems": 2
+        }
+    },
+    "$ref": "#/definitions/MyType"
+}

--- a/test/valid-data/array-min-max-items-optional/main.ts
+++ b/test/valid-data/array-min-max-items-optional/main.ts
@@ -1,0 +1,1 @@
+export type MyType = [string, string, string?];

--- a/test/valid-data/array-min-max-items-optional/schema.json
+++ b/test/valid-data/array-min-max-items-optional/schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "MyType": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "minItems": 2,
+            "maxItems": 3
+        }
+    },
+    "$ref": "#/definitions/MyType"
+}

--- a/test/valid-data/array-min-max-items/main.ts
+++ b/test/valid-data/array-min-max-items/main.ts
@@ -1,0 +1,1 @@
+export type MyType = [string, string, string];

--- a/test/valid-data/array-min-max-items/schema.json
+++ b/test/valid-data/array-min-max-items/schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "MyType": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "minItems": 3,
+            "maxItems": 3
+        }
+    },
+    "$ref": "#/definitions/MyType"
+}


### PR DESCRIPTION
The type expression above can be used to indicate a uniform array with a minimum number of elements.

Prior to this change, output for the expression looks roughly as follows (schema references omitted for clarity):

```json
{
  "type": "array",
  "items": [
    {
      "type": "A"
    },
    {
      "type": "A"
    }
  ],
  "minItems": 2,
  "additionalItems": {
    "type": "A"
  }
}
```

While this is technically correct, and a direct translation of the input, it obscures intent.  It also causes a warning to be emitted in Ajv 7.x, see https://github.com/ajv-validator/ajv/issues/1417

With this change the output looks as below and doesn't generate a warning:

```json
{
  "type": "array",
  "items": {
    "type": "A"
  },
  "minItems": 2,
}
```
