### PR TITLE
feat: parameter type selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install --save ts-json-schema-generator
 ./node_modules/.bin/ts-json-schema-generator --path 'my/project/**/*.ts' --type 'My.Type.Selector'
 ```
 
-Note that different platforms (e.g. Windows) may different path separators so you may have to adjust the command above.
+Note that different platforms (e.g. Windows) may use different path separators so you may have to adjust the command above.
 
 ## Programmatic Usage
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This project is made possible by a [community of contributors](https://github.co
 
 ```bash
 npm install --save ts-json-schema-generator
-./node_modules/.bin/ts-json-schema-generator --path 'my/project/**/*.ts' --type 'My.Type.Full.Name'
+./node_modules/.bin/ts-json-schema-generator --path 'my/project/**/*.ts' --type 'My.Type.Selector'
 ```
 
 Note that different platforms (e.g. Windows) may different path separators so you may have to adjust the command above.
@@ -36,7 +36,7 @@ const fs = require("fs");
 const config = {
     path: "path/to/source/file",
     tsconfig: "path/to/tsconfig.json",
-    type: "*", // Or <type-name> if you want to generate schema for that one type only
+    type: "*", // Or <type-selector> if you want to generate schema for that one type only
 };
 
 const output_path = "path/to/output/file";
@@ -95,7 +95,7 @@ import fs from "fs";
 const config = {
     path: "path/to/source/file",
     tsconfig: "path/to/tsconfig.json",
-    type: "*", // Or <type-name> if you want to generate schema for that one type only
+    type: "*", // Or <type-selector> if you want to generate schema for that one type only
 };
 
 // We configure the formatter an add our custom formatter to it.
@@ -145,7 +145,7 @@ import fs from "fs";
 const config = {
     path: "path/to/source/file",
     tsconfig: "path/to/tsconfig.json",
-    type: "*", // Or <type-name> if you want to generate schema for that one type only
+    type: "*", // Or <type-selector> if you want to generate schema for that one type only
 };
 
 const program = createProgram(config);
@@ -171,8 +171,8 @@ fs.writeFile(output_path, schemaString, (err) => {
 -p, --path 'index.ts'
     The path to the TypeScript source file. If this is not provided, the type will be searched in the project specified in the `.tsconfig`.
 
--t, --type 'My.Type.Full.Name'
-    The type the generated schema will represent. If omitted, the generated schema will contain all
+-t, --type 'My.Type.Selector'
+    The type the generated schema will represent. Can be expressed as either as the Type Reference name or as a type utility (E.g. `Parameters<typeof func>`). If omitted, the generated schema will contain all
     types found in the files matching path. The same is true if '*' is specified.
 
 -i, --id 'generatedSchemaId'

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This project is made possible by a [community of contributors](https://github.co
 
 ```bash
 npm install --save ts-json-schema-generator
