### PR TITLE
feat: Add directory creation to --out

### DIFF
--- a/ts-json-schema-generator.ts
+++ b/ts-json-schema-generator.ts
@@ -1,5 +1,4 @@
 import { Command, Option } from "commander";
-import { mkdir, writeFile } from "fs";
 import stringify from "json-stable-stringify";
 import { createGenerator } from "./factory/generator";
 import { Config, DEFAULT_CONFIG } from "./src/Config";
@@ -7,6 +6,7 @@ import { BaseError } from "./src/Error/BaseError";
 import { formatError } from "./src/Utils/formatError";
 import * as pkg from "./package.json";
 import { dirname } from "path";
+import { mkdirSync, writeFileSync } from "fs";
 
 const args = new Command()
     .option("-p, --path <path>", "Source file path")
@@ -66,12 +66,8 @@ try {
     if (args.out) {
         // write to file
         const outPath = dirname(args.out);
-        mkdir(outPath, { recursive: true }, (dirErr) => {
-            if (dirErr) throw dirErr;
-            writeFile(args.out, schemaString, (fileErr) => {
-                if (fileErr) throw fileErr;
-            });
-        });
+        mkdirSync(outPath, { recursive: true });
+        writeFileSync(args.out, schemaString);
     } else {
         // write to stdout
         process.stdout.write(`${schemaString}\n`);

--- a/ts-json-schema-generator.ts
+++ b/ts-json-schema-generator.ts
@@ -1,11 +1,12 @@
 import { Command, Option } from "commander";
-import { writeFile } from "fs";
+import { mkdir, writeFile } from "fs";
 import stringify from "json-stable-stringify";
 import { createGenerator } from "./factory/generator";
 import { Config, DEFAULT_CONFIG } from "./src/Config";
 import { BaseError } from "./src/Error/BaseError";
 import { formatError } from "./src/Utils/formatError";
 import * as pkg from "./package.json";
+import { dirname } from "path";
 
 const args = new Command()
     .option("-p, --path <path>", "Source file path")
@@ -64,8 +65,12 @@ try {
 
     if (args.out) {
         // write to file
-        writeFile(args.out, schemaString, (err) => {
-            if (err) throw err;
+        const outPath = dirname(args.out);
+        mkdir(outPath, { recursive: true }, (dirErr) => {
+            if (dirErr) throw dirErr;
+            writeFile(args.out, schemaString, (fileErr) => {
+                if (fileErr) throw fileErr;
+            });
         });
     } else {
         // write to stdout


### PR DESCRIPTION
This PR adds recursive directory creation to the --out parameter as proposed in #994.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.97.0-next.4`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: Skip Hendriks ([@SkipHendriks](https://github.com/SkipHendriks))
  
  :heart: Josh Kelley ([@joshkel](https://github.com/joshkel))
  
  #### 🚀 Enhancement
  
  - feat: Add directory creation to --out [#1000](https://github.com/vega/ts-json-schema-generator/pull/1000) (skip.hendriks@posteo.net)
  - feat: improve handling of unique symbols [#989](https://github.com/vega/ts-json-schema-generator/pull/989) ([@joshkel](https://github.com/joshkel))
  - feat: handle intersections of aliased unions [#985](https://github.com/vega/ts-json-schema-generator/pull/985) ([@joshkel](https://github.com/joshkel))
  
  #### 🐛 Bug Fix
  
  - fix: json tags that are not json do not default to text [#984](https://github.com/vega/ts-json-schema-generator/pull/984) ([@stevenlandis-rl](https://github.com/stevenlandis-rl))
  - fix: remove sourceRoot [#986](https://github.com/vega/ts-json-schema-generator/pull/986) ([@joshkel](https://github.com/joshkel))
  - chore(release): use bot email for making auto commits [#983](https://github.com/vega/ts-json-schema-generator/pull/983) ([@hydrosquall](https://github.com/hydrosquall))
  - ci: add caching [#982](https://github.com/vega/ts-json-schema-generator/pull/982) ([@domoritz](https://github.com/domoritz))
  - chore: upgrade deps, fix workflow merge [#978](https://github.com/vega/ts-json-schema-generator/pull/978) ([@domoritz](https://github.com/domoritz))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump @types/glob from 7.1.4 to 7.2.0 [#995](https://github.com/vega/ts-json-schema-generator/pull/995) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 27.2.5 to 27.3.1 [#996](https://github.com/vega/ts-json-schema-generator/pull/996) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.11.1 to 16.11.4 [#997](https://github.com/vega/ts-json-schema-generator/pull/997) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 8.2.0 to 8.3.0 [#998](https://github.com/vega/ts-json-schema-generator/pull/998) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ts-node from 10.3.0 to 10.4.0 [#999](https://github.com/vega/ts-json-schema-generator/pull/999) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ts-node from 10.2.1 to 10.3.0 [#991](https://github.com/vega/ts-json-schema-generator/pull/991) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.4.3 to 4.4.4 [#990](https://github.com/vega/ts-json-schema-generator/pull/990) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.10.3 to 16.11.1 [#992](https://github.com/vega/ts-json-schema-generator/pull/992) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 27.2.4 to 27.2.5 [#981](https://github.com/vega/ts-json-schema-generator/pull/981) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 6
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - [@stevenlandis-rl](https://github.com/stevenlandis-rl)
  - Cameron Yick ([@hydrosquall](https://github.com/hydrosquall))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
  - Josh Kelley ([@joshkel](https://github.com/joshkel))
  - Skip Hendriks ([@SkipHendriks](https://github.com/SkipHendriks))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
