### PR TITLE
chore: simplify workflow setup 

### DIFF
--- a/.github/workflows/publish-auto.yml
+++ b/.github/workflows/publish-auto.yml
@@ -19,9 +19,8 @@ jobs:
         with:
           registry-url: "https://registry.npmjs.org"
           node-version: "16"
-
-      - name: Prepare repository
-        run: git fetch --unshallow --tags
+          # Fetch all history for all tags and branches
+          fetch-depth: 0
 
       - name: Install Node dependencies
         run: yarn --frozen-lockfile


### PR DESCRIPTION

## Motivation

- https://github.com/orgs/vega/projects/8#card-73869834

## Changes

- Replace `git fetch`'s  `--unshallow` with configuration for the Github `checkout` action

## Background

- https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches

- https://github.com/actions/checkout/blob/ec3a7ce113134d7a93b817d10a8272cb61118579/src/git-command-manager.ts#L180-L188
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.97.1--canary.1039.7266c79.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install ts-json-schema-generator@0.97.1--canary.1039.7266c79.0
  # or 
  yarn add ts-json-schema-generator@0.97.1--canary.1039.7266c79.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
