### PR TITLE
feat: parse jsdoc tags using json5

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "fast-json-stable-stringify": "^2.1.0",
     "glob": "^7.1.7",
     "json-stable-stringify": "^1.0.1",
+    "json5": "^2.2.0",
     "typescript": "~4.3.4"
   },
   "devDependencies": {

--- a/src/AnnotationsReader/BasicAnnotationsReader.ts
+++ b/src/AnnotationsReader/BasicAnnotationsReader.ts
@@ -1,4 +1,4 @@
-import { runInNewContext } from "vm";
+import json5 from "json5";
 import ts from "typescript";
 import { AnnotationsReader } from "../AnnotationsReader";
 import { Annotations } from "../Type/AnnotatedType";
@@ -97,7 +97,7 @@ export class BasicAnnotationsReader implements AnnotationsReader {
     }
     private parseJson(value: string): any {
         try {
-            return runInNewContext(`(${value})`);
+            return json5.parse(value);
         } catch (e) {
             return undefined;
         }

--- a/src/AnnotationsReader/BasicAnnotationsReader.ts
+++ b/src/AnnotationsReader/BasicAnnotationsReader.ts
@@ -1,3 +1,4 @@
+import { runInNewContext } from "vm";
 import ts from "typescript";
 import { AnnotationsReader } from "../AnnotationsReader";
 import { Annotations } from "../Type/AnnotatedType";
@@ -96,7 +97,7 @@ export class BasicAnnotationsReader implements AnnotationsReader {
     }
     private parseJson(value: string): any {
         try {
-            return JSON.parse(value);
+            return runInNewContext(`(${value})`);
         } catch (e) {
             return undefined;
         }

--- a/test/config/jsdoc-complex-basic/main.ts
+++ b/test/config/jsdoc-complex-basic/main.ts
@@ -38,13 +38,13 @@ export interface MyObject {
      * Some ignored comment description
      *
      * @description Export field description
-     * @default {"length": 10}
+     * @default {'length': 10}
      * @nullable
      */
     exportString: MyExportString;
     /**
      * @description Export field description
-     * @default "private"
+     * @default 'private'
      */
     privateString: MyPrivateString;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1727,14 +1727,6 @@
     "@typescript-eslint/typescript-estree" "4.28.2"
     debug "^4.3.1"
 
-"@typescript-eslint/scope-manager@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.28.1.tgz#fd3c20627cdc12933f6d98b386940d8d0ce8a991"
-  integrity sha512-o95bvGKfss6705x7jFGDyS7trAORTy57lwJ+VsYwil/lOUxKQ9tA7Suuq+ciMhJc/1qPwB3XE2DKh9wubW8YYA==
-  dependencies:
-    "@typescript-eslint/types" "4.28.1"
-    "@typescript-eslint/visitor-keys" "4.28.1"
-
 "@typescript-eslint/scope-manager@4.28.2":
   version "4.28.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.28.2.tgz#451dce90303a3ce283750111495d34c9c204e510"
@@ -1743,28 +1735,10 @@
     "@typescript-eslint/types" "4.28.2"
     "@typescript-eslint/visitor-keys" "4.28.2"
 
-"@typescript-eslint/types@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.28.1.tgz#d0f2ecbef3684634db357b9bbfc97b94b828f83f"
-  integrity sha512-4z+knEihcyX7blAGi7O3Fm3O6YRCP+r56NJFMNGsmtdw+NCdpG5SgNz427LS9nQkRVTswZLhz484hakQwB8RRg==
-
 "@typescript-eslint/types@4.28.2":
   version "4.28.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.28.2.tgz#e6b9e234e0e9a66c4d25bab881661e91478223b5"
   integrity sha512-Gr15fuQVd93uD9zzxbApz3wf7ua3yk4ZujABZlZhaxxKY8ojo448u7XTm/+ETpy0V0dlMtj6t4VdDvdc0JmUhA==
-
-"@typescript-eslint/typescript-estree@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.1.tgz#af882ae41740d1f268e38b4d0fad21e7e8d86a81"
-  integrity sha512-GhKxmC4sHXxHGJv8e8egAZeTZ6HI4mLU6S7FUzvFOtsk7ZIDN1ksA9r9DyOgNqowA9yAtZXV0Uiap61bIO81FQ==
-  dependencies:
-    "@typescript-eslint/types" "4.28.1"
-    "@typescript-eslint/visitor-keys" "4.28.1"
-    debug "^4.3.1"
-    globby "^11.0.3"
-    is-glob "^4.0.1"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
 
 "@typescript-eslint/typescript-estree@4.28.2":
   version "4.28.2"
@@ -1778,14 +1752,6 @@
     is-glob "^4.0.1"
     semver "^7.3.5"
     tsutils "^3.21.0"
-
-"@typescript-eslint/visitor-keys@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.1.tgz#162a515ee255f18a6068edc26df793cdc1ec9157"
-  integrity sha512-K4HMrdFqr9PFquPu178SaSb92CaWe2yErXyPumc8cYWxFmhgJsNY9eSePmO05j0JhBvf2Cdhptd6E6Yv9HVHcg==
-  dependencies:
-    "@typescript-eslint/types" "4.28.1"
-    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.28.2":
   version "4.28.2"
@@ -4572,7 +4538,7 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@^2.1.2:
+json5@^2.1.2, json5@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
   integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==


### PR DESCRIPTION
This allows using non-JSON compatible JavaScript features, such as single quotes, backticks, and trailing commas. It’s similar to using `eval()`, but in a sandboxed environment.

This opens up `ts-json-schema-generator` to the following malicious input:

```ts
interface MySchema {
  /**
   * @default function() { while (true) {} }()
   */
  foo: string;
}
```

Alternatively [json5](https://github.com/json5/json5) could be used, but that introduces a new dependency.