### PR TITLE
chore: replace stable stringify packages with safe-stable-stringify

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,9 +46,8 @@
   "dependencies": {
     "@types/json-schema": "^7.0.9",
     "commander": "^8.2.0",
-    "fast-json-stable-stringify": "^2.1.0",
     "glob": "^7.2.0",
-    "json-stable-stringify": "^1.0.1",
+    "safe-stable-stringify": "^2.2.0",
     "json5": "^2.2.0",
     "typescript": "~4.4.3"
   },
@@ -60,7 +59,6 @@
     "@babel/preset-typescript": "^7.15.0",
     "@types/glob": "^7.1.4",
     "@types/jest": "^27.0.2",
-    "@types/json-stable-stringify": "^1.0.33",
     "@types/node": "^16.10.3",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",

--- a/src/NodeParser.ts
+++ b/src/NodeParser.ts
@@ -1,4 +1,4 @@
-import stringify from "fast-json-stable-stringify";
+import stringify from "safe-stable-stringify";
 import ts from "typescript";
 import { BaseType } from "./Type/BaseType";
 import { ReferenceType } from "./Type/ReferenceType";

--- a/src/Utils/intersectionOfArrays.ts
+++ b/src/Utils/intersectionOfArrays.ts
@@ -1,4 +1,4 @@
-import stringify from "fast-json-stable-stringify";
+import stringify from "safe-stable-stringify";
 
 export function intersectionOfArrays<T>(a: T[], b: T[]): T[] {
     const output: T[] = [];

--- a/src/Utils/nodeKey.ts
+++ b/src/Utils/nodeKey.ts
@@ -1,4 +1,4 @@
-import stringify from "fast-json-stable-stringify";
+import stringify from "safe-stable-stringify";
 import { Node } from "typescript";
 import { Context } from "../NodeParser";
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,7 +1,7 @@
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
 import { readFileSync, writeFileSync } from "fs";
-import stringify from "json-stable-stringify";
+import stringify from "safe-stable-stringify";
 import { resolve } from "path";
 import ts from "typescript";
 import { createFormatter } from "../factory/formatter";
@@ -45,7 +45,7 @@ export function assertValidSchema(
         const schemaFile = resolve(`${basePath}/${relativePath}/schema.json`);
 
         if (process.env.UPDATE_SCHEMA) {
-            writeFileSync(schemaFile, stringify(schema, { space: 2 }) + "\n", "utf8");
+            writeFileSync(schemaFile, stringify(schema, null, 2) + "\n", "utf8");
         }
 
         const expected: any = JSON.parse(readFileSync(schemaFile, "utf8"));

--- a/test/vega-lite.test.ts
+++ b/test/vega-lite.test.ts
@@ -2,7 +2,7 @@ import { readFileSync, writeFileSync } from "fs";
 import { resolve } from "path";
 import { Config } from "../src/Config";
 import { createGenerator } from "./utils";
-import stringify from "json-stable-stringify";
+import stringify from "safe-stable-stringify";
 
 describe("vega-lite", () => {
     it("schema", () => {
@@ -19,7 +19,7 @@ describe("vega-lite", () => {
         const schemaFile = resolve("test/vega-lite/schema.json");
 
         if (process.env.UPDATE_SCHEMA) {
-            writeFileSync(schemaFile, stringify(schema, { space: 2 }) + "\n", "utf8");
+            writeFileSync(schemaFile, stringify(schema, null, 2) + "\n", "utf8");
         }
 
         const vegaLiteSchema = JSON.parse(readFileSync(schemaFile, "utf8"));

--- a/ts-json-schema-generator.ts
+++ b/ts-json-schema-generator.ts
@@ -1,5 +1,5 @@
 import { Command, Option } from "commander";
-import stringify from "json-stable-stringify";
+import stringify from "safe-stable-stringify";
 import { createGenerator } from "./factory/generator";
 import { Config, DEFAULT_CONFIG } from "./src/Config";
 import { BaseError } from "./src/Error/BaseError";
@@ -61,7 +61,7 @@ const config: Config = {
 
 try {
     const schema = createGenerator(config).createSchema(args.type);
-    const schemaString = config.sortProps ? stringify(schema, { space: 2 }) : JSON.stringify(schema, null, 2);
+    const schemaString = config.sortProps ? stringify(schema, null, 2) : JSON.stringify(schema, null, 2);
 
     if (args.out) {
         // write to file

--- a/yarn.lock
+++ b/yarn.lock
@@ -1663,11 +1663,6 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
-"@types/json-stable-stringify@^1.0.33":
-  version "1.0.33"
-  resolved "https://registry.yarnpkg.com/@types/json-stable-stringify/-/json-stable-stringify-1.0.33.tgz#099b0712d824d15e2660c20e1c16e6a8381f308c"
-  integrity sha512-qEWiQff6q2tA5gcJGWwzplQcXdJtm+0oy6IHGHzlOf3eFAkGE/FIPXZK9ofWgNSHVp8AFFI33PJJshS0ei3Gvw==
-
 "@types/minimatch@*":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
@@ -3094,7 +3089,7 @@ fast-json-parse@^1.0.3:
   resolved "https://registry.yarnpkg.com/fast-json-parse/-/fast-json-parse-1.0.3.tgz#43e5c61ee4efa9265633046b770fb682a7577c4d"
   integrity sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==
 
-fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0, fast-json-stable-stringify@~2.1.0:
+fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -4304,13 +4299,6 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json-stable-stringify@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
-  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
-  dependencies:
-    jsonify "~0.0.0"
-
 json-stringify-pretty-compact@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz#f71ef9d82ef16483a407869556588e91b681d9ab"
@@ -4327,11 +4315,6 @@ json5@^2.1.2, json5@^2.2.0:
   integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
   dependencies:
     minimist "^1.2.5"
-
-jsonify@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
-  integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
 jsonparse@^1.2.0:
   version "1.3.1"
@@ -5257,6 +5240,11 @@ safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-stable-stringify@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.2.0.tgz#26a52f13a6988de16a0d88e20248f38e8a7d840c"
+  integrity sha512-C6AuMdYPuPV/P1leplHNu0lgc2LAElq/g3TdoksDCIVtBhr78o/CH03bt/9SKqugFbKU9CUjsNlCu0fjtQzQUw==
 
 "safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"


### PR DESCRIPTION
This is a performance improvement as the latter is actually faster.

fast-json-stable-stringify x 18,765 ops/sec ±0.71% (94 runs sampled)
json-stable-stringify x 13,870 ops/sec ±0.72% (94 runs sampled)
safe-stable-stringify x 30,367 ops/sec ±0.39% (96 runs sampled)

The only difference is that objects with circular reference are from
now on also accepted instead of throwing an error.