### PR TITLE
fix: crash on a recursive interface with an intersection type

### DIFF
--- a/src/TypeFormatter/IntersectionTypeFormatter.ts
+++ b/src/TypeFormatter/IntersectionTypeFormatter.ts
@@ -1,7 +1,6 @@
 import { Definition } from "../Schema/Definition";
 import { SubTypeFormatter } from "../SubTypeFormatter";
 import { BaseType } from "../Type/BaseType";
-import { DefinitionType } from "../Type/DefinitionType";
 import { IntersectionType } from "../Type/IntersectionType";
 import { TypeFormatter } from "../TypeFormatter";
 import { getAllOfDefinitionReducer } from "../Utils/allOfDefinition";
@@ -27,12 +26,9 @@ export class IntersectionTypeFormatter implements SubTypeFormatter {
 
     public getChildren(type: IntersectionType): BaseType[] {
         return uniqueArray(
-            type.getTypes().reduce((result: BaseType[], item) => {
-                // Remove the first child, which is the definition of the child itself because we are merging objects.
-                // However, if the child is just a reference, we cannot remove it.
-                const slice = item instanceof DefinitionType ? 1 : 0;
-                return [...result, ...this.childTypeFormatter.getChildren(item).slice(slice)];
-            }, [])
+            type
+                .getTypes()
+                .reduce((result: BaseType[], item) => [...result, ...this.childTypeFormatter.getChildren(item)], [])
         );
     }
 }

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -39,6 +39,10 @@ describe("valid-data-type", () => {
     it("type-intersection-conflict", assertValidSchema("type-intersection-conflict", "MyObject"));
     it("type-intersection-partial-conflict", assertValidSchema("type-intersection-partial-conflict", "MyType"));
     it("type-intersection-partial-conflict-ref", assertValidSchema("type-intersection-partial-conflict", "MyType"));
+    it(
+        "type-intersection-recursive-interface",
+        assertValidSchema("type-intersection-recursive-interface", "Intersection")
+    );
     it("type-intersection-union", assertValidSchema("type-intersection-union", "MyObject"));
     it("type-intersection-union-enum", assertValidSchema("type-intersection-union-enum", "MyObject"));
     it("type-intersection-union-primitive", assertValidSchema("type-intersection-union", "MyObject"));

--- a/test/valid-data/type-intersection-recursive-interface/main.ts
+++ b/test/valid-data/type-intersection-recursive-interface/main.ts
@@ -1,0 +1,9 @@
+export interface Container {
+    children: Container[];
+}
+
+export type Dummy = {
+    x: number;
+};
+
+export type Intersection = Container & Dummy;

--- a/test/valid-data/type-intersection-recursive-interface/schema.json
+++ b/test/valid-data/type-intersection-recursive-interface/schema.json
@@ -1,0 +1,40 @@
+{
+    "$ref": "#/definitions/Intersection",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+      "Container": {
+        "additionalProperties": false,
+        "properties": {
+          "children": {
+            "items": {
+              "$ref": "#/definitions/Container"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "children"
+        ],
+        "type": "object"
+      },
+      "Intersection": {
+        "additionalProperties": false,
+        "properties": {
+          "children": {
+            "items": {
+              "$ref": "#/definitions/Container"
+            },
+            "type": "array"
+          },
+          "x": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "children",
+          "x"
+        ],
+        "type": "object"
+      }
+    }
+  }


### PR DESCRIPTION
This PR closes #1038 

`IntersectionTypeFormatter` was doing some premature culling on the child types, which may have been a reasonable optimization previously. However, [`RemoveUnreachable.ts`](https://github.com/vega/ts-json-schema-generator/blob/35d9c2585910d0c2882d17d641aabcb5e397e94a/src/Utils/removeUnreachable.ts), which was introduced later as a post-processing step, seems to do the pruning properly, making the optimization in the formatter unnecessary.

This doesn't seem to cause performance regressions. Running the test suite took ~270s before and after the fix.

The test case fails on `next` branch, passes on this.