### PR TITLE
feat: append sourceFileName on BaseType, used by TopRefNodeParser and ExposeNodeParser

### DIFF
--- a/src/ExposeNodeParser.ts
+++ b/src/ExposeNodeParser.ts
@@ -21,16 +21,20 @@ export class ExposeNodeParser implements SubNodeParser {
 
     public createType(node: ts.Node, context: Context, reference?: ReferenceType): BaseType | undefined {
         const baseType = this.subNodeParser.createType(node, context, reference);
+        const sourceFileName = node.getSourceFile().fileName;
 
         if (baseType === undefined) {
             return undefined;
         }
 
         if (!this.isExportNode(node)) {
+            baseType.sourceFileName = sourceFileName;
             return baseType;
         }
 
-        return new DefinitionType(this.getDefinitionName(node, context), baseType);
+        const defBaseType = new DefinitionType(this.getDefinitionName(node, context), baseType);
+        defBaseType.sourceFileName = sourceFileName;
+        return defBaseType;
     }
 
     private isExportNode(node: ts.Node): boolean {

--- a/src/TopRefNodeParser.ts
+++ b/src/TopRefNodeParser.ts
@@ -12,16 +12,22 @@ export class TopRefNodeParser implements NodeParser {
 
     public createType(node: ts.Node, context: Context): BaseType | undefined {
         const baseType = this.childNodeParser.createType(node, context);
+        const sourceFileName = node.getSourceFile().fileName;
 
         if (baseType === undefined) {
             return undefined;
         }
 
         if (this.topRef && !(baseType instanceof DefinitionType)) {
-            return new DefinitionType(this.fullName, baseType);
+            const defBaseType = new DefinitionType(this.fullName, baseType);
+            defBaseType.sourceFileName = sourceFileName;
+            return defBaseType;
         } else if (!this.topRef && baseType instanceof DefinitionType) {
-            return baseType.getType();
+            const base = baseType.getType();
+            base.sourceFileName = sourceFileName;
+            return base;
         } else {
+            baseType.sourceFileName = sourceFileName;
             return baseType;
         }
     }

--- a/src/Type/BaseType.ts
+++ b/src/Type/BaseType.ts
@@ -1,4 +1,11 @@
 export abstract class BaseType {
+    /**
+     * sourcecode fileName for DefinitionType. used at TopRefNodeParser
+     * and ExposeNodeParser. so that, you can override DefinitionFormatter
+     * to custome your self DefinitionType name by fileName.
+     */
+    sourceFileName?: string;
+
     public abstract getId(): string;
 
     /**


### PR DESCRIPTION
for this idea https://github.com/vega/ts-json-schema-generator/issues/1018

And here is my custome example

utils/reformatRefDefName.ts
```ts
import {
  BaseType,
  DefinitionType,
  ReferenceType,
} from 'ts-json-schema-generator';

export const reformatDefName = (type: BaseType) => {
  let name = type.getName();
  /** myCustomeName Rule */
  if (!(type instanceof DefinitionType) || /def-\[REQ\]/.test(name)) {
    return name;
  }
  if (/__file:\/\/\//.test(name)) {
    return name;
  }
  const source = (type.sourceFileName || '').replace(process.cwd(), '');
  const ref = name + (source ? `__file:///${source}` : '');
  (type as any).name = ref;
  return ref;
};

export const reformatRefName = (type: any) => {
  let name = type.getName();
  if (!(type instanceof ReferenceType)) {
    return name;
  }
  const isDef = (type as any).type instanceof DefinitionType;
  if (!isDef) return name;
  const defName = (type as any)?.type?.name;
  const isDiff = defName !== name;
  if (isDiff) {
    (type as any).name = defName;
    return defName;
  } else {
    return name;
  }
};

```

custome DefinitionTypeFormatter
```ts
import {
  BaseType,
  Definition,
  DefinitionType,
  SubTypeFormatter,
  TypeFormatter,
  uniqueArray,
} from 'ts-json-schema-generator';
import { reformatDefName } from '../utils/reformatRefDefName';

export class DefinitionTypeFormatter implements SubTypeFormatter {
  public constructor(
    private childTypeFormatter: TypeFormatter,
    private encodeRefs: boolean,
  ) {}

  public supportsType(type: DefinitionType): boolean {
    return type instanceof DefinitionType;
  }
  public getDefinition(type: DefinitionType): Definition {
    const ref = reformatDefName(type);
    return {
      $ref: `#/definitions/${this.encodeRefs ? encodeURIComponent(ref) : ref}`,
    };
  }
  public getChildren(type: DefinitionType): BaseType[] {
    return uniqueArray([
      type,
      ...this.childTypeFormatter.getChildren(type.getType()),
    ]);
  }
}

```

custom ReferenceTypeFormatter

```ts
import {
  BaseType,
  Definition,
  DefinitionType,
  ReferenceType,
  SubTypeFormatter,
  TypeFormatter,
} from 'ts-json-schema-generator';
import { reformatRefName } from '../utils/reformatRefDefName';

export class ReferenceTypeFormatter implements SubTypeFormatter {
  public constructor(
    private childTypeFormatter: TypeFormatter,
    private encodeRefs: boolean,
  ) {}

  public supportsType(type: ReferenceType): boolean {
    return type instanceof ReferenceType;
  }
  public getDefinition(type: ReferenceType): Definition {
    const ref = reformatRefName(type);
    return {
      $ref: `#/definitions/${this.encodeRefs ? encodeURIComponent(ref) : ref}`,
    };
  }
  public getChildren(type: ReferenceType): BaseType[] {
    if (type.getType() instanceof DefinitionType) {
      return [];
    }

    // this means that the referred interface is private
    // so we have to expose it in the schema definitions
    return this.childTypeFormatter.getChildren(
      new DefinitionType(reformatRefName(type), type.getType()),
    );
  }
}

```