### PR TITLE
feat: support circular refs in custom formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ export class MyFunctionTypeFormatter implements SubTypeFormatter {
         return type instanceof FunctionType;
     }
 
-    public getDefinition(_type: FunctionType): Definition {
+    public getDefinition(type: FunctionType): Definition {
         // Return a custom schema for the function property.
         return {
             type: "object",
@@ -79,8 +79,15 @@ export class MyFunctionTypeFormatter implements SubTypeFormatter {
         };
     }
 
-    public getChildren(_type: FunctionType): BaseType[] {
+    // If this type does NOT HAVE children, generally all you need is:
+    public getChildren(type: FunctionType): BaseType[] {
         return [];
+    }
+
+    // However, if children ARE supported, you'll need something similar to
+    // this (see src/TypeFormatter/{Array,Definition,etc}.ts for some examples):
+    public getChildren(type: FunctionType): BaseType[] {
+        return this.childTypeFormatter.getChildren(type.getType());
     }
 }
 ```
@@ -99,8 +106,11 @@ const config = {
 };
 
 // We configure the formatter an add our custom formatter to it.
-const formatter = createFormatter(config, (fmt) => {
+const formatter = createFormatter(config, (fmt, circularReferenceTypeFormatter) => {
+    // If your formatter DOES NOT support children, e.g. getChildren() { return [] }:
     fmt.addTypeFormatter(new MyFunctionTypeFormatter());
+    // If your formatter DOES support children, you'll need this reference too:
+    fmt.addTypeFormatter(new MyFunctionTypeFormatter(circularReferenceTypeFormatter));
 });
 
 const program = createProgram(config);

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ import { BaseType, Definition, FunctionType, SubTypeFormatter } from "ts-json-sc
 import ts from "typescript";
 
 export class MyFunctionTypeFormatter implements SubTypeFormatter {
+    // You can skip this line if you don't need childTypeFormatter
+    public constructor(private childTypeFormatter: TypeFormatter) {}
+
     public supportsType(type: FunctionType): boolean {
         return type instanceof FunctionType;
     }

--- a/factory/formatter.ts
+++ b/factory/formatter.ts
@@ -28,14 +28,17 @@ import { UnknownTypeFormatter } from "../src/TypeFormatter/UnknownTypeFormatter"
 import { VoidTypeFormatter } from "../src/TypeFormatter/VoidTypeFormatter";
 import { MutableTypeFormatter } from "../src/MutableTypeFormatter";
 
-export type FormatterAugmentor = (formatter: MutableTypeFormatter) => void;
+export type FormatterAugmentor = (
+    formatter: MutableTypeFormatter,
+    circularReferenceTypeFormatter: CircularReferenceTypeFormatter
+) => void;
 
 export function createFormatter(config: Config, augmentor?: FormatterAugmentor): TypeFormatter {
     const chainTypeFormatter = new ChainTypeFormatter([]);
     const circularReferenceTypeFormatter = new CircularReferenceTypeFormatter(chainTypeFormatter);
 
     if (augmentor) {
-        augmentor(chainTypeFormatter);
+        augmentor(chainTypeFormatter, circularReferenceTypeFormatter);
     }
 
     chainTypeFormatter

--- a/factory/formatter.ts
+++ b/factory/formatter.ts
@@ -30,7 +30,7 @@ import { MutableTypeFormatter } from "../src/MutableTypeFormatter";
 
 export type FormatterAugmentor = (
     formatter: MutableTypeFormatter,
-    circularReferenceTypeFormatter?: CircularReferenceTypeFormatter
+    circularReferenceTypeFormatter: CircularReferenceTypeFormatter
 ) => void;
 
 export function createFormatter(config: Config, augmentor?: FormatterAugmentor): TypeFormatter {

--- a/factory/formatter.ts
+++ b/factory/formatter.ts
@@ -30,7 +30,7 @@ import { MutableTypeFormatter } from "../src/MutableTypeFormatter";
 
 export type FormatterAugmentor = (
     formatter: MutableTypeFormatter,
-    circularReferenceTypeFormatter: CircularReferenceTypeFormatter
+    circularReferenceTypeFormatter?: CircularReferenceTypeFormatter
 ) => void;
 
 export function createFormatter(config: Config, augmentor?: FormatterAugmentor): TypeFormatter {

--- a/test/config/custom-formatter-configuration-circular/main.ts
+++ b/test/config/custom-formatter-configuration-circular/main.ts
@@ -1,0 +1,7 @@
+export interface InnerInterface {
+    exportValue: string;
+}
+
+export interface MyObject {
+    inner: InnerInterface;
+}

--- a/test/config/custom-formatter-configuration-circular/schema.json
+++ b/test/config/custom-formatter-configuration-circular/schema.json
@@ -1,0 +1,28 @@
+{
+  "$comment": "overriden",
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "InnerInterface": {
+      "additionalProperties": false,
+      "properties": {
+        "exportValue": {
+          "type": "string"
+        }
+      },
+      "required": ["exportValue"],
+      "type": "object"
+    },
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "inner": {
+          "$comment": "overriden",
+          "$ref": "#/definitions/InnerInterface"
+        }
+      },
+      "required": ["inner"],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
Closes #820.

* [X] Passes `circularReferenceTypeFormatter` as a 2nd argument to custom augmentor functions.
* [X] Amends custom formatter examples in README with example usage
* [X] Tests that this all functions as expected

I feel compelled to note that I'm fairly new to this project and even to TypeScript, but I don't feel like there was opportunity to do too much damage here :)  Maybe just double check that my explanations in the docs make sense.

Will happily make any amendments you suggest.