### PR TITLE
fix: ensure @asType annotation overrides $ref

### DIFF
--- a/src/TypeFormatter/AnnotatedTypeFormatter.ts
+++ b/src/TypeFormatter/AnnotatedTypeFormatter.ts
@@ -56,6 +56,10 @@ export class AnnotatedTypeFormatter implements SubTypeFormatter {
             ...type.getAnnotations(),
         };
 
+        if ("$ref" in def && "type" in def) {
+            delete def["$ref"];
+        }
+
         if (type.isNullable()) {
             return makeNullable(def);
         }

--- a/test/config/jsdoc-complex-extended/main.ts
+++ b/test/config/jsdoc-complex-extended/main.ts
@@ -63,6 +63,11 @@ export interface MyObject {
      * @nullable
      */
     number: number;
+
+    /**
+     * @asType number
+     */
+    overriddenRefType: MyExportString;
 }
 
 /**

--- a/test/config/jsdoc-complex-extended/schema.json
+++ b/test/config/jsdoc-complex-extended/schema.json
@@ -56,6 +56,9 @@
         },
         "number": {
           "type": ["number", "null"]
+        },
+        "overriddenRefType": {
+          "type": "number"
         }
       },
       "required": [
@@ -66,7 +69,8 @@
         "exportString",
         "privateString",
         "numberArray",
-        "number"
+        "number",
+        "overriddenRefType"
       ],
       "additionalProperties": false,
       "description": "Some description here",


### PR DESCRIPTION
When using the `@asType` annotation on a complex type, a schema containing both a `$ref` and `type` attribute is generated, which is invalid.

The `@asType` annotation should take precedence over the `$ref` since this allows the user to override the detected type - e.g. when a property will be serialized to some other type.

This patch makes the generator behave consistently when using the `@asType` annotation on both simple and complex types.