### PR TITLE
chore: move fetch-depth config to checkout action

### DIFF
--- a/.github/workflows/publish-auto.yml
+++ b/.github/workflows/publish-auto.yml
@@ -14,13 +14,14 @@ jobs:
     name: Make a release and publish to NPM
     steps:
       - uses: actions/checkout@v2
+        with:
+          # Fetch all history for all tags and branches
+          fetch-depth: 0
 
       - uses: actions/setup-node@v2.5.0
         with:
           registry-url: "https://registry.npmjs.org"
           node-version: "16"
-          # Fetch all history for all tags and branches
-          fetch-depth: 0
 
       - name: Install Node dependencies
         run: yarn --frozen-lockfile


### PR DESCRIPTION
Implements #1039 correctly (previous PR configured the wrong action)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.97.1--canary.1045.b192845.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install ts-json-schema-generator@0.97.1--canary.1045.b192845.0
  # or 
  yarn add ts-json-schema-generator@0.97.1--canary.1045.b192845.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
