### PR TITLE
feat: add Source FileName for DefinitionType, used by TopRefNodeParser and ExposeNodeParser.

### DIFF
--- a/src/ExposeNodeParser.ts
+++ b/src/ExposeNodeParser.ts
@@ -6,6 +6,7 @@ import { DefinitionType } from "./Type/DefinitionType";
 import { ReferenceType } from "./Type/ReferenceType";
 import { hasJsDocTag } from "./Utils/hasJsDocTag";
 import { symbolAtNode } from "./Utils/symbolAtNode";
+import { setSourceFileNameIfDefinitionType } from "./Utils/setSourceFileNameIfDefinitionType";
 
 export class ExposeNodeParser implements SubNodeParser {
     public constructor(
@@ -21,16 +22,17 @@ export class ExposeNodeParser implements SubNodeParser {
 
     public createType(node: ts.Node, context: Context, reference?: ReferenceType): BaseType | undefined {
         const baseType = this.subNodeParser.createType(node, context, reference);
+        const sourceFileName = node.getSourceFile().fileName;
 
         if (baseType === undefined) {
             return undefined;
         }
 
         if (!this.isExportNode(node)) {
-            return baseType;
+            return setSourceFileNameIfDefinitionType(baseType, sourceFileName);
         }
 
-        return new DefinitionType(this.getDefinitionName(node, context), baseType);
+        return new DefinitionType(this.getDefinitionName(node, context), baseType, sourceFileName);
     }
 
     private isExportNode(node: ts.Node): boolean {

--- a/src/TopRefNodeParser.ts
+++ b/src/TopRefNodeParser.ts
@@ -22,7 +22,7 @@ export class TopRefNodeParser implements NodeParser {
         if (this.topRef && !(baseType instanceof DefinitionType)) {
             return new DefinitionType(this.fullName, baseType, sourceFileName);
         } else if (!this.topRef && baseType instanceof DefinitionType) {
-            return setSourceFileNameIfDefinitionType(baseType.getType(), sourceFileName)
+            return setSourceFileNameIfDefinitionType(baseType.getType(), sourceFileName);
         } else {
             return setSourceFileNameIfDefinitionType(baseType, sourceFileName);
         }

--- a/src/TopRefNodeParser.ts
+++ b/src/TopRefNodeParser.ts
@@ -2,6 +2,7 @@ import ts from "typescript";
 import { Context, NodeParser } from "./NodeParser";
 import { BaseType } from "./Type/BaseType";
 import { DefinitionType } from "./Type/DefinitionType";
+import { setSourceFileNameIfDefinitionType } from "./Utils/setSourceFileNameIfDefinitionType";
 
 export class TopRefNodeParser implements NodeParser {
     public constructor(
@@ -12,17 +13,18 @@ export class TopRefNodeParser implements NodeParser {
 
     public createType(node: ts.Node, context: Context): BaseType | undefined {
         const baseType = this.childNodeParser.createType(node, context);
+        const sourceFileName = node.getSourceFile().fileName;
 
         if (baseType === undefined) {
             return undefined;
         }
 
         if (this.topRef && !(baseType instanceof DefinitionType)) {
-            return new DefinitionType(this.fullName, baseType);
+            return new DefinitionType(this.fullName, baseType, sourceFileName);
         } else if (!this.topRef && baseType instanceof DefinitionType) {
-            return baseType.getType();
+            return setSourceFileNameIfDefinitionType(baseType.getType(), sourceFileName)
         } else {
-            return baseType;
+            return setSourceFileNameIfDefinitionType(baseType, sourceFileName);
         }
     }
 }

--- a/src/Type/DefinitionType.ts
+++ b/src/Type/DefinitionType.ts
@@ -1,7 +1,16 @@
 import { BaseType } from "./BaseType";
 
 export class DefinitionType extends BaseType {
-    public constructor(private name: string | undefined, private type: BaseType) {
+    public constructor(
+        private name: string | undefined,
+        private type: BaseType,
+        /**
+         * Source Code fileName for DefinitionType. Used at TopRefNodeParser
+         * and ExposeNodeParser. So that, You can override DefinitionFormatter
+         * to custome your self DefinitionType name by fileName.
+         */
+        private sourceFileName?: string
+    ) {
         super();
     }
 
@@ -15,5 +24,13 @@ export class DefinitionType extends BaseType {
 
     public getType(): BaseType {
         return this.type;
+    }
+
+    public setSourceFileName(fileName: string) {
+        this.sourceFileName = fileName;
+    }
+
+    public getSourceFileName() {
+        return this.sourceFileName;
     }
 }

--- a/src/Utils/setSourceFileNameIfDefinitionType.ts
+++ b/src/Utils/setSourceFileNameIfDefinitionType.ts
@@ -1,0 +1,9 @@
+import { DefinitionType } from "../Type/DefinitionType";
+import { BaseType } from "../Type/BaseType";
+
+export const setSourceFileNameIfDefinitionType = (type: BaseType, sourceFileName: string) => {
+    if (type instanceof DefinitionType) {
+        type.setSourceFileName(sourceFileName);
+    }
+    return type;
+};


### PR DESCRIPTION
For this idea  #1018

This is **same** PR with  #1019 , but cause by my Incorrect operation, i have to resbumit this one.  #1019 discuss at the bottom.

And here is custome DefinitionTypeFormatter example

```ts
import {
  BaseType,
  Definition,
  DefinitionType,
  SubTypeFormatter,
  TypeFormatter,
  uniqueArray,
} from 'ts-json-schema-generator';

export class DefinitionTypeFormatter implements SubTypeFormatter {
  public constructor(
    private childTypeFormatter: TypeFormatter,
    private encodeRefs: boolean,
  ) {}

  public supportsType(type: DefinitionType): boolean {
    return type instanceof DefinitionType;
  }
  public getDefinition(type: DefinitionType): Definition {
    // so that you can see the name here.
    console.log(type.sourceFileName);
    return {
      $ref: `#/definitions/${this.encodeRefs ? encodeURIComponent(type) : type}`,
    };
  }

}

```

![github com_vega_ts-json-schema-generator_pull_1019_files](https://user-images.githubusercontent.com/18055018/145132532-a80f841d-1a7e-4be8-9214-86f7b7ca1347.png)

