### PR TITLE
fix: always expose referred DefinitionType to avoid issues with recursive intersections of unions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,6 @@
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
-  }
+  },
+  "jest.autoRun": "off"
 }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "test:coverage": "yarn jest test/ --collectCoverage=true",
     "test:update": "cross-env UPDATE_SCHEMA=true yarn test:fast",
     "debug": "node -r ts-node/register --inspect-brk ts-json-schema-generator.ts",
-    "run": "ts-node ts-json-schema-generator.ts",
+    "run": "ts-node-transpile-only ts-json-schema-generator.ts",
     "release": "yarn build && auto shipit"
   }
 }

--- a/src/TypeFormatter/ReferenceTypeFormatter.ts
+++ b/src/TypeFormatter/ReferenceTypeFormatter.ts
@@ -19,13 +19,10 @@ export class ReferenceTypeFormatter implements SubTypeFormatter {
     public getChildren(type: ReferenceType): BaseType[] {
         const referredType = type.getType();
         if (referredType instanceof DefinitionType) {
-            const definedType = referredType.getType();
-            // Exposes a referred AliasType as a DefinitionType to ensure its
-            // inclusion in the type definitions.
+            // Exposes a referred DefinitionType if it wraps an AliasType
+            // to ensure its inclusion in the type definitions.
             // Fixes: https://github.com/vega/ts-json-schema-generator/issues/1046
-            return definedType instanceof AliasType
-                ? this.childTypeFormatter.getChildren(new DefinitionType(type.getName(), definedType))
-                : [];
+            return referredType.getType() instanceof AliasType ? this.childTypeFormatter.getChildren(referredType) : [];
         }
 
         // this means that the referred interface is private

--- a/src/TypeFormatter/ReferenceTypeFormatter.ts
+++ b/src/TypeFormatter/ReferenceTypeFormatter.ts
@@ -1,6 +1,5 @@
 import { Definition } from "../Schema/Definition";
 import { SubTypeFormatter } from "../SubTypeFormatter";
-import { AliasType } from "../Type/AliasType";
 import { BaseType } from "../Type/BaseType";
 import { DefinitionType } from "../Type/DefinitionType";
 import { ReferenceType } from "../Type/ReferenceType";
@@ -19,10 +18,11 @@ export class ReferenceTypeFormatter implements SubTypeFormatter {
     public getChildren(type: ReferenceType): BaseType[] {
         const referredType = type.getType();
         if (referredType instanceof DefinitionType) {
-            // Exposes a referred DefinitionType if it wraps an AliasType
-            // to ensure its inclusion in the type definitions.
-            // Fixes: https://github.com/vega/ts-json-schema-generator/issues/1046
-            return referredType.getType() instanceof AliasType ? this.childTypeFormatter.getChildren(referredType) : [];
+            // We probably already have the definitions for the children created so we could return `[]`.
+            // There are cases where we may not have (in particular intersections of unions with recursion).
+            // To make sure we create the necessary definitions, we return the children of the referred type here.
+            // Because we cache definitions, this should not incur any performance impact.
+            return this.childTypeFormatter.getChildren(referredType);
         }
 
         // this means that the referred interface is private

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -43,6 +43,10 @@ describe("valid-data-type", () => {
         "type-intersection-recursive-interface",
         assertValidSchema("type-intersection-recursive-interface", "Intersection")
     );
+    it(
+        "type-intersection-union-recursive-interface",
+        assertValidSchema("type-intersection-union-recursive-interface", "Intersection")
+    );
     it("type-intersection-union", assertValidSchema("type-intersection-union", "MyObject"));
     it("type-intersection-union-enum", assertValidSchema("type-intersection-union-enum", "MyObject"));
     it("type-intersection-union-primitive", assertValidSchema("type-intersection-union", "MyObject"));

--- a/test/valid-data/type-intersection-union-recursive-interface/main.ts
+++ b/test/valid-data/type-intersection-union-recursive-interface/main.ts
@@ -1,0 +1,15 @@
+export interface Container {
+    child: Union;
+}
+
+export interface Dummy {
+    x: number;
+}
+
+export interface Silly {
+    y: number;
+}
+
+export type Union = Container | Silly;
+
+export type Intersection = Union & Dummy;

--- a/test/valid-data/type-intersection-union-recursive-interface/schema.json
+++ b/test/valid-data/type-intersection-union-recursive-interface/schema.json
@@ -1,0 +1,76 @@
+{
+    "$ref": "#/definitions/Intersection",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+      "Container": {
+        "additionalProperties": false,
+        "properties": {
+          "child": {
+            "$ref": "#/definitions/Union"
+          }
+        },
+        "required": [
+          "child"
+        ],
+        "type": "object"
+      },
+      "Intersection": {
+        "anyOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "child": {
+                "$ref": "#/definitions/Union"
+              },
+              "x": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "child",
+              "x"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "x",
+              "y"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "Silly": {
+        "additionalProperties": false,
+        "properties": {
+          "y": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "y"
+        ],
+        "type": "object"
+      },
+      "Union": {
+        "anyOf": [
+          {
+            "$ref": "#/definitions/Container"
+          },
+          {
+            "$ref": "#/definitions/Silly"
+          }
+        ]
+      }
+    }
+  }


### PR DESCRIPTION
New version of https://github.com/vega/ts-json-schema-generator/pull/1047
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.97.1--canary.1093.43d6c2f.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install ts-json-schema-generator@0.97.1--canary.1093.43d6c2f.0
  # or 
  yarn add ts-json-schema-generator@0.97.1--canary.1093.43d6c2f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.97.1-next.0`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Kari Lavikka ([@tuner](https://github.com/tuner)), for all your work!
  
  #### 🐛 Bug Fix
  
  - fix: always expose referred DefinitionType to avoid issues with recursive intersections of unions [#1093](https://github.com/vega/ts-json-schema-generator/pull/1093) ([@domoritz](https://github.com/domoritz))
  - chore: upgrade deps [#1092](https://github.com/vega/ts-json-schema-generator/pull/1092) ([@domoritz](https://github.com/domoritz))
  - chore: add descriptive error message to `removeUnreachable` [#1048](https://github.com/vega/ts-json-schema-generator/pull/1048) ([@tuner](https://github.com/tuner))
  - chore: move fetch-depth config to checkout action [#1045](https://github.com/vega/ts-json-schema-generator/pull/1045) ([@hydrosquall](https://github.com/hydrosquall))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump @typescript-eslint/parser from 5.8.1 to 5.9.0 [#1088](https://github.com/vega/ts-json-schema-generator/pull/1088) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 27.4.5 to 27.4.7 [#1089](https://github.com/vega/ts-json-schema-generator/pull/1089) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.8.1 to 5.9.0 [#1090](https://github.com/vega/ts-json-schema-generator/pull/1090) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.6 to 17.0.8 [#1091](https://github.com/vega/ts-json-schema-generator/pull/1091) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.16.5 to 7.16.7 [#1081](https://github.com/vega/ts-json-schema-generator/pull/1081) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.8.0 to 5.8.1 [#1082](https://github.com/vega/ts-json-schema-generator/pull/1082) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.16.5 to 7.16.7 [#1084](https://github.com/vega/ts-json-schema-generator/pull/1084) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.8.0 to 5.8.1 [#1085](https://github.com/vega/ts-json-schema-generator/pull/1085) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.4 to 17.0.6 [#1080](https://github.com/vega/ts-json-schema-generator/pull/1080) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 27.0.3 to 27.4.0 [#1083](https://github.com/vega/ts-json-schema-generator/pull/1083) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.5.0 to 8.6.0 [#1086](https://github.com/vega/ts-json-schema-generator/pull/1086) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.16.5 to 7.16.7 [#1087](https://github.com/vega/ts-json-schema-generator/pull/1087) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/setup-node from 2.5.0 to 2.5.1 [#1079](https://github.com/vega/ts-json-schema-generator/pull/1079) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.7.0 to 5.8.0 [#1076](https://github.com/vega/ts-json-schema-generator/pull/1076) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.7.0 to 5.8.0 [#1077](https://github.com/vega/ts-json-schema-generator/pull/1077) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.0 to 17.0.4 [#1078](https://github.com/vega/ts-json-schema-generator/pull/1078) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.11.12 to 17.0.0 [#1071](https://github.com/vega/ts-json-schema-generator/pull/1071) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.6.0 to 5.7.0 [#1067](https://github.com/vega/ts-json-schema-generator/pull/1067) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.6.0 to 5.7.0 [#1068](https://github.com/vega/ts-json-schema-generator/pull/1068) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.16.0 to 7.16.5 [#1066](https://github.com/vega/ts-json-schema-generator/pull/1066) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.16.4 to 7.16.5 [#1069](https://github.com/vega/ts-json-schema-generator/pull/1069) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.5.3 to 4.5.4 [#1070](https://github.com/vega/ts-json-schema-generator/pull/1070) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 27.4.4 to 27.4.5 [#1072](https://github.com/vega/ts-json-schema-generator/pull/1072) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.16.0 to 7.16.5 [#1073](https://github.com/vega/ts-json-schema-generator/pull/1073) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.4.1 to 8.5.0 [#1074](https://github.com/vega/ts-json-schema-generator/pull/1074) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.5.0 to 5.6.0 [#1058](https://github.com/vega/ts-json-schema-generator/pull/1058) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.5.0 to 5.6.0 [#1059](https://github.com/vega/ts-json-schema-generator/pull/1059) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.32.3 to 10.32.5 [#1057](https://github.com/vega/ts-json-schema-generator/pull/1057) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.4.0 to 8.4.1 [#1060](https://github.com/vega/ts-json-schema-generator/pull/1060) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.11.11 to 16.11.12 [#1061](https://github.com/vega/ts-json-schema-generator/pull/1061) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 27.4.3 to 27.4.4 [#1062](https://github.com/vega/ts-json-schema-generator/pull/1062) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.32.3 to 10.32.5 [#1063](https://github.com/vega/ts-json-schema-generator/pull/1063) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.32.3 to 10.32.5 [#1064](https://github.com/vega/ts-json-schema-generator/pull/1064) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.5.2 to 4.5.3 [#1065](https://github.com/vega/ts-json-schema-generator/pull/1065) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.4.0 to 5.5.0 [#1049](https://github.com/vega/ts-json-schema-generator/pull/1049) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump safe-stable-stringify from 2.2.0 to 2.3.1 [#1050](https://github.com/vega/ts-json-schema-generator/pull/1050) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 27.3.1 to 27.4.3 [#1051](https://github.com/vega/ts-json-schema-generator/pull/1051) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.3.0 to 8.4.0 [#1052](https://github.com/vega/ts-json-schema-generator/pull/1052) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.5.0 to 2.5.1 [#1053](https://github.com/vega/ts-json-schema-generator/pull/1053) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.11.10 to 16.11.11 [#1054](https://github.com/vega/ts-json-schema-generator/pull/1054) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.4.0 to 5.5.0 [#1055](https://github.com/vega/ts-json-schema-generator/pull/1055) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 4
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Cameron Yick ([@hydrosquall](https://github.com/hydrosquall))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
  - Kari Lavikka ([@tuner](https://github.com/tuner))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
