### PR TITLE
ci: run tests on pushes to next

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - next
   pull_request:
+    branches:
+      - next
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   push:
     branches:
-      - master
+      - next
   pull_request:
 
 jobs:


### PR DESCRIPTION
I think this was missing from the updates. We will need to redo this for other repos. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.95.1--canary.941.ae0db8a.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install ts-json-schema-generator@0.95.1--canary.941.ae0db8a.0
  # or 
  yarn add ts-json-schema-generator@0.95.1--canary.941.ae0db8a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
