### PR TITLE
chore(build): fix branches-ignore syntax in auto publish Github workflow

### DIFF
--- a/.github/workflows/publish-auto.yml
+++ b/.github/workflows/publish-auto.yml
@@ -1,9 +1,10 @@
 name: Publish Auto
 
-on: [push]
-  branches-ignore:
-    # No canary deploys for branches opened by dependabot
-    - 'dependabot/**'
+on:
+  push:
+    branches-ignore:
+      # No canary deploys for branches opened by dependabot
+      - 'dependabot/**'
 
 jobs:
   publish:


### PR DESCRIPTION
## Motivation

- Previous workflow was unable to run https://github.com/vega/ts-json-schema-generator/actions/runs/1054570715
- It was a clash of syntaxes (previous array shorthand not compatible with configuring options with YAML keys)

## Testing

- CI should be green (not sure how it passed before in #856 )

## Notes

Tested the docs in https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-ignoring-branches-and-tags