### PR TITLE
fix: failed to resolve type for typeof static class property

### DIFF
--- a/src/NodeParser/TypeofNodeParser.ts
+++ b/src/NodeParser/TypeofNodeParser.ts
@@ -24,7 +24,11 @@ export class TypeofNodeParser implements SubNodeParser {
         const valueDec = symbol.valueDeclaration!;
         if (ts.isEnumDeclaration(valueDec)) {
             return this.createObjectFromEnum(valueDec, context, reference);
-        } else if (ts.isVariableDeclaration(valueDec) || ts.isPropertySignature(valueDec)) {
+        } else if (
+            ts.isVariableDeclaration(valueDec) ||
+            ts.isPropertySignature(valueDec) ||
+            ts.isPropertyDeclaration(valueDec)
+        ) {
             if (valueDec.type) {
                 return this.childNodeParser.createType(valueDec.type, context);
             } else if (valueDec.initializer) {

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -59,6 +59,7 @@ describe("valid-data-type", () => {
     it("type-typeof", assertValidSchema("type-typeof", "MyType"));
     it("type-typeof-value", assertValidSchema("type-typeof-value", "MyType"));
     it("type-typeof-object-property", assertValidSchema("type-typeof-object-property", "MyType"));
+    it("type-typeof-class-static-property", assertValidSchema("type-typeof-class-static-property", "MyType"));
     it("type-typeof-enum", assertValidSchema("type-typeof-enum", "MyObject"));
     it("type-typeof-class", assertValidSchema("type-typeof-class", "MyObject"));
     it("type-keys", assertValidSchema("type-typeof-keys", "MyType"));

--- a/test/valid-data/type-typeof-class-static-property/main.ts
+++ b/test/valid-data/type-typeof-class-static-property/main.ts
@@ -1,0 +1,5 @@
+class Foo {
+    static bar = "foo"
+}
+
+export type MyType = typeof Foo.bar;

--- a/test/valid-data/type-typeof-class-static-property/schema.json
+++ b/test/valid-data/type-typeof-class-static-property/schema.json
@@ -1,0 +1,10 @@
+{
+  "$ref": "#/definitions/MyType",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyType": {
+      "const": "foo",
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
Hey, this fixes an issue I came across when trying to use this (wonderful) package.

Didn't see a contribution guide, so I'm not sure if I'm following the standards. If not, let me know.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.97.1-next.1`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: Mark Sheinkman ([@MarkSheinkman](https://github.com/MarkSheinkman))
  
  :heart: null[@chimurai](https://github.com/chimurai)
  
  :heart: Kari Lavikka ([@tuner](https://github.com/tuner))
  
  #### 🐛 Bug Fix
  
  - fix: failed to resolve type for typeof static class property [#1119](https://github.com/vega/ts-json-schema-generator/pull/1119) ([@MarkSheinkman](https://github.com/MarkSheinkman))
  - docs: autocomplete configuration [#1106](https://github.com/vega/ts-json-schema-generator/pull/1106) ([@chimurai](https://github.com/chimurai))
  - fix: always expose referred DefinitionType to avoid issues with recursive intersections of unions [#1093](https://github.com/vega/ts-json-schema-generator/pull/1093) ([@domoritz](https://github.com/domoritz))
  - chore: upgrade deps [#1092](https://github.com/vega/ts-json-schema-generator/pull/1092) ([@domoritz](https://github.com/domoritz))
  - chore: add descriptive error message to `removeUnreachable` [#1048](https://github.com/vega/ts-json-schema-generator/pull/1048) ([@tuner](https://github.com/tuner))
  - chore: move fetch-depth config to checkout action [#1045](https://github.com/vega/ts-json-schema-generator/pull/1045) ([@hydrosquall](https://github.com/hydrosquall))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.10.1 to 5.10.2 [#1117](https://github.com/vega/ts-json-schema-generator/pull/1117) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv from 8.9.0 to 8.10.0 [#1113](https://github.com/vega/ts-json-schema-generator/pull/1113) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 27.4.7 to 27.5.0 [#1114](https://github.com/vega/ts-json-schema-generator/pull/1114) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.16.12 to 7.17.0 [#1115](https://github.com/vega/ts-json-schema-generator/pull/1115) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.13 to 17.0.15 [#1116](https://github.com/vega/ts-json-schema-generator/pull/1116) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.10.1 to 5.10.2 [#1118](https://github.com/vega/ts-json-schema-generator/pull/1118) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.10.0 to 5.10.1 [#1111](https://github.com/vega/ts-json-schema-generator/pull/1111) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 8.3.0 to 9.0.0 [#1109](https://github.com/vega/ts-json-schema-generator/pull/1109) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump chai from 4.3.4 to 4.3.6 [#1107](https://github.com/vega/ts-json-schema-generator/pull/1107) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.7.0 to 8.8.0 [#1108](https://github.com/vega/ts-json-schema-generator/pull/1108) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.10 to 17.0.13 [#1110](https://github.com/vega/ts-json-schema-generator/pull/1110) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.10.0 to 5.10.1 [#1112](https://github.com/vega/ts-json-schema-generator/pull/1112) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.16.7 to 7.16.12 [#1102](https://github.com/vega/ts-json-schema-generator/pull/1102) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.9.1 to 5.10.0 [#1098](https://github.com/vega/ts-json-schema-generator/pull/1098) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.32.5 to 10.32.6 [#1097](https://github.com/vega/ts-json-schema-generator/pull/1097) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.32.5 to 10.32.6 [#1099](https://github.com/vega/ts-json-schema-generator/pull/1099) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.8 to 17.0.10 [#1100](https://github.com/vega/ts-json-schema-generator/pull/1100) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.32.5 to 10.32.6 [#1101](https://github.com/vega/ts-json-schema-generator/pull/1101) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.9.1 to 5.10.0 [#1103](https://github.com/vega/ts-json-schema-generator/pull/1103) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.5.4 to 4.5.5 [#1104](https://github.com/vega/ts-json-schema-generator/pull/1104) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.16.8 to 7.16.11 [#1105](https://github.com/vega/ts-json-schema-generator/pull/1105) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.6.0 to 8.7.0 [#1094](https://github.com/vega/ts-json-schema-generator/pull/1094) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv from 8.8.2 to 8.9.0 [#1095](https://github.com/vega/ts-json-schema-generator/pull/1095) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.8.1 to 5.9.0 [#1088](https://github.com/vega/ts-json-schema-generator/pull/1088) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 27.4.5 to 27.4.7 [#1089](https://github.com/vega/ts-json-schema-generator/pull/1089) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.8.1 to 5.9.0 [#1090](https://github.com/vega/ts-json-schema-generator/pull/1090) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.6 to 17.0.8 [#1091](https://github.com/vega/ts-json-schema-generator/pull/1091) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.16.5 to 7.16.7 [#1081](https://github.com/vega/ts-json-schema-generator/pull/1081) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.8.0 to 5.8.1 [#1082](https://github.com/vega/ts-json-schema-generator/pull/1082) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.16.5 to 7.16.7 [#1084](https://github.com/vega/ts-json-schema-generator/pull/1084) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.8.0 to 5.8.1 [#1085](https://github.com/vega/ts-json-schema-generator/pull/1085) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.4 to 17.0.6 [#1080](https://github.com/vega/ts-json-schema-generator/pull/1080) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 27.0.3 to 27.4.0 [#1083](https://github.com/vega/ts-json-schema-generator/pull/1083) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.5.0 to 8.6.0 [#1086](https://github.com/vega/ts-json-schema-generator/pull/1086) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.16.5 to 7.16.7 [#1087](https://github.com/vega/ts-json-schema-generator/pull/1087) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/setup-node from 2.5.0 to 2.5.1 [#1079](https://github.com/vega/ts-json-schema-generator/pull/1079) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.7.0 to 5.8.0 [#1076](https://github.com/vega/ts-json-schema-generator/pull/1076) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.7.0 to 5.8.0 [#1077](https://github.com/vega/ts-json-schema-generator/pull/1077) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.0 to 17.0.4 [#1078](https://github.com/vega/ts-json-schema-generator/pull/1078) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.11.12 to 17.0.0 [#1071](https://github.com/vega/ts-json-schema-generator/pull/1071) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.6.0 to 5.7.0 [#1067](https://github.com/vega/ts-json-schema-generator/pull/1067) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.6.0 to 5.7.0 [#1068](https://github.com/vega/ts-json-schema-generator/pull/1068) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.16.0 to 7.16.5 [#1066](https://github.com/vega/ts-json-schema-generator/pull/1066) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.16.4 to 7.16.5 [#1069](https://github.com/vega/ts-json-schema-generator/pull/1069) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.5.3 to 4.5.4 [#1070](https://github.com/vega/ts-json-schema-generator/pull/1070) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 27.4.4 to 27.4.5 [#1072](https://github.com/vega/ts-json-schema-generator/pull/1072) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.16.0 to 7.16.5 [#1073](https://github.com/vega/ts-json-schema-generator/pull/1073) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.4.1 to 8.5.0 [#1074](https://github.com/vega/ts-json-schema-generator/pull/1074) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.5.0 to 5.6.0 [#1058](https://github.com/vega/ts-json-schema-generator/pull/1058) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.5.0 to 5.6.0 [#1059](https://github.com/vega/ts-json-schema-generator/pull/1059) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.32.3 to 10.32.5 [#1057](https://github.com/vega/ts-json-schema-generator/pull/1057) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.4.0 to 8.4.1 [#1060](https://github.com/vega/ts-json-schema-generator/pull/1060) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.11.11 to 16.11.12 [#1061](https://github.com/vega/ts-json-schema-generator/pull/1061) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 27.4.3 to 27.4.4 [#1062](https://github.com/vega/ts-json-schema-generator/pull/1062) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.32.3 to 10.32.5 [#1063](https://github.com/vega/ts-json-schema-generator/pull/1063) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.32.3 to 10.32.5 [#1064](https://github.com/vega/ts-json-schema-generator/pull/1064) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.5.2 to 4.5.3 [#1065](https://github.com/vega/ts-json-schema-generator/pull/1065) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.4.0 to 5.5.0 [#1049](https://github.com/vega/ts-json-schema-generator/pull/1049) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump safe-stable-stringify from 2.2.0 to 2.3.1 [#1050](https://github.com/vega/ts-json-schema-generator/pull/1050) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 27.3.1 to 27.4.3 [#1051](https://github.com/vega/ts-json-schema-generator/pull/1051) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.3.0 to 8.4.0 [#1052](https://github.com/vega/ts-json-schema-generator/pull/1052) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.5.0 to 2.5.1 [#1053](https://github.com/vega/ts-json-schema-generator/pull/1053) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 16.11.10 to 16.11.11 [#1054](https://github.com/vega/ts-json-schema-generator/pull/1054) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.4.0 to 5.5.0 [#1055](https://github.com/vega/ts-json-schema-generator/pull/1055) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 6
  
  - [@chimurai](https://github.com/chimurai)
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Cameron Yick ([@hydrosquall](https://github.com/hydrosquall))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
  - Kari Lavikka ([@tuner](https://github.com/tuner))
  - Mark Sheinkman ([@MarkSheinkman](https://github.com/MarkSheinkman))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
