### PR TITLE
Reproduce test for recursive mapped types + unions

### DIFF
--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -96,4 +96,5 @@ describe("valid-data-type", () => {
     it("type-conditional-jsdoc", assertValidSchema("type-conditional-jsdoc", "MyObject", "extended"));
 
     it("type-recursive-deep-exclude", assertValidSchema("type-recursive-deep-exclude", "MyType"));
+    it("type-recursive-mapped-union", assertValidSchema("type-recursive-mapped-union", "SerializedParent"));
 });

--- a/test/valid-data/type-recursive-mapped-union/main.ts
+++ b/test/valid-data/type-recursive-mapped-union/main.ts
@@ -1,0 +1,45 @@
+type A = {
+    /**
+     * Some comment on property a
+     */
+    a: string;
+};
+
+type B = {
+    /**
+     * Some comment on property b
+     */
+    b?: string;
+    y: string;
+};
+
+type ComposedWithIntersection = (A | B) & {
+    model: string;
+};
+
+type ComposedSingle = A | B;
+
+type Parent = {
+    prop: string;
+    composed_single: ComposedSingle[];
+    composed_with_intersection: ComposedWithIntersection;
+};
+
+type Primitive = string | number | boolean | null | undefined;
+type ComplexProperty = Date;
+
+/**
+ * Comment on mapped type. Should not appear on usages
+ */
+type SerializedDeep<T> = T extends Primitive
+    ? T
+    : T extends ComplexProperty
+    ? string
+    : {
+          [P in keyof T]: SerializedDeep<T[P]>;
+      };
+
+/**
+ * Comment on serialized parent
+ */
+export type SerializedParent = SerializedDeep<Parent>;

--- a/test/valid-data/type-recursive-mapped-union/schema.json
+++ b/test/valid-data/type-recursive-mapped-union/schema.json
@@ -1,0 +1,98 @@
+{
+    "$ref": "#/definitions/SerializedParent",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+      "SerializedParent": {
+        "additionalProperties": false,
+        "description": "Comment on serialized parent",
+        "properties": {
+          "composed_single": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "a": {
+                      "description": "Some comment on property a",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "a"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "b": {
+                      "description": "Some comment on property b",
+                      "type": "string"
+                    },
+                    "y": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "y"
+                  ],
+                  "type": "object"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "composed_with_intersection": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "a": {
+                    "description": "Some comment on property a",
+                    "type": "string"
+                  },
+                  "model": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "a",
+                  "model"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "b": {
+                    "description": "Some comment on property b",
+                    "type": "string"
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "y": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "model",
+                  "y"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "prop": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "prop",
+          "composed_single",
+          "composed_with_intersection"
+        ],
+        "type": "object"
+      }
+    }
+  }


### PR DESCRIPTION
This reproduces the issue described in #952 where recursive mapped types that operate over definitions containing a union will produce an incorrect schema.
