### PR TITLE
chore: fix typo in path in example command line usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This project is made possible by a [community of contributors](https://github.co
 
 ```bash
 npm install --save ts-json-schema-generator
-./node_modules/.bin/ts-json-schema-generator --path 'my/project/**.*.ts' --type 'My.Type.Full.Name'
+./node_modules/.bin/ts-json-schema-generator --path 'my/project/**/*.ts' --type 'My.Type.Full.Name'
 ```
 
 Note that different platforms (e.g. Windows) may different path separators so you may have to adjust the command above.


### PR DESCRIPTION
Trying this out and noticed a little typo in the path in the example usage.