### PR TITLE
feat: add support for never type

### DIFF
--- a/factory/formatter.ts
+++ b/factory/formatter.ts
@@ -27,6 +27,7 @@ import { UnionTypeFormatter } from "../src/TypeFormatter/UnionTypeFormatter";
 import { UnknownTypeFormatter } from "../src/TypeFormatter/UnknownTypeFormatter";
 import { VoidTypeFormatter } from "../src/TypeFormatter/VoidTypeFormatter";
 import { MutableTypeFormatter } from "../src/MutableTypeFormatter";
+import { NeverTypeFormatter } from "../src/TypeFormatter/NeverTypeFormatter";
 
 export type FormatterAugmentor = (
     formatter: MutableTypeFormatter,
@@ -54,6 +55,7 @@ export function createFormatter(config: Config, augmentor?: FormatterAugmentor):
         .addTypeFormatter(new UndefinedTypeFormatter())
         .addTypeFormatter(new UnknownTypeFormatter())
         .addTypeFormatter(new VoidTypeFormatter())
+        .addTypeFormatter(new NeverTypeFormatter())
 
         .addTypeFormatter(new LiteralTypeFormatter())
         .addTypeFormatter(new EnumTypeFormatter())

--- a/src/NodeParser/NeverTypeNodeParser.ts
+++ b/src/NodeParser/NeverTypeNodeParser.ts
@@ -2,12 +2,13 @@ import ts from "typescript";
 import { Context } from "../NodeParser";
 import { SubNodeParser } from "../SubNodeParser";
 import { BaseType } from "../Type/BaseType";
+import { NeverType } from "../Type/NeverType";
 
 export class NeverTypeNodeParser implements SubNodeParser {
     public supportsNode(node: ts.KeywordTypeNode): boolean {
         return node.kind === ts.SyntaxKind.NeverKeyword;
     }
     public createType(node: ts.KeywordTypeNode, context: Context): BaseType | undefined {
-        return undefined;
+        return new NeverType();
     }
 }

--- a/src/Type/NeverType.ts
+++ b/src/Type/NeverType.ts
@@ -1,0 +1,7 @@
+import { BaseType } from "./BaseType";
+
+export class NeverType extends BaseType {
+    public getId(): string {
+        return "never";
+    }
+}

--- a/src/Type/UnionType.ts
+++ b/src/Type/UnionType.ts
@@ -1,5 +1,6 @@
 import { BaseType } from "./BaseType";
 import { uniqueTypeArray } from "../Utils/uniqueTypeArray";
+import { NeverType } from "./NeverType";
 
 export class UnionType extends BaseType {
     private readonly types: BaseType[];
@@ -10,7 +11,7 @@ export class UnionType extends BaseType {
             types.reduce((flatTypes, type) => {
                 if (type instanceof UnionType) {
                     flatTypes.push(...type.getTypes());
-                } else if (type !== undefined) {
+                } else if (type !== undefined && !(type instanceof NeverType)) {
                     flatTypes.push(type);
                 }
                 return flatTypes;

--- a/src/TypeFormatter/NeverTypeFormatter.ts
+++ b/src/TypeFormatter/NeverTypeFormatter.ts
@@ -1,0 +1,16 @@
+import { Definition } from "../Schema/Definition";
+import { SubTypeFormatter } from "../SubTypeFormatter";
+import { BaseType } from "../Type/BaseType";
+import { NeverType } from "../Type/NeverType";
+
+export class NeverTypeFormatter implements SubTypeFormatter {
+    public supportsType(type: NeverType): boolean {
+        return type instanceof NeverType;
+    }
+    public getDefinition(type: NeverType): Definition {
+        return { not: {} };
+    }
+    public getChildren(type: NeverType): BaseType[] {
+        return [];
+    }
+}

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -65,6 +65,9 @@ describe("valid-data-other", () => {
     it("undefined-union", assertValidSchema("undefined-union", "MyType"));
     it("undefined-property", assertValidSchema("undefined-property", "MyType"));
 
+    it("never", assertValidSchema("never", "BasicNever"));
+    it("never-record", assertValidSchema("never-record", "Mapped"));
+
     it("any-unknown", assertValidSchema("any-unknown", "MyObject"));
 
     it("multiple-roots1", assertValidSchema("multiple-roots1"));

--- a/test/valid-data/never-record/main.ts
+++ b/test/valid-data/never-record/main.ts
@@ -1,0 +1,3 @@
+// This form is recommended by the typescript-eslint rule "ban-types" to mean
+// "an object with no properties"
+export type Mapped = Record<string, never>;

--- a/test/valid-data/never-record/schema.json
+++ b/test/valid-data/never-record/schema.json
@@ -1,0 +1,12 @@
+{
+  "$ref": "#/definitions/Mapped",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Mapped": {
+      "additionalProperties": {
+        "not": {}
+      },
+      "type": "object"
+    }
+  }
+}

--- a/test/valid-data/never/main.ts
+++ b/test/valid-data/never/main.ts
@@ -1,0 +1,1 @@
+export type BasicNever = never;

--- a/test/valid-data/never/schema.json
+++ b/test/valid-data/never/schema.json
@@ -1,0 +1,9 @@
+{
+  "$ref": "#/definitions/BasicNever",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "BasicNever": {
+      "not": {}
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1152 
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.98.1-next.0`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Hadrien Milano ([@hmil](https://github.com/hmil)), for all your work!
  
  #### 🚀 Enhancement
  
  - feat: add support for never type [#1154](https://github.com/vega/ts-json-schema-generator/pull/1154) ([@hmil](https://github.com/hmil))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump @typescript-eslint/parser from 5.12.1 to 5.13.0 [#1144](https://github.com/vega/ts-json-schema-generator/pull/1144) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.32.6 to 10.34.1 [#1145](https://github.com/vega/ts-json-schema-generator/pull/1145) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.12.1 to 5.13.0 [#1146](https://github.com/vega/ts-json-schema-generator/pull/1146) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ts-node from 10.5.0 to 10.7.0 [#1147](https://github.com/vega/ts-json-schema-generator/pull/1147) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.32.6 to 10.34.1 [#1148](https://github.com/vega/ts-json-schema-generator/pull/1148) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.5.5 to 4.6.2 [#1149](https://github.com/vega/ts-json-schema-generator/pull/1149) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.32.6 to 10.34.1 [#1150](https://github.com/vega/ts-json-schema-generator/pull/1150) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 8.4.0 to 8.5.0 [#1151](https://github.com/vega/ts-json-schema-generator/pull/1151) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/checkout from 2 to 3 [#1143](https://github.com/vega/ts-json-schema-generator/pull/1143) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.12.0 to 5.12.1 [#1139](https://github.com/vega/ts-json-schema-generator/pull/1139) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.9.0 to 8.10.0 [#1138](https://github.com/vega/ts-json-schema-generator/pull/1138) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.18 to 17.0.21 [#1140](https://github.com/vega/ts-json-schema-generator/pull/1140) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 27.4.0 to 27.4.1 [#1141](https://github.com/vega/ts-json-schema-generator/pull/1141) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.12.0 to 5.12.1 [#1142](https://github.com/vega/ts-json-schema-generator/pull/1142) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/setup-node from 2.5.1 to 3 [#1137](https://github.com/vega/ts-json-schema-generator/pull/1137) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.11.0 to 5.12.0 [#1132](https://github.com/vega/ts-json-schema-generator/pull/1132) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.17.2 to 7.17.5 [#1133](https://github.com/vega/ts-json-schema-generator/pull/1133) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.17 to 17.0.18 [#1134](https://github.com/vega/ts-json-schema-generator/pull/1134) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.11.0 to 5.12.0 [#1135](https://github.com/vega/ts-json-schema-generator/pull/1135) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 8.3.0 to 8.4.0 [#1136](https://github.com/vega/ts-json-schema-generator/pull/1136) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 2
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Hadrien Milano ([@hmil](https://github.com/hmil))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
