### PR TITLE
fix: fix handling of falsy enums like 0 and ''

### DIFF
--- a/src/NodeParser/MappedTypeNodeParser.ts
+++ b/src/NodeParser/MappedTypeNodeParser.ts
@@ -103,7 +103,7 @@ export class MappedTypeNodeParser implements SubNodeParser {
     private getValues(node: ts.MappedTypeNode, keyListType: EnumType, context: Context): ObjectProperty[] {
         return keyListType
             .getValues()
-            .filter((value: EnumValue) => !!value)
+            .filter((value: EnumValue) => value != null)
             .map((value: EnumValue) => {
                 const type = this.childNodeParser.createType(
                     node.type!,

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -78,6 +78,7 @@ describe("valid-data-type", () => {
     it("type-mapped-enum", assertValidSchema("type-mapped-enum", "MyObject"));
     it("type-mapped-enum-optional", assertValidSchema("type-mapped-enum-optional", "MyObject"));
     it("type-mapped-enum-null", assertValidSchema("type-mapped-enum-null", "MyObject"));
+    it("type-mapped-enum-number", assertValidSchema("type-mapped-enum-number", "MyObject"));
     it("type-mapped-exclude", assertValidSchema("type-mapped-exclude", "MyObject", "extended"));
     it("type-mapped-double-exclude", assertValidSchema("type-mapped-double-exclude", "MyObject", "extended"));
     it("type-mapped-symbol", assertValidSchema("type-mapped-symbol", "MyObject"));

--- a/test/valid-data/type-mapped-enum-number/main.ts
+++ b/test/valid-data/type-mapped-enum-number/main.ts
@@ -1,0 +1,9 @@
+enum Test {
+    A,
+    B,
+    C,
+}
+
+export type MyObject = {
+    [P in Test]: string;
+};

--- a/test/valid-data/type-mapped-enum-number/schema.json
+++ b/test/valid-data/type-mapped-enum-number/schema.json
@@ -1,0 +1,26 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "0": {
+          "type": "string"
+        },
+        "1": {
+          "type": "string"
+        },
+        "2": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "0",
+        "1",
+        "2"
+      ],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
I noticed that zero-valued enums were excluded from generated schemas.