### PR TITLE
feat: handle intersections of aliased unions

### DIFF
--- a/src/NodeParser/IntersectionNodeParser.ts
+++ b/src/NodeParser/IntersectionNodeParser.ts
@@ -30,7 +30,12 @@ export class IntersectionNodeParser implements SubNodeParser {
 
 function derefAndFlattenUnions(type: BaseType): BaseType[] {
     const derefed = derefType(type);
-    return derefed instanceof UnionType ? derefed.getTypes().flatMap(derefAndFlattenUnions) : [type];
+    return derefed instanceof UnionType
+        ? derefed.getTypes().reduce((result: BaseType[], derefedType: BaseType) => {
+              result.push(...derefAndFlattenUnions(derefedType));
+              return result;
+          }, [])
+        : [type];
 }
 
 /**

--- a/src/NodeParser/IntersectionNodeParser.ts
+++ b/src/NodeParser/IntersectionNodeParser.ts
@@ -28,6 +28,11 @@ export class IntersectionNodeParser implements SubNodeParser {
     }
 }
 
+function derefAndFlattenUnions(type: BaseType): BaseType[] {
+    const derefed = derefType(type);
+    return derefed instanceof UnionType ? derefed.getTypes().flatMap(derefAndFlattenUnions) : [type];
+}
+
 /**
  * Translates the given intersection type into a union type if necessary so `A & (B | C)` becomes
  * `(A & B) | (A & C)`. If no translation is needed then the original intersection type is returned.
@@ -39,10 +44,7 @@ export function translate(types: BaseType[]): BaseType | undefined {
         return types[0];
     }
 
-    const unions = types.map((type) => {
-        const derefed = derefType(type);
-        return derefed instanceof UnionType ? derefed.getTypes() : [type];
-    });
+    const unions = types.map(derefAndFlattenUnions);
     const result: BaseType[] = [];
     function process(i: number, t: BaseType[] = []) {
         for (const type of unions[i]) {

--- a/src/TypeFormatter/IntersectionTypeFormatter.ts
+++ b/src/TypeFormatter/IntersectionTypeFormatter.ts
@@ -17,9 +17,6 @@ export class IntersectionTypeFormatter implements SubTypeFormatter {
     public getDefinition(type: IntersectionType): Definition {
         const types = type.getTypes();
 
-        // FIXME: when we have union types as children, we have to translate.
-        // See https://github.com/vega/ts-json-schema-generator/issues/62
-
         return types.length > 1
             ? types.reduce(getAllOfDefinitionReducer(this.childTypeFormatter), {
                   type: "object",

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -42,6 +42,7 @@ describe("valid-data-type", () => {
     it("type-intersection-union", assertValidSchema("type-intersection-union", "MyObject"));
     it("type-intersection-union-enum", assertValidSchema("type-intersection-union-enum", "MyObject"));
     it("type-intersection-union-primitive", assertValidSchema("type-intersection-union", "MyObject"));
+    it("type-intersection-aliased-union", assertValidSchema("type-intersection-aliased-union", "MyObject"));
     it("type-intersection-additional-props", assertValidSchema("type-intersection-additional-props", "MyObject"));
     it("type-extend", assertValidSchema("type-extend", "MyObject"));
     it("type-extend-circular", assertValidSchema("type-extend-circular", "MyType"));

--- a/test/valid-data/type-intersection-aliased-union/main.ts
+++ b/test/valid-data/type-intersection-aliased-union/main.ts
@@ -1,0 +1,19 @@
+export interface A1 {
+    a1: number;
+}
+
+export interface A2 {
+    a2: number;
+}
+
+export type A = A1 | A2;
+
+export interface B {
+    b: number;
+}
+
+export interface C {
+    c: number;
+}
+
+export type MyObject = (A | B) & C;

--- a/test/valid-data/type-intersection-aliased-union/schema.json
+++ b/test/valid-data/type-intersection-aliased-union/schema.json
@@ -1,0 +1,58 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "a1": {
+              "type": "number"
+            },
+            "c": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "a1",
+            "c"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "a2": {
+              "type": "number"
+            },
+            "c": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "a2",
+            "c"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "b": {
+              "type": "number"
+            },
+            "c": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "b",
+            "c"
+          ],
+          "type": "object"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Handle intersections of aliased unions. ts-json-schema-generator correctly handles basic types like `(A | B) & C`, but if A is itself an alias for `A1 | A2`, it failed.

Delete the FIXME comment and the reference to #62; if I understand correctly, this is correctly handled as of d9b9a15.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.97.0-next.1`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Josh Kelley ([@joshkel](https://github.com/joshkel)), for all your work!
  
  #### 🚀 Enhancement
  
  - feat: handle intersections of aliased unions [#985](https://github.com/vega/ts-json-schema-generator/pull/985) ([@joshkel](https://github.com/joshkel))
  
  #### 🐛 Bug Fix
  
  - fix: remove sourceRoot [#986](https://github.com/vega/ts-json-schema-generator/pull/986) ([@joshkel](https://github.com/joshkel))
  - chore(release): use bot email for making auto commits [#983](https://github.com/vega/ts-json-schema-generator/pull/983) ([@hydrosquall](https://github.com/hydrosquall))
  - ci: add caching [#982](https://github.com/vega/ts-json-schema-generator/pull/982) ([@domoritz](https://github.com/domoritz))
  - chore: upgrade deps, fix workflow merge [#978](https://github.com/vega/ts-json-schema-generator/pull/978) ([@domoritz](https://github.com/domoritz))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump jest from 27.2.4 to 27.2.5 [#981](https://github.com/vega/ts-json-schema-generator/pull/981) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 4
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Cameron Yick ([@hydrosquall](https://github.com/hydrosquall))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
  - Josh Kelley ([@joshkel](https://github.com/joshkel))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
