### PR TITLE
chore: add descriptive error message to `removeUnreachable`

### DIFF
--- a/src/Utils/removeUnreachable.ts
+++ b/src/Utils/removeUnreachable.ts
@@ -18,7 +18,11 @@ function addReachable(
             return;
         }
         reachable.add(typeName);
-        addReachable(definitions[typeName], definitions, reachable);
+        const refDefinition = definitions[typeName];
+        if (!refDefinition) {
+            throw new Error(`Encountered a reference to a missing definition: "${definition.$ref}". This is a bug.`);
+        }
+        addReachable(refDefinition, definitions, reachable);
     } else if (definition.anyOf) {
         for (const def of definition.anyOf) {
             addReachable(def, definitions, reachable);


### PR DESCRIPTION
Nobody should see this message, but if they see, it probably makes a bit more sense after this PR.

Before:

```
TypeError: Cannot read properties of undefined (reading '$ref')
    at addReachable (/Users/klavikka/src/ts-json-schema-generator/src/Utils/removeUnreachable.ts:14:20)
```

After:

```
Error: Encountered a reference to a missing definition: "#/definitions/Union". This is a bug.
    at addReachable (/Users/klavikka/src/ts-json-schema-generator/src/Utils/removeUnreachable.ts:23:19)
```