### PR TITLE
ci: use GITHUB_TOKEN instead of PAT

### DIFF
--- a/.github/workflows/publish-auto.yml
+++ b/.github/workflows/publish-auto.yml
@@ -26,7 +26,8 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: Create release
+        run: npm run release
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: yarn run release
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-auto.yml
+++ b/.github/workflows/publish-auto.yml
@@ -26,7 +26,7 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: Create release
-        run: npm run release
+        run: yarn release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-auto.yml
+++ b/.github/workflows/publish-auto.yml
@@ -17,7 +17,8 @@ jobs:
 
       - uses: actions/setup-node@v2.4.1
         with:
-          cache: "yarn"
+          registry-url: "https://registry.npmjs.org"
+          node-version: "16"
 
       - name: Prepare repository
         run: git fetch --unshallow --tags
@@ -26,7 +27,7 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: Create release
-        run: yarn release
+        run: npm run release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.97.1--canary.1017.a612074.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install ts-json-schema-generator@0.97.1--canary.1017.a612074.0
  # or 
  yarn add ts-json-schema-generator@0.97.1--canary.1017.a612074.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
