### PR TITLE
fix: broken schema since v0.91

### DIFF
--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -331,6 +331,11 @@ describe("config", () => {
             expose: "all",
         })
     );
+    it('function-parameters-all',
+        assertSchema("function-parameters-all", {
+            type: "*",
+        })
+    )
 
     it(
         "custom-formatter-configuration",

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -331,11 +331,12 @@ describe("config", () => {
             expose: "all",
         })
     );
-    it('function-parameters-all',
+    it(
+        "function-parameters-all",
         assertSchema("function-parameters-all", {
             type: "*",
         })
-    )
+    );
 
     it(
         "custom-formatter-configuration",

--- a/test/config/function-parameters-all/main.ts
+++ b/test/config/function-parameters-all/main.ts
@@ -1,0 +1,10 @@
+export type String = string
+
+export const myFunction = (
+    /**
+     * @description Inline parameter description
+     */
+    requiredString: String
+) => {
+    return "whatever";
+};

--- a/test/config/function-parameters-all/schema.json
+++ b/test/config/function-parameters-all/schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "String": {
+      "type": "string"
+    },
+    "NamedParameters<typeof myFunction>": {
+      "additionalProperties": false,
+      "properties": {
+        "requiredString": {
+          "$ref": "#/definitions/String",
+          "description": "Inline parameter description"
+        }
+      },
+      "required": [
+        "requiredString"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/test/invalid-data.test.ts
+++ b/test/invalid-data.test.ts
@@ -33,5 +33,12 @@ describe("invalid-data", () => {
 
     it("script-empty", assertSchema("script-empty", "MyType", `No root type "MyType" found`));
     it("duplicates", assertSchema("duplicates", "MyType", `Type "A" has multiple definitions.`));
-    it("no-function-name", assertSchema("function-parameters-declaration-missing-name", "*", `Unknown node \"export default function () { }`));
+    it(
+        "no-function-name",
+        assertSchema(
+            "function-parameters-declaration-missing-name",
+            "*",
+            `Unknown node "export default function () { }`
+        )
+    );
 });

--- a/test/invalid-data.test.ts
+++ b/test/invalid-data.test.ts
@@ -33,4 +33,5 @@ describe("invalid-data", () => {
 
     it("script-empty", assertSchema("script-empty", "MyType", `No root type "MyType" found`));
     it("duplicates", assertSchema("duplicates", "MyType", `Type "A" has multiple definitions.`));
+    it("no-function-name", assertSchema("function-parameters-declaration-missing-name", "*", `Unknown node \"export default function () { }`));
 });

--- a/test/invalid-data/function-parameters-declaration-missing-name/main.ts
+++ b/test/invalid-data/function-parameters-declaration-missing-name/main.ts
@@ -1,0 +1,1 @@
+export default function () { }

--- a/test/invalid-data/function-parameters-declaration-missing-name/schema.json
+++ b/test/invalid-data/function-parameters-declaration-missing-name/schema.json
@@ -1,0 +1,10 @@
+{
+  "$ref": "#/definitions/NamedParameters%3Ctypeof%20myFunction%3E",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "NamedParameters<typeof myFunction>": {
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -13,6 +13,10 @@ describe("valid-data-other", () => {
         assertValidSchema("function-parameters-default-value", "NamedParameters<typeof myFunction>")
     );
     it(
+        "function-parameters-declaration",
+        assertValidSchema("function-parameters-declaration", "NamedParameters<typeof myFunction>")
+    );
+    it(
         "function-parameters-jsdoc",
         assertValidSchema("function-parameters-jsdoc", "NamedParameters<typeof myFunction>", "basic")
     );

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -24,6 +24,10 @@ describe("valid-data-other", () => {
         "function-parameters-required",
         assertValidSchema("function-parameters-required", "NamedParameters<typeof myFunction>")
     );
+    it(
+        "function-parameters-variable-assignment",
+        assertValidSchema("function-parameters-variable-assignment", "NamedParameters<typeof myFunction>")
+    );
 
     it("string-literals", assertValidSchema("string-literals", "MyObject"));
     it("string-literals-inline", assertValidSchema("string-literals-inline", "MyObject"));

--- a/test/valid-data/function-parameters-declaration/main.ts
+++ b/test/valid-data/function-parameters-declaration/main.ts
@@ -1,0 +1,1 @@
+export function myFunction() { }

--- a/test/valid-data/function-parameters-declaration/schema.json
+++ b/test/valid-data/function-parameters-declaration/schema.json
@@ -1,0 +1,10 @@
+{
+  "$ref": "#/definitions/NamedParameters%3Ctypeof%20myFunction%3E",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "NamedParameters<typeof myFunction>": {
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/test/valid-data/function-parameters-variable-assignment/main.ts
+++ b/test/valid-data/function-parameters-variable-assignment/main.ts
@@ -1,0 +1,1 @@
+export const myFunction = () => { }

--- a/test/valid-data/function-parameters-variable-assignment/schema.json
+++ b/test/valid-data/function-parameters-variable-assignment/schema.json
@@ -1,0 +1,10 @@
+{
+  "$ref": "#/definitions/NamedParameters%3Ctypeof%20myFunction%3E",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "NamedParameters<typeof myFunction>": {
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
 fix Function node parser to return a `DefinitionType` instead of `ObjectType`
Also:
* Add logic to retrieve the name of the function
* Add (conservative) logic to try not get into a scenario where we cannot retrieve a function name
* Add test case for the specific issue (#793)

Should fix #793 