### PR TITLE
fix: JSDoc parser ignores empty annotations

### DIFF
--- a/src/AnnotationsReader/BasicAnnotationsReader.ts
+++ b/src/AnnotationsReader/BasicAnnotationsReader.ts
@@ -79,11 +79,7 @@ export class BasicAnnotationsReader implements AnnotationsReader {
     }
 
     private parseJsDocTag(jsDocTag: ts.JSDocTagInfo): any {
-        if (!jsDocTag.text) {
-            return undefined;
-        }
-
-        const text = jsDocTag.text?.map((part) => part.text).join("");
+        const text = (jsDocTag.text ?? []).map((part) => part.text).join("");
         if (BasicAnnotationsReader.textTags.has(jsDocTag.name)) {
             return text;
         } else if (BasicAnnotationsReader.jsonTags.has(jsDocTag.name)) {

--- a/src/AnnotationsReader/ExtendedAnnotationsReader.ts
+++ b/src/AnnotationsReader/ExtendedAnnotationsReader.ts
@@ -63,10 +63,11 @@ export class ExtendedAnnotationsReader extends BasicAnnotationsReader {
         }
 
         const jsDocTag = jsDocTags.find((tag) => tag.name === "asType");
-        if (!jsDocTag || !jsDocTag.text) {
+        if (!jsDocTag) {
             return undefined;
         }
 
-        return { type: jsDocTag.text[0].text };
+        const text = (jsDocTag.text ?? []).map((part) => part.text).join("");
+        return { type: text };
     }
 }

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -70,6 +70,8 @@ describe("valid-data-other", () => {
         ])
     );
 
+    it("annotation-empty", assertValidSchema("annotation-empty", "MyObject", "basic", ["customEmptyAnnotation"]));
+
     it("nullable-null", assertValidSchema("nullable-null", "MyObject"));
 
     it("undefined-alias", assertValidSchema("undefined-alias", "MyType"));

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -70,7 +70,11 @@ describe("valid-data-other", () => {
         ])
     );
 
-    it("annotation-empty", assertValidSchema("annotation-empty", "MyObject", "basic", ["customEmptyAnnotation"]));
+    it("annotation-empty-basic", assertValidSchema("annotation-empty", "MyObject", "basic", ["customEmptyAnnotation"]));
+    it(
+        "annotation-empty-extended",
+        assertValidSchema("annotation-empty", "MyObject", "extended", ["customEmptyAnnotation"])
+    );
 
     it("nullable-null", assertValidSchema("nullable-null", "MyObject"));
 

--- a/test/valid-data/annotation-empty/main.ts
+++ b/test/valid-data/annotation-empty/main.ts
@@ -1,0 +1,4 @@
+/**
+ * @customEmptyAnnotation
+ */
+export interface MyObject {}

