### PR TITLE
fix: support constants with lambda functions

### DIFF
--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -142,6 +142,13 @@ export class SchemaGenerator {
     }
     protected inspectNode(node: ts.Node, typeChecker: ts.TypeChecker, allTypes: Map<string, ts.Node>): void {
         switch (node.kind) {
+            case ts.SyntaxKind.VariableDeclaration: {
+                const variableDeclarationNode = node as ts.VariableDeclaration;
+                if (variableDeclarationNode.initializer?.kind === ts.SyntaxKind.ArrowFunction) {
+                    this.inspectNode(variableDeclarationNode.initializer, typeChecker, allTypes);
+                }
+                return;
+            }
             case ts.SyntaxKind.InterfaceDeclaration:
             case ts.SyntaxKind.ClassDeclaration:
             case ts.SyntaxKind.EnumDeclaration:

--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -144,7 +144,10 @@ export class SchemaGenerator {
         switch (node.kind) {
             case ts.SyntaxKind.VariableDeclaration: {
                 const variableDeclarationNode = node as ts.VariableDeclaration;
-                if (variableDeclarationNode.initializer?.kind === ts.SyntaxKind.ArrowFunction) {
+                if (
+                    variableDeclarationNode.initializer?.kind === ts.SyntaxKind.ArrowFunction ||
+                    variableDeclarationNode.initializer?.kind === ts.SyntaxKind.FunctionExpression
+                ) {
                     this.inspectNode(variableDeclarationNode.initializer, typeChecker, allTypes);
                 }
                 return;
@@ -162,6 +165,7 @@ export class SchemaGenerator {
                 }
                 return;
             case ts.SyntaxKind.FunctionDeclaration:
+            case ts.SyntaxKind.FunctionExpression:
             case ts.SyntaxKind.ArrowFunction:
                 allTypes.set(`NamedParameters<typeof ${this.getFullName(node, typeChecker)}>`, node);
                 return;

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -32,6 +32,7 @@ describe("valid-data-other", () => {
         "function-parameters-variable-assignment",
         assertValidSchema("function-parameters-variable-assignment", "NamedParameters<typeof myFunction>")
     );
+    it("function-function-syntax", assertValidSchema("function-function-syntax", "NamedParameters<typeof myFunction>"));
 
     it("string-literals", assertValidSchema("string-literals", "MyObject"));
     it("string-literals-inline", assertValidSchema("string-literals-inline", "MyObject"));

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -96,4 +96,5 @@ describe("valid-data-type", () => {
     it("type-conditional-jsdoc", assertValidSchema("type-conditional-jsdoc", "MyObject", "extended"));
 
     it("type-recursive-deep-exclude", assertValidSchema("type-recursive-deep-exclude", "MyType"));
+    it("ignore-export", assertValidSchema("ignore-export", "*"));
 });

--- a/test/valid-data/function-function-syntax/main.ts
+++ b/test/valid-data/function-function-syntax/main.ts
@@ -1,0 +1,1 @@
+export const myFunction = function () {};

--- a/test/valid-data/function-function-syntax/schema.json
+++ b/test/valid-data/function-function-syntax/schema.json
@@ -1,0 +1,10 @@
+{
+  "$ref": "#/definitions/NamedParameters%3Ctypeof%20myFunction%3E",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "NamedParameters<typeof myFunction>": {
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/test/valid-data/ignore-export/main.ts
+++ b/test/valid-data/ignore-export/main.ts
@@ -1,0 +1,10 @@
+// This constant should be ignored
+const foo = [].map(() => {});
+
+export class A {
+    a: string;
+}
+
+export class B {
+    b: string;
+}

--- a/test/valid-data/ignore-export/schema.json
+++ b/test/valid-data/ignore-export/schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "A": {
+      "type": "object",
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "a"
+      ],
+      "additionalProperties": false
+    },
+    "B": {
+      "type": "object",
+      "properties": {
+        "b": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "b"
+      ],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
There's a bug when parsing constants like this:
```
const foo = [].map(()=>{});
```
When a constant is defined that includes a lambda function, the parser fails with the following message:
```
(1 git/ts-json-schema-generator)npx jest --detectOpenHandles -t 'ignore-export'
 FAIL  test/valid-data-type.test.ts
  ● valid-data-type › ignore-export

    Unknown node "() => {}

      45 |         }
      46 |
    > 47 |         throw new UnknownNodeError(node, context.getReference());
         |               ^
      48 |     }
      49 | }
      50 |

      at ChainNodeParser.getNodeParser (src/ChainNodeParser.ts:47:15)
      at ChainNodeParser.createType (src/ChainNodeParser.ts:32:25)
      at TopRefNodeParser.createType (src/TopRefNodeParser.ts:14:47)
      at map (src/SchemaGenerator.ts:32:40)
          at Array.map (<anonymous>)
      at SchemaGenerator.createSchemaFromNodes (src/SchemaGenerator.ts:31:14)
      at SchemaGenerator.createSchema (src/SchemaGenerator.ts:26:21)
      at Object.<anonymous> (test/utils.ts:44:34)
```
This pull request fixes the bug by only traversing variable declaration nodes if they are functions.

This is my first contribution, so please let me know if I should change anything.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.96.0-next.0`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: null[@stevenlandis-rl](https://github.com/stevenlandis-rl)
  
  :heart: Remco Haszing ([@remcohaszing](https://github.com/remcohaszing))
  
  :heart: Cameron Yick ([@hydrosquall](https://github.com/hydrosquall))
  
  #### 🚀 Enhancement
  
  - chore: release [#872](https://github.com/vega/ts-json-schema-generator/pull/872) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@remcohaszing](https://github.com/remcohaszing) [@hydrosquall](https://github.com/hydrosquall) [@domoritz](https://github.com/domoritz))
  - feat: parse jsdoc tags using json5 [#854](https://github.com/vega/ts-json-schema-generator/pull/854) ([@remcohaszing](https://github.com/remcohaszing))
  
  #### 🐛 Bug Fix
  
  - fix: support constants with lambda functions [#940](https://github.com/vega/ts-json-schema-generator/pull/940) ([@stevenlandis-rl](https://github.com/stevenlandis-rl))
  - chore: upgrade deps [#954](https://github.com/vega/ts-json-schema-generator/pull/954) ([@domoritz](https://github.com/domoritz))
  - ci: run tests on pushes to next [#941](https://github.com/vega/ts-json-schema-generator/pull/941) ([@domoritz](https://github.com/domoritz))
  - refactor: optional chaining [#942](https://github.com/vega/ts-json-schema-generator/pull/942) ([@domoritz](https://github.com/domoritz))
  - docs: describe how to merge prs [#880](https://github.com/vega/ts-json-schema-generator/pull/880) ([@domoritz](https://github.com/domoritz))
  - chore(build): fix branches-ignore syntax in auto publish Github workflow [#865](https://github.com/vega/ts-json-schema-generator/pull/865) ([@hydrosquall](https://github.com/hydrosquall))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump @typescript-eslint/parser from 4.31.0 to 4.31.1 [#947](https://github.com/vega/ts-json-schema-generator/pull/947) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.31.0 to 4.31.1 [#949](https://github.com/vega/ts-json-schema-generator/pull/949) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.9.1 to 16.9.3 [#943](https://github.com/vega/ts-json-schema-generator/pull/943) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.31.0 to 10.32.0 [#944](https://github.com/vega/ts-json-schema-generator/pull/944) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.4.0 to 2.4.1 [#945](https://github.com/vega/ts-json-schema-generator/pull/945) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 27.1.1 to 27.2.0 [#946](https://github.com/vega/ts-json-schema-generator/pull/946) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.31.0 to 10.32.0 [#948](https://github.com/vega/ts-json-schema-generator/pull/948) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv from 8.6.2 to 8.6.3 [#950](https://github.com/vega/ts-json-schema-generator/pull/950) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.31.0 to 10.32.0 [#951](https://github.com/vega/ts-json-schema-generator/pull/951) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump codecov/codecov-action from 2.0.3 to 2.1.0 [#938](https://github.com/vega/ts-json-schema-generator/pull/938) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.30.0 to 4.31.0 [#935](https://github.com/vega/ts-json-schema-generator/pull/935) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 4.30.0 to 4.31.0 [#933](https://github.com/vega/ts-json-schema-generator/pull/933) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 8.1.0 to 8.2.0 [#930](https://github.com/vega/ts-json-schema-generator/pull/930) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.3.2 to 2.4.0 [#931](https://github.com/vega/ts-json-schema-generator/pull/931) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.15.4 to 7.15.6 [#932](https://github.com/vega/ts-json-schema-generator/pull/932) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.7.10 to 16.9.1 [#934](https://github.com/vega/ts-json-schema-generator/pull/934) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 27.1.0 to 27.1.1 [#936](https://github.com/vega/ts-json-schema-generator/pull/936) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.4.2 to 4.4.3 [#937](https://github.com/vega/ts-json-schema-generator/pull/937) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 3.4.1 to 4.0.0 [#925](https://github.com/vega/ts-json-schema-generator/pull/925) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.15.0 to 7.15.5 [#922](https://github.com/vega/ts-json-schema-generator/pull/922) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 4.29.3 to 4.30.0 [#926](https://github.com/vega/ts-json-schema-generator/pull/926) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.29.3 to 4.30.0 [#923](https://github.com/vega/ts-json-schema-generator/pull/923) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.7.5 to 16.7.10 [#924](https://github.com/vega/ts-json-schema-generator/pull/924) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.15.0 to 7.15.4 [#927](https://github.com/vega/ts-json-schema-generator/pull/927) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.3.5 to 4.4.2 [#917](https://github.com/vega/ts-json-schema-generator/pull/917) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.7.1 to 16.7.5 [#919](https://github.com/vega/ts-json-schema-generator/pull/919) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 27.0.6 to 27.1.0 [#920](https://github.com/vega/ts-json-schema-generator/pull/920) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 4.29.2 to 4.29.3 [#918](https://github.com/vega/ts-json-schema-generator/pull/918) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.29.2 to 4.29.3 [#921](https://github.com/vega/ts-json-schema-generator/pull/921) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump codecov/codecov-action from 2.0.2 to 2.0.3 [#916](https://github.com/vega/ts-json-schema-generator/pull/916) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.29.1 to 4.29.2 [#911](https://github.com/vega/ts-json-schema-generator/pull/911) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 4.29.1 to 4.29.2 [#912](https://github.com/vega/ts-json-schema-generator/pull/912) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.6.1 to 16.7.1 [#913](https://github.com/vega/ts-json-schema-generator/pull/913) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ts-node from 10.2.0 to 10.2.1 [#914](https://github.com/vega/ts-json-schema-generator/pull/914) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 3.4.0 to 3.4.1 [#915](https://github.com/vega/ts-json-schema-generator/pull/915) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 26.0.24 to 27.0.1 [#905](https://github.com/vega/ts-json-schema-generator/pull/905) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv-formats from 2.1.0 to 2.1.1 [#902](https://github.com/vega/ts-json-schema-generator/pull/902) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.29.0 to 4.29.1 [#904](https://github.com/vega/ts-json-schema-generator/pull/904) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 4.29.0 to 4.29.1 [#909](https://github.com/vega/ts-json-schema-generator/pull/909) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.30.0 to 10.31.0 [#903](https://github.com/vega/ts-json-schema-generator/pull/903) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.30.0 to 10.31.0 [#906](https://github.com/vega/ts-json-schema-generator/pull/906) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.30.0 to 10.31.0 [#907](https://github.com/vega/ts-json-schema-generator/pull/907) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.4.13 to 16.6.1 [#908](https://github.com/vega/ts-json-schema-generator/pull/908) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ts-node from 10.1.0 to 10.2.0 [#910](https://github.com/vega/ts-json-schema-generator/pull/910) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.14.9 to 7.15.0 [#894](https://github.com/vega/ts-json-schema-generator/pull/894) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 4.28.5 to 4.29.0 [#895](https://github.com/vega/ts-json-schema-generator/pull/895) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.28.5 to 4.29.0 [#896](https://github.com/vega/ts-json-schema-generator/pull/896) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.14.5 to 7.15.0 [#898](https://github.com/vega/ts-json-schema-generator/pull/898) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @types/json-schema from 7.0.8 to 7.0.9 [#897](https://github.com/vega/ts-json-schema-generator/pull/897) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.4.9 to 16.4.13 [#899](https://github.com/vega/ts-json-schema-generator/pull/899) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.14.8 to 7.15.0 [#900](https://github.com/vega/ts-json-schema-generator/pull/900) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/setup-node from 2.3.2 to 2.4.0 [#892](https://github.com/vega/ts-json-schema-generator/pull/892) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/setup-node from 2.3.1 to 2.3.2 [#890](https://github.com/vega/ts-json-schema-generator/pull/890) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/setup-node from 2.3.0 to 2.3.1 [#889](https://github.com/vega/ts-json-schema-generator/pull/889) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.4.2 to 16.4.9 [#882](https://github.com/vega/ts-json-schema-generator/pull/882) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 8.0.0 to 8.1.0 [#883](https://github.com/vega/ts-json-schema-generator/pull/883) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.28.4 to 4.28.5 [#884](https://github.com/vega/ts-json-schema-generator/pull/884) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 7.31.0 to 7.32.0 [#885](https://github.com/vega/ts-json-schema-generator/pull/885) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 4.28.4 to 4.28.5 [#886](https://github.com/vega/ts-json-schema-generator/pull/886) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.14.8 to 7.14.9 [#887](https://github.com/vega/ts-json-schema-generator/pull/887) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump codecov/codecov-action from 2.0.1 to 2.0.2 [#877](https://github.com/vega/ts-json-schema-generator/pull/877) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.4.0 to 16.4.2 [#873](https://github.com/vega/ts-json-schema-generator/pull/873) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.29.3 to 10.30.0 [#874](https://github.com/vega/ts-json-schema-generator/pull/874) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.29.3 to 10.30.0 [#875](https://github.com/vega/ts-json-schema-generator/pull/875) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.29.3 to 10.30.0 [#876](https://github.com/vega/ts-json-schema-generator/pull/876) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.14.6 to 7.14.8 [#866](https://github.com/vega/ts-json-schema-generator/pull/866) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.14.7 to 7.14.8 [#867](https://github.com/vega/ts-json-schema-generator/pull/867) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 4.28.3 to 4.28.4 [#868](https://github.com/vega/ts-json-schema-generator/pull/868) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.3.3 to 16.4.0 [#869](https://github.com/vega/ts-json-schema-generator/pull/869) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.28.3 to 4.28.4 [#870](https://github.com/vega/ts-json-schema-generator/pull/870) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/setup-node from 2.2.0 to 2.3.0 [#871](https://github.com/vega/ts-json-schema-generator/pull/871) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore: set up auto for versioning/release management [#856](https://github.com/vega/ts-json-schema-generator/pull/856) ([@remcohaszing](https://github.com/remcohaszing) [@hydrosquall](https://github.com/hydrosquall))
  - chore(deps): bump codecov/codecov-action from 1.5.2 to 2.0.1 [#863](https://github.com/vega/ts-json-schema-generator/pull/863) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.28.2 to 4.28.3 [#857](https://github.com/vega/ts-json-schema-generator/pull/857) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 4.28.2 to 4.28.3 [#859](https://github.com/vega/ts-json-schema-generator/pull/859) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv from 8.6.1 to 8.6.2 [#858](https://github.com/vega/ts-json-schema-generator/pull/858) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 7.30.0 to 7.31.0 [#860](https://github.com/vega/ts-json-schema-generator/pull/860) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.3.1 to 16.3.3 [#861](https://github.com/vega/ts-json-schema-generator/pull/861) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/json-stable-stringify from 1.0.32 to 1.0.33 [#845](https://github.com/vega/ts-json-schema-generator/pull/845) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 4.28.1 to 4.28.2 [#846](https://github.com/vega/ts-json-schema-generator/pull/846) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/glob from 7.1.3 to 7.1.4 [#847](https://github.com/vega/ts-json-schema-generator/pull/847) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ts-node from 10.0.0 to 10.1.0 [#848](https://github.com/vega/ts-json-schema-generator/pull/848) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @types/json-schema from 7.0.7 to 7.0.8 [#849](https://github.com/vega/ts-json-schema-generator/pull/849) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.28.1 to 4.28.2 [#850](https://github.com/vega/ts-json-schema-generator/pull/850) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 26.0.23 to 26.0.24 [#851](https://github.com/vega/ts-json-schema-generator/pull/851) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.0.0 to 16.3.1 [#852](https://github.com/vega/ts-json-schema-generator/pull/852) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 5
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - [@stevenlandis-rl](https://github.com/stevenlandis-rl)
  - Cameron Yick ([@hydrosquall](https://github.com/hydrosquall))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
  - Remco Haszing ([@remcohaszing](https://github.com/remcohaszing))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