-./node_modules/.bin/ts-json-schema-generator --path 'my/project/**/*.ts' --type 'My.Type.Selector'
+./node_modules/.bin/ts-json-schema-generator --path 'my/project/**/*.ts' --type 'My.Type.Name'
 ```
 
 Note that different platforms (e.g. Windows) may use different path separators so you may have to adjust the command above.
@@ -36,7 +36,7 @@ const fs = require("fs");
 const config = {
     path: "path/to/source/file",
     tsconfig: "path/to/tsconfig.json",
-    type: "*", // Or <type-selector> if you want to generate schema for that one type only
+    type: "*", // Or <type-name> if you want to generate schema for that one type only
 };
 
 const output_path = "path/to/output/file";
@@ -95,7 +95,7 @@ import fs from "fs";
 const config = {
     path: "path/to/source/file",
     tsconfig: "path/to/tsconfig.json",
-    type: "*", // Or <type-selector> if you want to generate schema for that one type only
+    type: "*", // Or <type-name> if you want to generate schema for that one type only
 };
 
 // We configure the formatter an add our custom formatter to it.
@@ -145,7 +145,7 @@ import fs from "fs";
 const config = {
     path: "path/to/source/file",
     tsconfig: "path/to/tsconfig.json",
-    type: "*", // Or <type-selector> if you want to generate schema for that one type only
+    type: "*", // Or <type-name> if you want to generate schema for that one type only
 };
 
 const program = createProgram(config);
@@ -171,8 +171,8 @@ fs.writeFile(output_path, schemaString, (err) => {
 -p, --path 'index.ts'
     The path to the TypeScript source file. If this is not provided, the type will be searched in the project specified in the `.tsconfig`.
 
--t, --type 'My.Type.Selector'
-    The type the generated schema will represent. Can be expressed as either as the Type Reference name or as a type utility (e.g. `Parameters<typeof func>`). If omitted, the generated schema will contain all
+-t, --type 'My.Type.Name'
+    The type the generated schema will represent. If omitted, the generated schema will contain all
     types found in the files matching path. The same is true if '*' is specified.
 
 -i, --id 'generatedSchemaId'

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ fs.writeFile(output_path, schemaString, (err) => {
     The path to the TypeScript source file. If this is not provided, the type will be searched in the project specified in the `.tsconfig`.
 
 -t, --type 'My.Type.Selector'
-    The type the generated schema will represent. Can be expressed as either as the Type Reference name or as a type utility (E.g. `Parameters<typeof func>`). If omitted, the generated schema will contain all
+    The type the generated schema will represent. Can be expressed as either as the Type Reference name or as a type utility (e.g. `Parameters<typeof func>`). If omitted, the generated schema will contain all
     types found in the files matching path. The same is true if '*' is specified.
 
 -i, --id 'generatedSchemaId'

--- a/factory/parser.ts
+++ b/factory/parser.ts
@@ -8,6 +8,8 @@ import { Config, DEFAULT_CONFIG } from "../src/Config";
 import { ExposeNodeParser } from "../src/ExposeNodeParser";
 import { NodeParser } from "../src/NodeParser";
 import { AnnotatedNodeParser } from "../src/NodeParser/AnnotatedNodeParser";
+import { FunctionParser } from "../src/NodeParser/FunctionParser";
+import { ParameterParser } from "../src/NodeParser/ParameterParser";
 import { AnyTypeNodeParser } from "../src/NodeParser/AnyTypeNodeParser";
 import { ArrayNodeParser } from "../src/NodeParser/ArrayNodeParser";
 import { BooleanLiteralNodeParser } from "../src/NodeParser/BooleanLiteralNodeParser";
@@ -97,7 +99,8 @@ export function createParser(program: ts.Program, config: Config, augmentor?: Pa
         .addNodeParser(new NeverTypeNodeParser())
         .addNodeParser(new ObjectTypeNodeParser())
         .addNodeParser(new AsExpressionNodeParser(chainNodeParser))
-
+        .addNodeParser(new FunctionParser(chainNodeParser))
+        .addNodeParser(withJsDoc(new ParameterParser(chainNodeParser)))
         .addNodeParser(new StringLiteralNodeParser())
         .addNodeParser(new NumberLiteralNodeParser())
         .addNodeParser(new BooleanLiteralNodeParser())

--- a/src/NodeParser/FunctionParser.ts
+++ b/src/NodeParser/FunctionParser.ts
@@ -1,0 +1,36 @@
+import ts from "typescript";
+import { NodeParser } from "../NodeParser";
+import { Context } from "../NodeParser";
+import { SubNodeParser } from "../SubNodeParser";
+import { ObjectProperty, ObjectType } from "./../Type/ObjectType";
+import { getKey } from "../Utils/nodeKey";
+
+/**
+ * This function parser supports both `FunctionDeclaration` & `ArrowFunction` nodes.
+ * This parser will only parse the input parameters.
+ * TODO: Parse `ReturnType` of the function?
+ */
+export class FunctionParser implements SubNodeParser {
+    constructor(private childNodeParser: NodeParser) {}
+
+    public supportsNode(node: ts.ArrowFunction): boolean {
+        return node.kind === ts.SyntaxKind.ArrowFunction || node.kind === ts.SyntaxKind.FunctionDeclaration;
+    }
+    public createType(node: ts.FunctionTypeNode | ts.ArrowFunction, context: Context): ObjectType | undefined {
+        const parameterTypes = node.parameters.map((parameter) => {
+            return this.childNodeParser.createType(parameter, context);
+        });
+
+        return new ObjectType(
+            `object-${getKey(node, context)}`,
+            [],
+            parameterTypes.map((parameterType, index) => {
+                // If it's missing a questionToken but has an initializer we can consider the property as not required
+                const required = node.parameters[index].questionToken ? false : !node.parameters[index].initializer;
+
+                return new ObjectProperty(node.parameters[index].name.getText(), parameterType, required);
+            }),
+            false
+        );
+    }
+}

--- a/src/NodeParser/ParameterParser.ts
+++ b/src/NodeParser/ParameterParser.ts
@@ -1,0 +1,16 @@
+import ts from "typescript";
+import { NodeParser } from "../NodeParser";
+import { Context } from "../NodeParser";
+import { SubNodeParser } from "../SubNodeParser";
+import { BaseType } from "../Type/BaseType";
+
+export class ParameterParser implements SubNodeParser {
+    constructor(private childNodeParser: NodeParser) {}
+
+    public supportsNode(node: ts.ParameterDeclaration): boolean {
+        return node.kind === ts.SyntaxKind.Parameter;
+    }
+    public createType(node: ts.FunctionTypeNode, context: Context): BaseType | undefined {
+        return this.childNodeParser.createType(node.type, context);
+    }
+}

--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -151,6 +151,9 @@ export class SchemaGenerator {
                     return;
                 }
                 return;
+            case ts.SyntaxKind.ArrowFunction:
+                allTypes.set(`Parameters<typeof ${this.getFullName(node, typeChecker)}>`, node);
+                return;
             default:
                 ts.forEachChild(node, (subnode) => this.inspectNode(subnode, typeChecker, allTypes));
                 return;

--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -151,6 +151,7 @@ export class SchemaGenerator {
                     return;
                 }
                 return;
+            case ts.SyntaxKind.FunctionDeclaration:
             case ts.SyntaxKind.ArrowFunction:
                 allTypes.set(`Parameters<typeof ${this.getFullName(node, typeChecker)}>`, node);
                 return;

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -325,6 +325,14 @@ describe("config", () => {
     );
 
     it(
+        "arrow-function-parameters",
+        assertSchema("arrow-function-parameters", {
+            type: "Parameters<typeof myFunction>",
+            expose: "all",
+        })
+    );
+
+    it(
         "custom-formatter-configuration",
         assertSchema(
             "custom-formatter-configuration",

--- a/test/config/arrow-function-parameters/main.ts
+++ b/test/config/arrow-function-parameters/main.ts
@@ -1,30 +1,13 @@
 /**
- * @minItems 1
- */
-export type MyNonEmptyArray<T> = T[];
-/**
- * @title String field title
- * @minLength 10
- * @format date-time
- * @pattern /^\d+$/
+ * @description Type reference description
  */
 export type StringValue = string;
 
-/**
- * @title String field title
- * @minLength 10
- * @format date-time
- * @pattern /^\d+$/
- */
-export type NumberValue = string;
-
 export const myFunction = (
     stringValue: StringValue,
-    numberValue: NumberValue,
     /**
-     * @nullable
+     * @description Inline parameter description
      */
-    nullableNumber: number,
     optionalArgument?: string,
     optionalArgumentWithDefault: number = 42
 ) => {

--- a/test/config/arrow-function-parameters/main.ts
+++ b/test/config/arrow-function-parameters/main.ts
@@ -1,0 +1,32 @@
+/**
+ * @minItems 1
+ */
+export type MyNonEmptyArray<T> = T[];
+/**
+ * @title String field title
+ * @minLength 10
+ * @format date-time
+ * @pattern /^\d+$/
+ */
+export type StringValue = string;
+
+/**
+ * @title String field title
+ * @minLength 10
+ * @format date-time
+ * @pattern /^\d+$/
+ */
+export type NumberValue = string;
+
+export const myFunction = (
+    stringValue: StringValue,
+    numberValue: NumberValue,
+    /**
+     * @nullable
+     */
+    nullableNumber: number,
+    optionalArgument?: string,
+    optionalArgumentWithDefault: number = 42
+) => {
+    return "whatever";
+};

--- a/test/config/arrow-function-parameters/schema.json
+++ b/test/config/arrow-function-parameters/schema.json
@@ -8,35 +8,20 @@
         "stringValue": {
           "$ref": "#/definitions/StringValue"
         },
-        "numberValue": {
-          "$ref": "#/definitions/NumberValue"
-        },
-        "nullableNumber": {
-          "type": ["number", "null"]
-        },
         "optionalArgument": {
-          "type": "string"
+          "type": "string",
+          "description": "Inline parameter description"
         },
         "optionalArgumentWithDefault": {
           "type": "number"
         }
       },
-      "required": ["stringValue", "numberValue", "nullableNumber"],
+      "required": ["stringValue"],
       "additionalProperties": false
     },
     "StringValue": {
       "type": "string",
-      "title": "String field title",
-      "minLength": 10,
-      "format": "date-time",
-      "pattern": "/^\\d+$/"
-    },
-    "NumberValue": {
-      "type": "string",
-      "title": "String field title",
-      "minLength": 10,
-      "format": "date-time",
-      "pattern": "/^\\d+$/"
+      "description": "Type reference description"
     }
   }
 }

--- a/test/config/arrow-function-parameters/schema.json
+++ b/test/config/arrow-function-parameters/schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Parameters%3Ctypeof%20myFunction%3E",
+  "definitions": {
+    "Parameters<typeof myFunction>": {
+      "type": "object",
+      "properties": {
+        "stringValue": {
+          "$ref": "#/definitions/StringValue"
+        },
+        "numberValue": {
+          "$ref": "#/definitions/NumberValue"
+        },
+        "nullableNumber": {
+          "type": ["number", "null"]
+        },
+        "optionalArgument": {
+          "type": "string"
+        },
+        "optionalArgumentWithDefault": {
+          "type": "number"
+        }
+      },
+      "required": ["stringValue", "numberValue", "nullableNumber"],
+      "additionalProperties": false
+    },
+    "StringValue": {
+      "type": "string",
+      "title": "String field title",
+      "minLength": 10,
+      "format": "date-time",
+      "pattern": "/^\\d+$/"
+    },
+    "NumberValue": {
+      "type": "string",
+      "title": "String field title",
+      "minLength": 10,
+      "format": "date-time",
+      "pattern": "/^\\d+$/"
+    }
+  }
+}

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -8,6 +8,23 @@ describe("valid-data-other", () => {
     it("enums-mixed", assertValidSchema("enums-mixed", "Enum"));
     it("enums-member", assertValidSchema("enums-member", "MyObject"));
 
+    it(
+        "function-parameters-default-value",
+        assertValidSchema("function-parameters-default-value", "Parameters<typeof myFunction>")
+    );
+    it(
+        "function-parameters-jsdoc",
+        assertValidSchema("function-parameters-jsdoc", "Parameters<typeof myFunction>", "basic")
+    );
+    it(
+        "function-parameters-optional",
+        assertValidSchema("function-parameters-optional", "Parameters<typeof myFunction>")
+    );
+    it(
+        "function-parameters-required",
+        assertValidSchema("function-parameters-required", "Parameters<typeof myFunction>")
+    );
+
     it("string-literals", assertValidSchema("string-literals", "MyObject"));
     it("string-literals-inline", assertValidSchema("string-literals-inline", "MyObject"));
     it("string-literals-null", assertValidSchema("string-literals-null", "MyObject"));

--- a/test/valid-data/function-parameters-default-value/main.ts
+++ b/test/valid-data/function-parameters-default-value/main.ts
@@ -1,0 +1,3 @@
+export const myFunction = (paramWithDefault: string = "something") => {
+    return "whatever";
+};

--- a/test/valid-data/function-parameters-default-value/schema.json
+++ b/test/valid-data/function-parameters-default-value/schema.json
@@ -1,0 +1,15 @@
+{
+  "$ref": "#/definitions/Parameters%3Ctypeof%20myFunction%3E",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Parameters<typeof myFunction>": {
+      "type": "object",
+      "properties": {
+        "paramWithDefault": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/test/valid-data/function-parameters-jsdoc/main.ts
+++ b/test/valid-data/function-parameters-jsdoc/main.ts
@@ -1,0 +1,8 @@
+export const myFunction = (
+    /**
+     * @description Inline parameter description
+     */
+    requiredString: string
+) => {
+    return "whatever";
+};

--- a/test/valid-data/function-parameters-jsdoc/schema.json
+++ b/test/valid-data/function-parameters-jsdoc/schema.json
@@ -1,0 +1,17 @@
+{
+  "$ref": "#/definitions/Parameters%3Ctypeof%20myFunction%3E",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Parameters<typeof myFunction>": {
+      "type": "object",
+      "properties": {
+        "requiredString": {
+          "type": "string",
+          "description": "Inline parameter description"
+        }
+      },
+      "required": ["requiredString"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/test/valid-data/function-parameters-optional/main.ts
+++ b/test/valid-data/function-parameters-optional/main.ts
@@ -1,0 +1,3 @@
+export const myFunction = (optionalString?: string) => {
+    return "whatever";
+};

--- a/test/valid-data/function-parameters-optional/schema.json
+++ b/test/valid-data/function-parameters-optional/schema.json
@@ -1,0 +1,15 @@
+{
+  "$ref": "#/definitions/Parameters%3Ctypeof%20myFunction%3E",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Parameters<typeof myFunction>": {
+      "type": "object",
+      "properties": {
+        "optionalString": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/test/valid-data/function-parameters-required/main.ts
+++ b/test/valid-data/function-parameters-required/main.ts
@@ -1,0 +1,3 @@
+export const myFunction = (requiredString: string) => {
+    return "whatever";
+};

--- a/test/valid-data/function-parameters-required/schema.json
+++ b/test/valid-data/function-parameters-required/schema.json
@@ -1,0 +1,16 @@
+{
+  "$ref": "#/definitions/Parameters%3Ctypeof%20myFunction%3E",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Parameters<typeof myFunction>": {
+      "type": "object",
+      "properties": {
+        "requiredString": {
+          "type": "string"
+        }
+      },
+      "required": ["requiredString"],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support for parsing function parameters and exposing them in the JSON schema as `Parameter<typeof func>` ([issue 733](https://github.com/vega/ts-json-schema-generator/issues/733)). Please let me know if you see any problems with this naming, am open for suggestions.

I decided to represent the parameters as an object with the argument names as the property keys. You could argue it should be represented as an array instead but then you would lose the argument name (unless you use the JSON schema `title` property to represent the argument name, but not sure if that makes sense).

I tried to shoehorn my changes into the documentation, but not sure if I'm sure if it makes sense without making bigger documentation changes, I'd be happy to hear your thoughts on it!

With this PR merged we could potentially add support for the `default` property to the outputted JSON schema, but I think that would require bigger changes so I decided not to in this PR. We could also decide to parse the `ReturnType` of the function ([added as a todo in the src/NodeParser/FunctionParser.ts](https://github.com/vega/ts-json-schema-generator/pull/735/files#diff-0f70a1b1c7bbe968d16fc8bddb3dd508adebaa260b1cea2071e9c01f413bf485R11))