### PR TITLE
fix: expose referred DefinitionType if it wraps an AliasType

### DIFF
--- a/src/TypeFormatter/ReferenceTypeFormatter.ts
+++ b/src/TypeFormatter/ReferenceTypeFormatter.ts
@@ -19,13 +19,10 @@ export class ReferenceTypeFormatter implements SubTypeFormatter {
     public getChildren(type: ReferenceType): BaseType[] {
         const referredType = type.getType();
         if (referredType instanceof DefinitionType) {
-            const definedType = referredType.getType();
-            // Exposes a referred AliasType as a DefinitionType to ensure its
-            // inclusion in the type definitions.
+            // Exposes a referred DefinitionType if it wraps an AliasType
+            // to ensure its inclusion in the type definitions.
             // Fixes: https://github.com/vega/ts-json-schema-generator/issues/1046
-            return definedType instanceof AliasType
-                ? this.childTypeFormatter.getChildren(new DefinitionType(type.getName(), definedType))
-                : [];
+            return referredType.getType() instanceof AliasType ? this.childTypeFormatter.getChildren(referredType) : [];
         }
 
         // this means that the referred interface is private

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -43,6 +43,10 @@ describe("valid-data-type", () => {
         "type-intersection-recursive-interface",
         assertValidSchema("type-intersection-recursive-interface", "Intersection")
     );
+    it(
+        "type-intersection-union-recursive-interface",
+        assertValidSchema("type-intersection-union-recursive-interface", "Intersection")
+    );
     it("type-intersection-union", assertValidSchema("type-intersection-union", "MyObject"));
     it("type-intersection-union-enum", assertValidSchema("type-intersection-union-enum", "MyObject"));
     it("type-intersection-union-primitive", assertValidSchema("type-intersection-union", "MyObject"));

--- a/test/valid-data/type-intersection-union-recursive-interface/main.ts
+++ b/test/valid-data/type-intersection-union-recursive-interface/main.ts
@@ -1,0 +1,15 @@
+export interface Container {
+    child: Union;
+}
+
+export interface Dummy {
+    x: number;
+}
+
+export interface Silly {
+    y: number;
+}
+
+export type Union = Container | Silly;
+
+export type Intersection = Union & Dummy;

--- a/test/valid-data/type-intersection-union-recursive-interface/schema.json
+++ b/test/valid-data/type-intersection-union-recursive-interface/schema.json
@@ -1,0 +1,76 @@
+{
+    "$ref": "#/definitions/Intersection",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+      "Container": {
+        "additionalProperties": false,
+        "properties": {
+          "child": {
+            "$ref": "#/definitions/Union"
+          }
+        },
+        "required": [
+          "child"
+        ],
+        "type": "object"
+      },
+      "Intersection": {
+        "anyOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "child": {
+                "$ref": "#/definitions/Union"
+              },
+              "x": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "child",
+              "x"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "x",
+              "y"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "Silly": {
+        "additionalProperties": false,
+        "properties": {
+          "y": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "y"
+        ],
+        "type": "object"
+      },
+      "Union": {
+        "anyOf": [
+          {
+            "$ref": "#/definitions/Container"
+          },
+          {
+            "$ref": "#/definitions/Silly"
+          }
+        ]
+      }
+    }
+  }


### PR DESCRIPTION
Closes #1046.

The `UnionType` object representing the `Union` type in the example was buried deep in the type hierarchy. The `getChildren()` method of `ReferenceTypeFormatter` ignored `DefinitionType`s and thus, didn't to expose the hierarchically referred type.

This PR exposes the referred `DefinitionType` if it wraps an `AliasType`. This seems to work, but I'm not 100% sure that this is the proper way to fix this – mainly because understanding the purpose of different types is quite difficult. However, all tests pass.

![image](https://user-images.githubusercontent.com/399972/144406134-50fd7da2-d900-4ac8-a603-489da9354f84.png)
