### PR TITLE
fix: rename Parameters to NamedParameters

### DIFF
--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -156,7 +156,7 @@ export class SchemaGenerator {
                 return;
             case ts.SyntaxKind.FunctionDeclaration:
             case ts.SyntaxKind.ArrowFunction:
-                allTypes.set(`Parameters<typeof ${this.getFullName(node, typeChecker)}>`, node);
+                allTypes.set(`NamedParameters<typeof ${this.getFullName(node, typeChecker)}>`, node);
                 return;
             default:
                 ts.forEachChild(node, (subnode) => this.inspectNode(subnode, typeChecker, allTypes));

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -327,7 +327,7 @@ describe("config", () => {
     it(
         "arrow-function-parameters",
         assertSchema("arrow-function-parameters", {
-            type: "Parameters<typeof myFunction>",
+            type: "NamedParameters<typeof myFunction>",
             expose: "all",
         })
     );

--- a/test/config/arrow-function-parameters/schema.json
+++ b/test/config/arrow-function-parameters/schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$ref": "#/definitions/Parameters%3Ctypeof%20myFunction%3E",
+  "$ref": "#/definitions/NamedParameters%3Ctypeof%20myFunction%3E",
   "definitions": {
-    "Parameters<typeof myFunction>": {
+    "NamedParameters<typeof myFunction>": {
       "type": "object",
       "properties": {
         "stringValue": {

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -10,19 +10,19 @@ describe("valid-data-other", () => {
 
     it(
         "function-parameters-default-value",
-        assertValidSchema("function-parameters-default-value", "Parameters<typeof myFunction>")
+        assertValidSchema("function-parameters-default-value", "NamedParameters<typeof myFunction>")
     );
     it(
         "function-parameters-jsdoc",
-        assertValidSchema("function-parameters-jsdoc", "Parameters<typeof myFunction>", "basic")
+        assertValidSchema("function-parameters-jsdoc", "NamedParameters<typeof myFunction>", "basic")
     );
     it(
         "function-parameters-optional",
-        assertValidSchema("function-parameters-optional", "Parameters<typeof myFunction>")
+        assertValidSchema("function-parameters-optional", "NamedParameters<typeof myFunction>")
     );
     it(
         "function-parameters-required",
-        assertValidSchema("function-parameters-required", "Parameters<typeof myFunction>")
+        assertValidSchema("function-parameters-required", "NamedParameters<typeof myFunction>")
     );
 
     it("string-literals", assertValidSchema("string-literals", "MyObject"));

--- a/test/valid-data/function-parameters-default-value/schema.json
+++ b/test/valid-data/function-parameters-default-value/schema.json
@@ -1,8 +1,8 @@
 {
-  "$ref": "#/definitions/Parameters%3Ctypeof%20myFunction%3E",
+  "$ref": "#/definitions/NamedParameters%3Ctypeof%20myFunction%3E",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "Parameters<typeof myFunction>": {
+    "NamedParameters<typeof myFunction>": {
       "additionalProperties": false,
       "properties": {
         "paramWithDefault": {

--- a/test/valid-data/function-parameters-jsdoc/schema.json
+++ b/test/valid-data/function-parameters-jsdoc/schema.json
@@ -1,8 +1,8 @@
 {
-  "$ref": "#/definitions/Parameters%3Ctypeof%20myFunction%3E",
+  "$ref": "#/definitions/NamedParameters%3Ctypeof%20myFunction%3E",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "Parameters<typeof myFunction>": {
+    "NamedParameters<typeof myFunction>": {
       "additionalProperties": false,
       "properties": {
         "requiredString": {

--- a/test/valid-data/function-parameters-optional/schema.json
+++ b/test/valid-data/function-parameters-optional/schema.json
@@ -1,8 +1,8 @@
 {
-  "$ref": "#/definitions/Parameters%3Ctypeof%20myFunction%3E",
+  "$ref": "#/definitions/NamedParameters%3Ctypeof%20myFunction%3E",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "Parameters<typeof myFunction>": {
+    "NamedParameters<typeof myFunction>": {
       "additionalProperties": false,
       "properties": {
         "optionalString": {

--- a/test/valid-data/function-parameters-required/schema.json
+++ b/test/valid-data/function-parameters-required/schema.json
@@ -1,8 +1,8 @@
 {
-  "$ref": "#/definitions/Parameters%3Ctypeof%20myFunction%3E",
+  "$ref": "#/definitions/NamedParameters%3Ctypeof%20myFunction%3E",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "Parameters<typeof myFunction>": {
+    "NamedParameters<typeof myFunction>": {
       "additionalProperties": false,
       "properties": {
         "requiredString": {


### PR DESCRIPTION
fix: Changed to use NamedParameters instead of Parameters for exported functions. #756 