### PR TITLE
fix: json tags that are not json do not default to text

### DIFF
--- a/src/AnnotationsReader/BasicAnnotationsReader.ts
+++ b/src/AnnotationsReader/BasicAnnotationsReader.ts
@@ -83,7 +83,7 @@ export class BasicAnnotationsReader implements AnnotationsReader {
         if (BasicAnnotationsReader.textTags.has(jsDocTag.name)) {
             return text;
         } else if (BasicAnnotationsReader.jsonTags.has(jsDocTag.name)) {
-            return this.parseJson(text);
+            return this.parseJson(text) ?? text;
         } else if (this.extraTags?.has(jsDocTag.name)) {
             return this.parseJson(text) ?? text;
         } else {

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -75,6 +75,14 @@ describe("valid-data-other", () => {
         "annotation-empty-extended",
         assertValidSchema("annotation-empty", "MyObject", "extended", ["customEmptyAnnotation"])
     );
+    it(
+        "annotation-deprecated-empty-basic",
+        assertValidSchema("annotation-deprecated-empty", "MyObject", "basic", ["customEmptyAnnotation"])
+    );
+    it(
+        "annotation-deprecated-empty-extended",
+        assertValidSchema("annotation-deprecated-empty", "MyObject", "extended", ["customEmptyAnnotation"])
+    );
 
     it("nullable-null", assertValidSchema("nullable-null", "MyObject"));
 

--- a/test/valid-data/annotation-deprecated-empty/main.ts
+++ b/test/valid-data/annotation-deprecated-empty/main.ts
@@ -1,0 +1,4 @@
+/**
+ * @deprecated
+ */
+export interface MyObject {}

--- a/test/valid-data/annotation-deprecated-empty/schema.json
+++ b/test/valid-data/annotation-deprecated-empty/schema.json
@@ -1,0 +1,11 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "deprecated": "",
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/test/vega-lite/schema.json
+++ b/test/vega-lite/schema.json
@@ -496,7 +496,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The inner radius in pixels of arc marks. `innerRadius` is an alias for `radius2`."
+          "description": "The inner radius in pixels of arc marks. `innerRadius` is an alias for `radius2`.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "interpolate": {
           "anyOf": [
@@ -597,7 +598,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The outer radius in pixels of arc marks. `outerRadius` is an alias for `radius`."
+          "description": "The outer radius in pixels of arc marks. `outerRadius` is an alias for `radius`.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "padAngle": {
           "anyOf": [
@@ -634,7 +636,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "For arc mark, the primary (outer) radius in pixels.\n\nFor text marks, polar coordinate radial offset, in pixels, of the text from the origin determined by the `x` and `y` properties."
+          "description": "For arc mark, the primary (outer) radius in pixels.\n\nFor text marks, polar coordinate radial offset, in pixels, of the text from the origin determined by the `x` and `y` properties.",
+          "minimum": "0\n\n__Default value:__ `min(plot_width, plot_height)/2`"
         },
         "radius2": {
           "anyOf": [
@@ -645,7 +648,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The secondary (inner) radius in pixels of arc marks."
+          "description": "The secondary (inner) radius in pixels of arc marks.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "shape": {
           "anyOf": [
@@ -3341,7 +3345,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The inner radius in pixels of arc marks. `innerRadius` is an alias for `radius2`."
+          "description": "The inner radius in pixels of arc marks. `innerRadius` is an alias for `radius2`.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "interpolate": {
           "anyOf": [
@@ -3431,7 +3436,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The outer radius in pixels of arc marks. `outerRadius` is an alias for `radius`."
+          "description": "The outer radius in pixels of arc marks. `outerRadius` is an alias for `radius`.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "padAngle": {
           "anyOf": [
@@ -3453,7 +3459,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "For arc mark, the primary (outer) radius in pixels.\n\nFor text marks, polar coordinate radial offset, in pixels, of the text from the origin determined by the `x` and `y` properties."
+          "description": "For arc mark, the primary (outer) radius in pixels.\n\nFor text marks, polar coordinate radial offset, in pixels, of the text from the origin determined by the `x` and `y` properties.",
+          "minimum": "0\n\n__Default value:__ `min(plot_width, plot_height)/2`"
         },
         "radius2": {
           "anyOf": [
@@ -3464,7 +3471,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The secondary (inner) radius in pixels of arc marks."
+          "description": "The secondary (inner) radius in pixels of arc marks.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "shape": {
           "anyOf": [
@@ -12765,6 +12773,7 @@
           "anyOf": [
             {
               "description": "The offset of the legend label.",
+              "minimum": "0\n\n__Default value:__ `4`.",
               "type": "number"
             },
             {
@@ -13585,6 +13594,7 @@
           "anyOf": [
             {
               "description": "The offset of the legend label.",
+              "minimum": "0\n\n__Default value:__ `4`.",
               "type": "number"
             },
             {
@@ -14523,7 +14533,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The inner radius in pixels of arc marks. `innerRadius` is an alias for `radius2`."
+          "description": "The inner radius in pixels of arc marks. `innerRadius` is an alias for `radius2`.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "interpolate": {
           "anyOf": [
@@ -14613,7 +14624,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The outer radius in pixels of arc marks. `outerRadius` is an alias for `radius`."
+          "description": "The outer radius in pixels of arc marks. `outerRadius` is an alias for `radius`.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "padAngle": {
           "anyOf": [
@@ -14650,7 +14662,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "For arc mark, the primary (outer) radius in pixels.\n\nFor text marks, polar coordinate radial offset, in pixels, of the text from the origin determined by the `x` and `y` properties."
+          "description": "For arc mark, the primary (outer) radius in pixels.\n\nFor text marks, polar coordinate radial offset, in pixels, of the text from the origin determined by the `x` and `y` properties.",
+          "minimum": "0\n\n__Default value:__ `min(plot_width, plot_height)/2`"
         },
         "radius2": {
           "anyOf": [
@@ -14661,7 +14674,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The secondary (inner) radius in pixels of arc marks."
+          "description": "The secondary (inner) radius in pixels of arc marks.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "shape": {
           "anyOf": [
@@ -15648,7 +15662,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The inner radius in pixels of arc marks. `innerRadius` is an alias for `radius2`."
+          "description": "The inner radius in pixels of arc marks. `innerRadius` is an alias for `radius2`.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "interpolate": {
           "anyOf": [
@@ -15738,7 +15753,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The outer radius in pixels of arc marks. `outerRadius` is an alias for `radius`."
+          "description": "The outer radius in pixels of arc marks. `outerRadius` is an alias for `radius`.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "padAngle": {
           "anyOf": [
@@ -15760,7 +15776,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "For arc mark, the primary (outer) radius in pixels.\n\nFor text marks, polar coordinate radial offset, in pixels, of the text from the origin determined by the `x` and `y` properties."
+          "description": "For arc mark, the primary (outer) radius in pixels.\n\nFor text marks, polar coordinate radial offset, in pixels, of the text from the origin determined by the `x` and `y` properties.",
+          "minimum": "0\n\n__Default value:__ `min(plot_width, plot_height)/2`"
         },
         "radius2": {
           "anyOf": [
@@ -15771,7 +15788,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The secondary (inner) radius in pixels of arc marks."
+          "description": "The secondary (inner) radius in pixels of arc marks.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "shape": {
           "anyOf": [
@@ -16481,7 +16499,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The inner radius in pixels of arc marks. `innerRadius` is an alias for `radius2`."
+          "description": "The inner radius in pixels of arc marks. `innerRadius` is an alias for `radius2`.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "interpolate": {
           "anyOf": [
@@ -16582,7 +16601,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The outer radius in pixels of arc marks. `outerRadius` is an alias for `radius`."
+          "description": "The outer radius in pixels of arc marks. `outerRadius` is an alias for `radius`.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "padAngle": {
           "anyOf": [
@@ -16619,7 +16639,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "For arc mark, the primary (outer) radius in pixels.\n\nFor text marks, polar coordinate radial offset, in pixels, of the text from the origin determined by the `x` and `y` properties."
+          "description": "For arc mark, the primary (outer) radius in pixels.\n\nFor text marks, polar coordinate radial offset, in pixels, of the text from the origin determined by the `x` and `y` properties.",
+          "minimum": "0\n\n__Default value:__ `min(plot_width, plot_height)/2`"
         },
         "radius2": {
           "anyOf": [
@@ -16630,7 +16651,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The secondary (inner) radius in pixels of arc marks."
+          "description": "The secondary (inner) radius in pixels of arc marks.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "radius2Offset": {
           "anyOf": [
@@ -17882,7 +17904,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The inner radius in pixels of arc marks. `innerRadius` is an alias for `radius2`."
+          "description": "The inner radius in pixels of arc marks. `innerRadius` is an alias for `radius2`.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "interpolate": {
           "anyOf": [
@@ -17972,7 +17995,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The outer radius in pixels of arc marks. `outerRadius` is an alias for `radius`."
+          "description": "The outer radius in pixels of arc marks. `outerRadius` is an alias for `radius`.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "padAngle": {
           "anyOf": [
@@ -17994,7 +18018,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "For arc mark, the primary (outer) radius in pixels.\n\nFor text marks, polar coordinate radial offset, in pixels, of the text from the origin determined by the `x` and `y` properties."
+          "description": "For arc mark, the primary (outer) radius in pixels.\n\nFor text marks, polar coordinate radial offset, in pixels, of the text from the origin determined by the `x` and `y` properties.",
+          "minimum": "0\n\n__Default value:__ `min(plot_width, plot_height)/2`"
         },
         "radius2": {
           "anyOf": [
@@ -18005,7 +18030,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The secondary (inner) radius in pixels of arc marks."
+          "description": "The secondary (inner) radius in pixels of arc marks.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "radius2Offset": {
           "anyOf": [
@@ -20090,7 +20116,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The inner radius in pixels of arc marks. `innerRadius` is an alias for `radius2`."
+          "description": "The inner radius in pixels of arc marks. `innerRadius` is an alias for `radius2`.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "interpolate": {
           "anyOf": [
@@ -20180,7 +20207,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The outer radius in pixels of arc marks. `outerRadius` is an alias for `radius`."
+          "description": "The outer radius in pixels of arc marks. `outerRadius` is an alias for `radius`.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "padAngle": {
           "anyOf": [
@@ -20202,7 +20230,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "For arc mark, the primary (outer) radius in pixels.\n\nFor text marks, polar coordinate radial offset, in pixels, of the text from the origin determined by the `x` and `y` properties."
+          "description": "For arc mark, the primary (outer) radius in pixels.\n\nFor text marks, polar coordinate radial offset, in pixels, of the text from the origin determined by the `x` and `y` properties.",
+          "minimum": "0\n\n__Default value:__ `min(plot_width, plot_height)/2`"
         },
         "radius2": {
           "anyOf": [
@@ -20213,7 +20242,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The secondary (inner) radius in pixels of arc marks."
+          "description": "The secondary (inner) radius in pixels of arc marks.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "shape": {
           "anyOf": [
@@ -26762,7 +26792,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The inner radius in pixels of arc marks. `innerRadius` is an alias for `radius2`."
+          "description": "The inner radius in pixels of arc marks. `innerRadius` is an alias for `radius2`.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "interpolate": {
           "anyOf": [
@@ -26852,7 +26883,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The outer radius in pixels of arc marks. `outerRadius` is an alias for `radius`."
+          "description": "The outer radius in pixels of arc marks. `outerRadius` is an alias for `radius`.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "padAngle": {
           "anyOf": [
@@ -26874,7 +26906,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "For arc mark, the primary (outer) radius in pixels.\n\nFor text marks, polar coordinate radial offset, in pixels, of the text from the origin determined by the `x` and `y` properties."
+          "description": "For arc mark, the primary (outer) radius in pixels.\n\nFor text marks, polar coordinate radial offset, in pixels, of the text from the origin determined by the `x` and `y` properties.",
+          "minimum": "0\n\n__Default value:__ `min(plot_width, plot_height)/2`"
         },
         "radius2": {
           "anyOf": [
@@ -26885,7 +26918,8 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "The secondary (inner) radius in pixels of arc marks."
+          "description": "The secondary (inner) radius in pixels of arc marks.",
+          "minimum": "0\n__Default value:__ `0`"
         },
         "shape": {
           "anyOf": [


### PR DESCRIPTION
Addresses [this issue](https://github.com/vega/ts-json-schema-generator/issues/977).

Before, adding a JSDoc tag like `@deprecated` would not appear in the schema because the tag has no text and the empty string is not valid JSON.

This PR changes it so it defaults to text if JSON parsing fails.

This change also exposed a bug in vega-lite typings where Default Value was below some @minimum tags. This PR updates the schema to generate correctly but does not fix the underlying issue in vega-lite. The new schema was generated by setting the `UPDATE_SCHEMA` env variable to true.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.97.0-next.2`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Josh Kelley ([@joshkel](https://github.com/joshkel)), for all your work!
  
  #### 🚀 Enhancement
  
  - feat: handle intersections of aliased unions [#985](https://github.com/vega/ts-json-schema-generator/pull/985) ([@joshkel](https://github.com/joshkel))
  
  #### 🐛 Bug Fix
  
  - fix: json tags that are not json do not default to text [#984](https://github.com/vega/ts-json-schema-generator/pull/984) ([@stevenlandis-rl](https://github.com/stevenlandis-rl))
  - fix: remove sourceRoot [#986](https://github.com/vega/ts-json-schema-generator/pull/986) ([@joshkel](https://github.com/joshkel))
  - chore(release): use bot email for making auto commits [#983](https://github.com/vega/ts-json-schema-generator/pull/983) ([@hydrosquall](https://github.com/hydrosquall))
  - ci: add caching [#982](https://github.com/vega/ts-json-schema-generator/pull/982) ([@domoritz](https://github.com/domoritz))
  - chore: upgrade deps, fix workflow merge [#978](https://github.com/vega/ts-json-schema-generator/pull/978) ([@domoritz](https://github.com/domoritz))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump jest from 27.2.4 to 27.2.5 [#981](https://github.com/vega/ts-json-schema-generator/pull/981) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 5
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - [@stevenlandis-rl](https://github.com/stevenlandis-rl)
  - Cameron Yick ([@hydrosquall](https://github.com/hydrosquall))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
  - Josh Kelley ([@joshkel](https://github.com/joshkel))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
