### PR TITLE
chore(release): use bot email for making auto commits

### DIFF
--- a/auto.config.ts
+++ b/auto.config.ts
@@ -13,6 +13,7 @@ export default function rc(): AutoRc {
         // Follow the 2 branch deployment scheme
         // https://intuit.github.io/auto/docs/generated/shipit#next-branch-default
         baseBranch: "stable",        // latest "official" release
-        prereleaseBranches: ["next"] // latest changes (subject to breaking). next, alpha, beta, and other multi-feature test branches can all be added here.
+        prereleaseBranches: ["next"], // latest changes (subject to breaking). next, alpha, beta, and other multi-feature test branches can all be added here.
+        author: "GitHub Actions Bot <vega-actions-bot@users.noreply.github.com>"
     };
 }


### PR DESCRIPTION

## Motivation

- Commits like https://github.com/vega/ts-json-schema-generator/commit/47936528db183db0a74bc94f3045af7b009e3d8c were getting mistagged with the author of the original maintainer of this package, rather than the maintainers of the fork.

## Changes

- Use the auto.rc author rather than the package.json author for making bot commits
- Deployment only, no need to publish a new release

## Notes

- Retrieved bot credentials from https://github.com/vega/vega-lite/commit/01f9691c6491e60e9ac33e4de6cea6f905c486df
- How Auto's author config works
  - Docs: https://intuit.github.io/auto/docs/configuration/autorc#author
  - Implementation: https://github.com/intuit/auto/blob/50bd00790fb471452be3552e0279440a6b7770c9/packages/package-json-utils/src/index.ts#L45-L59