### PR TITLE
feat: improve handling of unique symbols

### DIFF
--- a/src/NodeParser/CallExpressionParser.ts
+++ b/src/NodeParser/CallExpressionParser.ts
@@ -5,6 +5,7 @@ import { SubNodeParser } from "../SubNodeParser";
 import { BaseType } from "../Type/BaseType";
 import { UnionType } from "../Type/UnionType";
 import { LiteralType } from "../Type/LiteralType";
+import { SymbolType } from "../Type/SymbolType";
 
 export class CallExpressionParser implements SubNodeParser {
     public constructor(private typeChecker: ts.TypeChecker, private childNodeParser: NodeParser) {}
@@ -20,6 +21,11 @@ export class CallExpressionParser implements SubNodeParser {
             return new TupleType([
                 new UnionType((type as any).typeArguments[0].types.map((t: any) => new LiteralType(t.value))),
             ]);
+        }
+
+        // A call expression like Symbol("entity") that resulted in a `unique symbol`
+        if (type.flags === ts.TypeFlags.UniqueESSymbol) {
+            return new SymbolType();
         }
 
         const symbol = type.symbol || type.aliasSymbol;

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -98,6 +98,7 @@ describe("valid-data-other", () => {
     it("keyof-typeof-enum", assertValidSchema("keyof-typeof-enum", "MyObject"));
 
     it("symbol", assertValidSchema("symbol", "MyObject"));
+    it("unique-symbol", assertValidSchema("unique-symbol", "MyObject"));
 
     it("array-min-items-1", assertValidSchema("array-min-items-1", "MyType"));
     it("array-min-items-2", assertValidSchema("array-min-items-2", "MyType"));

--- a/test/valid-data/unique-symbol/main.ts
+++ b/test/valid-data/unique-symbol/main.ts
@@ -1,0 +1,9 @@
+// An explicitly typed unique symbol
+const Foo: unique symbol = Symbol('foo');
+// A unique symbol using type inference
+const Bar = Symbol('bar');
+
+export interface MyObject {
+    foo: typeof Foo;
+    bar: typeof Bar;
+}

--- a/test/valid-data/unique-symbol/schema.json
+++ b/test/valid-data/unique-symbol/schema.json
@@ -1,0 +1,20 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "bar": {
+        },
+        "foo": {
+        }
+      },
+      "required": [
+        "foo",
+        "bar"
+      ],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
ts-json-schema-generator could handle symbols that were explicitly typed with `unique symbol`, but using type inference threw an `UnknownNodeError` with output similar to the following:

```
Error: Unknown node "Symbol('bar')" (ts.SyntaxKind = 252)
```

TypeScript parses the `typeof` as a call expression (like `Symbol("parent")`), and its type checker resolves that as a unique symbol. Relying on the type checker's results seems like a better fix than trying to evaluate the `Symbol("parent")` call expression.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.97.0-next.3`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Josh Kelley ([@joshkel](https://github.com/joshkel)), for all your work!
  
  #### 🚀 Enhancement
  
  - feat: improve handling of unique symbols [#989](https://github.com/vega/ts-json-schema-generator/pull/989) ([@joshkel](https://github.com/joshkel))
  - feat: handle intersections of aliased unions [#985](https://github.com/vega/ts-json-schema-generator/pull/985) ([@joshkel](https://github.com/joshkel))
  
  #### 🐛 Bug Fix
  
  - fix: json tags that are not json do not default to text [#984](https://github.com/vega/ts-json-schema-generator/pull/984) ([@stevenlandis-rl](https://github.com/stevenlandis-rl))
  - fix: remove sourceRoot [#986](https://github.com/vega/ts-json-schema-generator/pull/986) ([@joshkel](https://github.com/joshkel))
  - chore(release): use bot email for making auto commits [#983](https://github.com/vega/ts-json-schema-generator/pull/983) ([@hydrosquall](https://github.com/hydrosquall))
  - ci: add caching [#982](https://github.com/vega/ts-json-schema-generator/pull/982) ([@domoritz](https://github.com/domoritz))
  - chore: upgrade deps, fix workflow merge [#978](https://github.com/vega/ts-json-schema-generator/pull/978) ([@domoritz](https://github.com/domoritz))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump jest from 27.2.4 to 27.2.5 [#981](https://github.com/vega/ts-json-schema-generator/pull/981) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 5
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - [@stevenlandis-rl](https://github.com/stevenlandis-rl)
  - Cameron Yick ([@hydrosquall](https://github.com/hydrosquall))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
  - Josh Kelley ([@joshkel](https://github.com/joshkel))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
