### PR TITLE
fix: update the lint npm script to include all files in the test folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "prepublishOnly": "yarn build",
     "build": "tsc",
     "watch": "tsc -w",
-    "lint": "eslint {src,test,factory}/**/*.ts",
+    "lint": "eslint {src,factory}/**/*.ts test/*.ts test/**/*.ts",
     "format": "yarn lint --fix",
     "test": "jest test/ --verbose",
     "test:fast": "cross-env FAST_TEST=1 jest test/ --verbose",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "prepublishOnly": "yarn build",
     "build": "tsc",
     "watch": "tsc -w",
-    "lint": "eslint {src,factory}/**/*.ts test/*.ts test/**/*.ts",
+    "lint": "eslint '{src,test,factory}/**/*.ts'",
     "format": "yarn lint --fix",
     "test": "jest test/ --verbose",
     "test:fast": "cross-env FAST_TEST=1 jest test/ --verbose",


### PR DESCRIPTION
As far as I can tell only these files were being covered by our lint script:
```
test/unit/AnnotatedTypeFormatter.test.ts
test/unit/String.test.ts
test/unit/deepMerge.test.ts
test/unit/intersectionOfArrays.test.ts
test/unit/isAssignableTo.test.ts
```
It should now cover all (but not the test fixtures, because I assume it we want it that way?)