--- a/test/valid-data/annotation-empty/schema.json
+++ b/test/valid-data/annotation-empty/schema.json
@@ -1,0 +1,11 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "customEmptyAnnotation": "",
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #972
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.96.0-next.1`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: null[@stevenlandis-rl](https://github.com/stevenlandis-rl)
  
  :heart: Remco Haszing ([@remcohaszing](https://github.com/remcohaszing))
  
  :heart: Cameron Yick ([@hydrosquall](https://github.com/hydrosquall))
  
  #### 🚀 Enhancement
  
  - chore: release [#872](https://github.com/vega/ts-json-schema-generator/pull/872) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@remcohaszing](https://github.com/remcohaszing) [@hydrosquall](https://github.com/hydrosquall) [@domoritz](https://github.com/domoritz))
  - feat: parse jsdoc tags using json5 [#854](https://github.com/vega/ts-json-schema-generator/pull/854) ([@remcohaszing](https://github.com/remcohaszing))
  
  #### 🐛 Bug Fix
  
  - fix: JSDoc parser ignores empty annotations [#973](https://github.com/vega/ts-json-schema-generator/pull/973) ([@stevenlandis-rl](https://github.com/stevenlandis-rl))
  - fix: support constants with lambda functions [#940](https://github.com/vega/ts-json-schema-generator/pull/940) ([@stevenlandis-rl](https://github.com/stevenlandis-rl))
  - chore: upgrade deps [#954](https://github.com/vega/ts-json-schema-generator/pull/954) ([@domoritz](https://github.com/domoritz))
  - ci: run tests on pushes to next [#941](https://github.com/vega/ts-json-schema-generator/pull/941) ([@domoritz](https://github.com/domoritz))
  - refactor: optional chaining [#942](https://github.com/vega/ts-json-schema-generator/pull/942) ([@domoritz](https://github.com/domoritz))
  - docs: describe how to merge prs [#880](https://github.com/vega/ts-json-schema-generator/pull/880) ([@domoritz](https://github.com/domoritz))
  - chore(build): fix branches-ignore syntax in auto publish Github workflow [#865](https://github.com/vega/ts-json-schema-generator/pull/865) ([@hydrosquall](https://github.com/hydrosquall))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump jest from 27.2.2 to 27.2.4 [#965](https://github.com/vega/ts-json-schema-generator/pull/965) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 4.31.2 to 4.32.0 [#966](https://github.com/vega/ts-json-schema-generator/pull/966) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.32.0 to 10.32.1 [#967](https://github.com/vega/ts-json-schema-generator/pull/967) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.32.0 to 10.32.1 [#968](https://github.com/vega/ts-json-schema-generator/pull/968) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.10.1 to 16.10.2 [#969](https://github.com/vega/ts-json-schema-generator/pull/969) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.32.0 to 10.32.1 [#970](https://github.com/vega/ts-json-schema-generator/pull/970) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.31.2 to 4.32.0 [#971](https://github.com/vega/ts-json-schema-generator/pull/971) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/setup-node from 2.4.0 to 2.4.1 [#964](https://github.com/vega/ts-json-schema-generator/pull/964) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 27.2.0 to 27.2.2 [#962](https://github.com/vega/ts-json-schema-generator/pull/962) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega from 5.20.2 to 5.21.0 [#956](https://github.com/vega/ts-json-schema-generator/pull/956) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest-junit from 12.2.0 to 12.3.0 [#957](https://github.com/vega/ts-json-schema-generator/pull/957) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 27.0.1 to 27.0.2 [#958](https://github.com/vega/ts-json-schema-generator/pull/958) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump glob from 7.1.7 to 7.2.0 [#959](https://github.com/vega/ts-json-schema-generator/pull/959) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 4.31.1 to 4.31.2 [#960](https://github.com/vega/ts-json-schema-generator/pull/960) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.9.4 to 16.10.1 [#961](https://github.com/vega/ts-json-schema-generator/pull/961) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.31.1 to 4.31.2 [#963](https://github.com/vega/ts-json-schema-generator/pull/963) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 4.31.0 to 4.31.1 [#947](https://github.com/vega/ts-json-schema-generator/pull/947) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.31.0 to 4.31.1 [#949](https://github.com/vega/ts-json-schema-generator/pull/949) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.9.1 to 16.9.3 [#943](https://github.com/vega/ts-json-schema-generator/pull/943) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.31.0 to 10.32.0 [#944](https://github.com/vega/ts-json-schema-generator/pull/944) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.4.0 to 2.4.1 [#945](https://github.com/vega/ts-json-schema-generator/pull/945) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 27.1.1 to 27.2.0 [#946](https://github.com/vega/ts-json-schema-generator/pull/946) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.31.0 to 10.32.0 [#948](https://github.com/vega/ts-json-schema-generator/pull/948) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv from 8.6.2 to 8.6.3 [#950](https://github.com/vega/ts-json-schema-generator/pull/950) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.31.0 to 10.32.0 [#951](https://github.com/vega/ts-json-schema-generator/pull/951) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump codecov/codecov-action from 2.0.3 to 2.1.0 [#938](https://github.com/vega/ts-json-schema-generator/pull/938) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.30.0 to 4.31.0 [#935](https://github.com/vega/ts-json-schema-generator/pull/935) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 4.30.0 to 4.31.0 [#933](https://github.com/vega/ts-json-schema-generator/pull/933) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 8.1.0 to 8.2.0 [#930](https://github.com/vega/ts-json-schema-generator/pull/930) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.3.2 to 2.4.0 [#931](https://github.com/vega/ts-json-schema-generator/pull/931) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.15.4 to 7.15.6 [#932](https://github.com/vega/ts-json-schema-generator/pull/932) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.7.10 to 16.9.1 [#934](https://github.com/vega/ts-json-schema-generator/pull/934) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 27.1.0 to 27.1.1 [#936](https://github.com/vega/ts-json-schema-generator/pull/936) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.4.2 to 4.4.3 [#937](https://github.com/vega/ts-json-schema-generator/pull/937) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 3.4.1 to 4.0.0 [#925](https://github.com/vega/ts-json-schema-generator/pull/925) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.15.0 to 7.15.5 [#922](https://github.com/vega/ts-json-schema-generator/pull/922) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 4.29.3 to 4.30.0 [#926](https://github.com/vega/ts-json-schema-generator/pull/926) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.29.3 to 4.30.0 [#923](https://github.com/vega/ts-json-schema-generator/pull/923) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.7.5 to 16.7.10 [#924](https://github.com/vega/ts-json-schema-generator/pull/924) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.15.0 to 7.15.4 [#927](https://github.com/vega/ts-json-schema-generator/pull/927) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.3.5 to 4.4.2 [#917](https://github.com/vega/ts-json-schema-generator/pull/917) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.7.1 to 16.7.5 [#919](https://github.com/vega/ts-json-schema-generator/pull/919) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 27.0.6 to 27.1.0 [#920](https://github.com/vega/ts-json-schema-generator/pull/920) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 4.29.2 to 4.29.3 [#918](https://github.com/vega/ts-json-schema-generator/pull/918) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.29.2 to 4.29.3 [#921](https://github.com/vega/ts-json-schema-generator/pull/921) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump codecov/codecov-action from 2.0.2 to 2.0.3 [#916](https://github.com/vega/ts-json-schema-generator/pull/916) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.29.1 to 4.29.2 [#911](https://github.com/vega/ts-json-schema-generator/pull/911) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 4.29.1 to 4.29.2 [#912](https://github.com/vega/ts-json-schema-generator/pull/912) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.6.1 to 16.7.1 [#913](https://github.com/vega/ts-json-schema-generator/pull/913) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ts-node from 10.2.0 to 10.2.1 [#914](https://github.com/vega/ts-json-schema-generator/pull/914) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 3.4.0 to 3.4.1 [#915](https://github.com/vega/ts-json-schema-generator/pull/915) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 26.0.24 to 27.0.1 [#905](https://github.com/vega/ts-json-schema-generator/pull/905) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv-formats from 2.1.0 to 2.1.1 [#902](https://github.com/vega/ts-json-schema-generator/pull/902) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.29.0 to 4.29.1 [#904](https://github.com/vega/ts-json-schema-generator/pull/904) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 4.29.0 to 4.29.1 [#909](https://github.com/vega/ts-json-schema-generator/pull/909) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.30.0 to 10.31.0 [#903](https://github.com/vega/ts-json-schema-generator/pull/903) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.30.0 to 10.31.0 [#906](https://github.com/vega/ts-json-schema-generator/pull/906) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.30.0 to 10.31.0 [#907](https://github.com/vega/ts-json-schema-generator/pull/907) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.4.13 to 16.6.1 [#908](https://github.com/vega/ts-json-schema-generator/pull/908) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ts-node from 10.1.0 to 10.2.0 [#910](https://github.com/vega/ts-json-schema-generator/pull/910) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.14.9 to 7.15.0 [#894](https://github.com/vega/ts-json-schema-generator/pull/894) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 4.28.5 to 4.29.0 [#895](https://github.com/vega/ts-json-schema-generator/pull/895) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.28.5 to 4.29.0 [#896](https://github.com/vega/ts-json-schema-generator/pull/896) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.14.5 to 7.15.0 [#898](https://github.com/vega/ts-json-schema-generator/pull/898) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @types/json-schema from 7.0.8 to 7.0.9 [#897](https://github.com/vega/ts-json-schema-generator/pull/897) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.4.9 to 16.4.13 [#899](https://github.com/vega/ts-json-schema-generator/pull/899) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.14.8 to 7.15.0 [#900](https://github.com/vega/ts-json-schema-generator/pull/900) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/setup-node from 2.3.2 to 2.4.0 [#892](https://github.com/vega/ts-json-schema-generator/pull/892) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/setup-node from 2.3.1 to 2.3.2 [#890](https://github.com/vega/ts-json-schema-generator/pull/890) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/setup-node from 2.3.0 to 2.3.1 [#889](https://github.com/vega/ts-json-schema-generator/pull/889) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.4.2 to 16.4.9 [#882](https://github.com/vega/ts-json-schema-generator/pull/882) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 8.0.0 to 8.1.0 [#883](https://github.com/vega/ts-json-schema-generator/pull/883) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.28.4 to 4.28.5 [#884](https://github.com/vega/ts-json-schema-generator/pull/884) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 7.31.0 to 7.32.0 [#885](https://github.com/vega/ts-json-schema-generator/pull/885) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 4.28.4 to 4.28.5 [#886](https://github.com/vega/ts-json-schema-generator/pull/886) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.14.8 to 7.14.9 [#887](https://github.com/vega/ts-json-schema-generator/pull/887) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump codecov/codecov-action from 2.0.1 to 2.0.2 [#877](https://github.com/vega/ts-json-schema-generator/pull/877) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.4.0 to 16.4.2 [#873](https://github.com/vega/ts-json-schema-generator/pull/873) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.29.3 to 10.30.0 [#874](https://github.com/vega/ts-json-schema-generator/pull/874) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.29.3 to 10.30.0 [#875](https://github.com/vega/ts-json-schema-generator/pull/875) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.29.3 to 10.30.0 [#876](https://github.com/vega/ts-json-schema-generator/pull/876) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.14.6 to 7.14.8 [#866](https://github.com/vega/ts-json-schema-generator/pull/866) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.14.7 to 7.14.8 [#867](https://github.com/vega/ts-json-schema-generator/pull/867) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 4.28.3 to 4.28.4 [#868](https://github.com/vega/ts-json-schema-generator/pull/868) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.3.3 to 16.4.0 [#869](https://github.com/vega/ts-json-schema-generator/pull/869) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.28.3 to 4.28.4 [#870](https://github.com/vega/ts-json-schema-generator/pull/870) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/setup-node from 2.2.0 to 2.3.0 [#871](https://github.com/vega/ts-json-schema-generator/pull/871) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore: set up auto for versioning/release management [#856](https://github.com/vega/ts-json-schema-generator/pull/856) ([@remcohaszing](https://github.com/remcohaszing) [@hydrosquall](https://github.com/hydrosquall))
  - chore(deps): bump codecov/codecov-action from 1.5.2 to 2.0.1 [#863](https://github.com/vega/ts-json-schema-generator/pull/863) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.28.2 to 4.28.3 [#857](https://github.com/vega/ts-json-schema-generator/pull/857) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 4.28.2 to 4.28.3 [#859](https://github.com/vega/ts-json-schema-generator/pull/859) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv from 8.6.1 to 8.6.2 [#858](https://github.com/vega/ts-json-schema-generator/pull/858) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 7.30.0 to 7.31.0 [#860](https://github.com/vega/ts-json-schema-generator/pull/860) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.3.1 to 16.3.3 [#861](https://github.com/vega/ts-json-schema-generator/pull/861) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/json-stable-stringify from 1.0.32 to 1.0.33 [#845](https://github.com/vega/ts-json-schema-generator/pull/845) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 4.28.1 to 4.28.2 [#846](https://github.com/vega/ts-json-schema-generator/pull/846) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/glob from 7.1.3 to 7.1.4 [#847](https://github.com/vega/ts-json-schema-generator/pull/847) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ts-node from 10.0.0 to 10.1.0 [#848](https://github.com/vega/ts-json-schema-generator/pull/848) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @types/json-schema from 7.0.7 to 7.0.8 [#849](https://github.com/vega/ts-json-schema-generator/pull/849) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 4.28.1 to 4.28.2 [#850](https://github.com/vega/ts-json-schema-generator/pull/850) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 26.0.23 to 26.0.24 [#851](https://github.com/vega/ts-json-schema-generator/pull/851) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.0.0 to 16.3.1 [#852](https://github.com/vega/ts-json-schema-generator/pull/852) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 5
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - [@stevenlandis-rl](https://github.com/stevenlandis-rl)
  - Cameron Yick ([@hydrosquall](https://github.com/hydrosquall))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
  - Remco Haszing ([@remcohaszing](https://github.com/remcohaszing))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
