### PR TITLE
feat: Add ability to augment the parser

### DIFF
--- a/factory/parser.ts
+++ b/factory/parser.ts
@@ -50,8 +50,11 @@ import { FunctionNodeParser } from "./../src/NodeParser/FunctionNodeParser";
 import { ObjectLiteralExpressionNodeParser } from "./../src/NodeParser/ObjectLiteralExpressionNodeParser";
 import { ArrayLiteralExpressionNodeParser } from "../src/NodeParser/ArrayLiteralExpressionNodeParser";
 import { PropertyAccessExpressionParser } from "../src/NodeParser/PropertyAccessExpressionParser";
+import { MutableParser } from "../src/MutableParser";
 
-export function createParser(program: ts.Program, config: Config): NodeParser {
+export type ParserAugmentor = (parser: MutableParser) => void;
+
+export function createParser(program: ts.Program, config: Config, augmentor?: ParserAugmentor): NodeParser {
     const typeChecker = program.getTypeChecker();
     const chainNodeParser = new ChainNodeParser(typeChecker, []);
 
@@ -75,6 +78,10 @@ export function createParser(program: ts.Program, config: Config): NodeParser {
     }
     function withCircular(nodeParser: SubNodeParser): SubNodeParser {
         return new CircularReferenceNodeParser(nodeParser);
+    }
+
+    if (augmentor) {
+        augmentor(chainNodeParser);
     }
 
     chainNodeParser

--- a/src/ChainNodeParser.ts
+++ b/src/ChainNodeParser.ts
@@ -1,11 +1,12 @@
 import ts from "typescript";
 import { UnknownNodeError } from "./Error/UnknownNodeError";
+import { MutableParser } from "./MutableParser";
 import { Context } from "./NodeParser";
 import { SubNodeParser } from "./SubNodeParser";
 import { BaseType } from "./Type/BaseType";
 import { ReferenceType } from "./Type/ReferenceType";
 
-export class ChainNodeParser implements SubNodeParser {
+export class ChainNodeParser implements SubNodeParser, MutableParser {
     private readonly typeCaches = new WeakMap<ts.Node, Map<string, BaseType | undefined>>();
 
     public constructor(private typeChecker: ts.TypeChecker, private nodeParsers: SubNodeParser[]) {}

--- a/src/MutableParser.ts
+++ b/src/MutableParser.ts
@@ -1,0 +1,5 @@
+import { SubNodeParser } from "./SubNodeParser";
+
+export interface MutableParser {
+    addNodeParser(parser: SubNodeParser): MutableParser;
+}

--- a/test/config/custom-formatter-configuration/custom-formatter-configuration-override/main.ts
+++ b/test/config/custom-formatter-configuration/custom-formatter-configuration-override/main.ts
@@ -1,0 +1,47 @@
+export interface ExportInterface {
+    exportValue: string;
+}
+export type ExportAlias = ExportInterface;
+
+interface PrivateInterface {
+    privateValue: string;
+}
+type PrivateAlias = PrivateInterface;
+
+interface MixedInterface {
+    mixedValue: ExportAlias;
+}
+export type MixedAlias = PrivateInterface;
+
+
+export type PublicAnonymousTypeLiteral = {
+    publicValue: string;
+};
+
+type PrivateAnonymousTypeLiteral = {
+    privateValue: string;
+};
+
+enum Direction {
+    Up,
+    Down,
+    Left,
+    Right,
+}
+
+export interface MyObject {
+    exportInterface: ExportInterface;
+    exportAlias: ExportAlias;
+
+    privateInterface: PrivateInterface;
+    privateAlias: PrivateAlias;
+
+    mixedInterface: MixedInterface;
+    mixedAlias: MixedAlias;
+
+    publicAnonymousTypeLiteral: PublicAnonymousTypeLiteral;
+    privateAnonymousTypeLiteral: PrivateAnonymousTypeLiteral;
+
+    exportedEnum: Direction
+}
+

--- a/test/config/custom-formatter-configuration/custom-formatter-configuration-override/schema.json
+++ b/test/config/custom-formatter-configuration/custom-formatter-configuration-override/schema.json
@@ -1,0 +1,135 @@
+{
+    "$ref": "#/definitions/MyObject",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "ExportInterface": {
+            "type": "object",
+            "properties": {
+                "exportValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "exportValue"
+            ],
+            "additionalProperties": false
+        },
+        "ExportAlias": {
+            "$ref": "#/definitions/ExportInterface"
+        },
+        "MixedAlias": {
+            "type": "object",
+            "properties": {
+                "privateValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "privateValue"
+            ],
+            "additionalProperties": false
+        },
+        "PublicAnonymousTypeLiteral": {
+            "type": "object",
+            "properties": {
+                "publicValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "publicValue"
+            ],
+            "additionalProperties": false
+        },
+        "MyObject": {
+            "type": "object",
+            "properties": {
+                "exportInterface": {
+                    "$ref": "#/definitions/ExportInterface"
+                },
+                "exportAlias": {
+                    "$ref": "#/definitions/ExportAlias"
+                },
+                "privateInterface": {
+                    "type": "object",
+                    "properties": {
+                        "privateValue": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "privateValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "privateAlias": {
+                    "type": "object",
+                    "properties": {
+                        "privateValue": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "privateValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "mixedInterface": {
+                    "type": "object",
+                    "properties": {
+                        "mixedValue": {
+                            "$ref": "#/definitions/ExportAlias"
+                        }
+                    },
+                    "required": [
+                        "mixedValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "mixedAlias": {
+                    "$ref": "#/definitions/MixedAlias"
+                },
+                "publicAnonymousTypeLiteral": {
+                    "$ref": "#/definitions/PublicAnonymousTypeLiteral"
+                },
+                "privateAnonymousTypeLiteral": {
+                    "type": "object",
+                    "properties": {
+                        "privateValue": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "privateValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "exportedEnum": {
+                    "type": "object",
+                    "properties": {
+                        "isEnum": {
+                            "type": "boolean",
+                            "const": true
+                        },
+                        "enumLength": {
+                            "type": "number",
+                            "const": 4
+                        }
+                    }
+                }
+            },
+            "required": [
+                "exportInterface",
+                "exportAlias",
+                "privateInterface",
+                "privateAlias",
+                "mixedInterface",
+                "mixedAlias",
+                "publicAnonymousTypeLiteral",
+                "privateAnonymousTypeLiteral",
+                "exportedEnum"
+            ],
+            "additionalProperties": false
+        }
+    }
+}

--- a/test/config/custom-parser-configuration-override/main.ts
+++ b/test/config/custom-parser-configuration-override/main.ts
@@ -1,0 +1,40 @@
+export interface ExportInterface {
+    exportValue: string;
+}
+export type ExportAlias = ExportInterface;
+
+interface PrivateInterface {
+    privateValue: string;
+}
+type PrivateAlias = PrivateInterface;
+
+interface MixedInterface {
+    mixedValue: ExportAlias;
+}
+export type MixedAlias = PrivateInterface;
+
+
+export type PublicAnonymousTypeLiteral = {
+    publicValue: string;
+};
+
+type PrivateAnonymousTypeLiteral = {
+    privateValue: string;
+};
+
+export interface MyObject {
+    exportInterface: ExportInterface;
+    exportAlias: ExportAlias;
+
+    privateInterface: PrivateInterface;
+    privateAlias: PrivateAlias;
+
+    mixedInterface: MixedInterface;
+    mixedAlias: MixedAlias;
+
+    publicAnonymousTypeLiteral: PublicAnonymousTypeLiteral;
+    privateAnonymousTypeLiteral: PrivateAnonymousTypeLiteral;
+
+    exportedNull: null
+}
+

--- a/test/config/custom-parser-configuration-override/schema.json
+++ b/test/config/custom-parser-configuration-override/schema.json
@@ -1,0 +1,125 @@
+{
+    "$ref": "#/definitions/MyObject",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "ExportInterface": {
+            "type": "object",
+            "properties": {
+                "exportValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "exportValue"
+            ],
+            "additionalProperties": false
+        },
+        "ExportAlias": {
+            "$ref": "#/definitions/ExportInterface"
+        },
+        "MixedAlias": {
+            "type": "object",
+            "properties": {
+                "privateValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "privateValue"
+            ],
+            "additionalProperties": false
+        },
+        "PublicAnonymousTypeLiteral": {
+            "type": "object",
+            "properties": {
+                "publicValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "publicValue"
+            ],
+            "additionalProperties": false
+        },
+        "MyObject": {
+            "type": "object",
+            "properties": {
+                "exportInterface": {
+                    "$ref": "#/definitions/ExportInterface"
+                },
+                "exportAlias": {
+                    "$ref": "#/definitions/ExportAlias"
+                },
+                "privateInterface": {
+                    "type": "object",
+                    "properties": {
+                        "privateValue": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "privateValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "privateAlias": {
+                    "type": "object",
+                    "properties": {
+                        "privateValue": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "privateValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "mixedInterface": {
+                    "type": "object",
+                    "properties": {
+                        "mixedValue": {
+                            "$ref": "#/definitions/ExportAlias"
+                        }
+                    },
+                    "required": [
+                        "mixedValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "mixedAlias": {
+                    "$ref": "#/definitions/MixedAlias"
+                },
+                "publicAnonymousTypeLiteral": {
+                    "$ref": "#/definitions/PublicAnonymousTypeLiteral"
+                },
+                "privateAnonymousTypeLiteral": {
+                    "type": "object",
+                    "properties": {
+                        "privateValue": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "privateValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "exportedNull": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "exportInterface",
+                "exportAlias",
+                "privateInterface",
+                "privateAlias",
+                "mixedInterface",
+                "mixedAlias",
+                "publicAnonymousTypeLiteral",
+                "privateAnonymousTypeLiteral",
+                "exportedNull"
+            ],
+            "additionalProperties": false
+        }
+    }
+}

--- a/test/config/custom-parser-configuration/main.ts
+++ b/test/config/custom-parser-configuration/main.ts
@@ -1,0 +1,43 @@
+export interface ExportInterface {
+    exportValue: string;
+}
+export type ExportAlias = ExportInterface;
+
+interface PrivateInterface {
+    privateValue: string;
+}
+type PrivateAlias = PrivateInterface;
+
+interface MixedInterface {
+    mixedValue: ExportAlias;
+}
+export type MixedAlias = PrivateInterface;
+
+
+export type PublicAnonymousTypeLiteral = {
+    publicValue: string;
+};
+
+type PrivateAnonymousTypeLiteral = {
+    privateValue: string;
+};
+
+interface ConstructedInterface {
+    isConstructed: boolean
+}
+
+export interface MyObject {
+    exportInterface: ExportInterface;
+    exportAlias: ExportAlias;
+
+    privateInterface: PrivateInterface;
+    privateAlias: PrivateAlias;
+
+    mixedInterface: MixedInterface;
+    mixedAlias: MixedAlias;
+
+    publicAnonymousTypeLiteral: PublicAnonymousTypeLiteral;
+    privateAnonymousTypeLiteral: PrivateAnonymousTypeLiteral;
+
+    exportedConstructor: (new () => ConstructedInterface);
+}

--- a/test/config/custom-parser-configuration/schema.json
+++ b/test/config/custom-parser-configuration/schema.json
@@ -1,0 +1,125 @@
+{
+    "$ref": "#/definitions/MyObject",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "ExportInterface": {
+            "type": "object",
+            "properties": {
+                "exportValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "exportValue"
+            ],
+            "additionalProperties": false
+        },
+        "ExportAlias": {
+            "$ref": "#/definitions/ExportInterface"
+        },
+        "MixedAlias": {
+            "type": "object",
+            "properties": {
+                "privateValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "privateValue"
+            ],
+            "additionalProperties": false
+        },
+        "PublicAnonymousTypeLiteral": {
+            "type": "object",
+            "properties": {
+                "publicValue": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "publicValue"
+            ],
+            "additionalProperties": false
+        },
+        "MyObject": {
+            "type": "object",
+            "properties": {
+                "exportInterface": {
+                    "$ref": "#/definitions/ExportInterface"
+                },
+                "exportAlias": {
+                    "$ref": "#/definitions/ExportAlias"
+                },
+                "privateInterface": {
+                    "type": "object",
+                    "properties": {
+                        "privateValue": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "privateValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "privateAlias": {
+                    "type": "object",
+                    "properties": {
+                        "privateValue": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "privateValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "mixedInterface": {
+                    "type": "object",
+                    "properties": {
+                        "mixedValue": {
+                            "$ref": "#/definitions/ExportAlias"
+                        }
+                    },
+                    "required": [
+                        "mixedValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "mixedAlias": {
+                    "$ref": "#/definitions/MixedAlias"
+                },
+                "publicAnonymousTypeLiteral": {
+                    "$ref": "#/definitions/PublicAnonymousTypeLiteral"
+                },
+                "privateAnonymousTypeLiteral": {
+                    "type": "object",
+                    "properties": {
+                        "privateValue": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "privateValue"
+                    ],
+                    "additionalProperties": false
+                },
+                "exportedConstructor": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "exportInterface",
+                "exportAlias",
+                "privateInterface",
+                "privateAlias",
+                "mixedInterface",
+                "mixedAlias",
+                "publicAnonymousTypeLiteral",
+                "privateAnonymousTypeLiteral",
+                "exportedConstructor"
+            ],
+            "additionalProperties": false
+        }
+    }
+}


### PR DESCRIPTION
Hello again! 👋

Heres a proposal on how to allow customisation of the parsing step.
It follows the same pattern as the [previous update to formatters](https://github.com/vega/ts-json-schema-generator/pull/565) and allows the consumer to add parsing of unsupported types and to override the built-in parsers.

