### PR TITLE
fix: fix shorthand array with readonly modifier

### DIFF
--- a/src/NodeParser/TypeOperatorNodeParser.ts
+++ b/src/NodeParser/TypeOperatorNodeParser.ts
@@ -20,6 +20,10 @@ export class TypeOperatorNodeParser implements SubNodeParser {
     public createType(node: ts.TypeOperatorNode, context: Context): BaseType {
         const type = this.childNodeParser.createType(node.type, context);
         const derefed = derefType(type);
+        // Remove readonly modifier from type
+        if (node.operator === ts.SyntaxKind.ReadonlyKeyword && derefed) {
+            return derefed;
+        }
         if (derefed instanceof ArrayType) {
             return new NumberType();
         }

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -64,4 +64,5 @@ describe("valid-data-other", () => {
     it("array-min-max-items", assertValidSchema("array-min-max-items", "MyType"));
     it("array-min-max-items-optional", assertValidSchema("array-min-max-items-optional", "MyType"));
     it("array-max-items-optional", assertValidSchema("array-max-items-optional", "MyType"));
+    it("shorthand-array", assertValidSchema("shorthand-array", "MyType"));
 });

--- a/test/valid-data/shorthand-array/main.ts
+++ b/test/valid-data/shorthand-array/main.ts
@@ -1,0 +1,4 @@
+export interface MyType {
+    numberArray: number[];
+    stringArray: readonly string[];
+}

--- a/test/valid-data/shorthand-array/schema.json
+++ b/test/valid-data/shorthand-array/schema.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "MyType": {
+            "type": "object",
+            "properties": {
+                "numberArray": {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "stringArray": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "numberArray",
+                "stringArray"
+            ],
+            "additionalProperties": false
+        }
+    },
+    "$ref": "#/definitions/MyType"
+}


### PR DESCRIPTION
This will fix that a shorthand array type with the readonly modifier becomes a number type in JSON schema.

```ts
interface Type {
  prop: readonly string[]
}
```

Closes https://github.com/vega/ts-json-schema-generator/issues/415