### PR TITLE
feat: support "[T] extends [never]" check

### DIFF
--- a/src/NodeParser/TupleNodeParser.ts
+++ b/src/NodeParser/TupleNodeParser.ts
@@ -3,7 +3,6 @@ import { Context, NodeParser } from "../NodeParser";
 import { SubNodeParser } from "../SubNodeParser";
 import { BaseType } from "../Type/BaseType";
 import { TupleType } from "../Type/TupleType";
-import { notUndefined } from "../Utils/notUndefined";
 
 export class TupleNodeParser implements SubNodeParser {
     public constructor(private typeChecker: ts.TypeChecker, private childNodeParser: NodeParser) {}
@@ -14,11 +13,9 @@ export class TupleNodeParser implements SubNodeParser {
 
     public createType(node: ts.TupleTypeNode, context: Context): BaseType {
         return new TupleType(
-            node.elements
-                .map((item) => {
-                    return this.childNodeParser.createType(item, context);
-                })
-                .filter(notUndefined)
+            node.elements.map((item) => {
+                return this.childNodeParser.createType(item, context);
+            })
         );
     }
 }

--- a/src/Type/TupleType.ts
+++ b/src/Type/TupleType.ts
@@ -1,15 +1,15 @@
 import { BaseType } from "./BaseType";
 
 export class TupleType extends BaseType {
-    public constructor(private types: readonly BaseType[]) {
+    public constructor(private types: readonly (BaseType | undefined)[]) {
         super();
     }
 
     public getId(): string {
-        return `[${this.types.map((item) => item.getId()).join(",")}]`;
+        return `[${this.types.map((item) => item?.getId() ?? "never").join(",")}]`;
     }
 
-    public getTypes(): readonly BaseType[] {
+    public getTypes(): readonly (BaseType | undefined)[] {
         return this.types;
     }
 }

--- a/src/Type/UnionType.ts
+++ b/src/Type/UnionType.ts
@@ -4,7 +4,7 @@ import { uniqueTypeArray } from "../Utils/uniqueTypeArray";
 export class UnionType extends BaseType {
     private readonly types: BaseType[];
 
-    public constructor(types: readonly BaseType[]) {
+    public constructor(types: readonly (BaseType | undefined)[]) {
         super();
         this.types = uniqueTypeArray(
             types.reduce((flatTypes, type) => {

--- a/src/TypeFormatter/TupleTypeFormatter.ts
+++ b/src/TypeFormatter/TupleTypeFormatter.ts
@@ -5,6 +5,7 @@ import { OptionalType } from "../Type/OptionalType";
 import { RestType } from "../Type/RestType";
 import { TupleType } from "../Type/TupleType";
 import { TypeFormatter } from "../TypeFormatter";
+import { notUndefined } from "../Utils/notUndefined";
 import { uniqueArray } from "../Utils/uniqueArray";
 
 export class TupleTypeFormatter implements SubTypeFormatter {
@@ -14,7 +15,7 @@ export class TupleTypeFormatter implements SubTypeFormatter {
         return type instanceof TupleType;
     }
     public getDefinition(type: TupleType): Definition {
-        const subTypes = type.getTypes();
+        const subTypes = type.getTypes().filter(notUndefined);
 
         const requiredElements = subTypes.filter((t) => !(t instanceof OptionalType) && !(t instanceof RestType));
         const optionalElements = subTypes.filter((t) => t instanceof OptionalType) as OptionalType[];
@@ -62,6 +63,7 @@ export class TupleTypeFormatter implements SubTypeFormatter {
         return uniqueArray(
             type
                 .getTypes()
+                .filter(notUndefined)
                 .reduce((result: BaseType[], item) => [...result, ...this.childTypeFormatter.getChildren(item)], [])
         );
     }

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -44,6 +44,7 @@ describe("valid-data-type", () => {
     it("type-intersection-additional-props", assertValidSchema("type-intersection-additional-props", "MyObject"));
     it("type-extend", assertValidSchema("type-extend", "MyObject"));
     it("type-extend-circular", assertValidSchema("type-extend-circular", "MyType"));
+    it("type-extends-never", assertValidSchema("type-extends-never", "MyType"));
 
     it("type-typeof", assertValidSchema("type-typeof", "MyType"));
     it("type-typeof-value", assertValidSchema("type-typeof-value", "MyType"));

--- a/test/valid-data/type-extends-never/main.ts
+++ b/test/valid-data/type-extends-never/main.ts
@@ -1,0 +1,9 @@
+type State<TValues> = [TValues] extends [never]
+    ? {
+          noValuesHere: true;
+      }
+    : {
+          values: TValues;
+      };
+
+export type MyType = State<"a" | "b"> | State<never>;

--- a/test/valid-data/type-extends-never/schema.json
+++ b/test/valid-data/type-extends-never/schema.json
@@ -1,0 +1,39 @@
+{
+  "$ref": "#/definitions/MyType",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyType": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "values": {
+              "type": "string",
+              "enum": [
+                "a",
+                "b"
+              ]
+            }
+          },
+          "required": [
+            "values"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "noValuesHere": {
+              "type": "boolean",
+              "const": true
+            }
+          },
+          "required": [
+            "noValuesHere"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR addresses an issue where  `[T] extends [never]` always evaluates to true because the `never` type is removed from tuples.
I considered adding a `NeverType` but that is a bigger change affecting way more files.