### PR TITLE
feat: move private to protected to allow extending behavior

### DIFF
--- a/src/ChainNodeParser.ts
+++ b/src/ChainNodeParser.ts
@@ -7,9 +7,9 @@ import { BaseType } from "./Type/BaseType";
 import { ReferenceType } from "./Type/ReferenceType";
 
 export class ChainNodeParser implements SubNodeParser, MutableParser {
-    private readonly typeCaches = new WeakMap<ts.Node, Map<string, BaseType | undefined>>();
+    protected readonly typeCaches = new WeakMap<ts.Node, Map<string, BaseType | undefined>>();
 
-    public constructor(private typeChecker: ts.TypeChecker, private nodeParsers: SubNodeParser[]) {}
+    public constructor(protected typeChecker: ts.TypeChecker, protected nodeParsers: SubNodeParser[]) {}
 
     public addNodeParser(nodeParser: SubNodeParser): this {
         this.nodeParsers.push(nodeParser);
@@ -37,7 +37,7 @@ export class ChainNodeParser implements SubNodeParser, MutableParser {
         return type;
     }
 
-    private getNodeParser(node: ts.Node, context: Context): SubNodeParser {
+    protected getNodeParser(node: ts.Node, context: Context): SubNodeParser {
         for (const nodeParser of this.nodeParsers) {
             if (nodeParser.supportsNode(node)) {
                 return nodeParser;

--- a/src/ChainTypeFormatter.ts
+++ b/src/ChainTypeFormatter.ts
@@ -5,7 +5,7 @@ import { SubTypeFormatter } from "./SubTypeFormatter";
 import { BaseType } from "./Type/BaseType";
 
 export class ChainTypeFormatter implements SubTypeFormatter, MutableTypeFormatter {
-    public constructor(private typeFormatters: SubTypeFormatter[]) {}
+    public constructor(protected typeFormatters: SubTypeFormatter[]) {}
 
     public addTypeFormatter(typeFormatter: SubTypeFormatter): this {
         this.typeFormatters.push(typeFormatter);
@@ -22,7 +22,7 @@ export class ChainTypeFormatter implements SubTypeFormatter, MutableTypeFormatte
         return this.getTypeFormatter(type).getChildren(type);
     }
 
-    private getTypeFormatter(type: BaseType): SubTypeFormatter {
+    protected getTypeFormatter(type: BaseType): SubTypeFormatter {
         for (const typeFormatter of this.typeFormatters) {
             if (typeFormatter.supportsType(type)) {
                 return typeFormatter;

--- a/src/CircularReferenceNodeParser.ts
+++ b/src/CircularReferenceNodeParser.ts
@@ -6,9 +6,9 @@ import { ReferenceType } from "./Type/ReferenceType";
 import { getKey } from "./Utils/nodeKey";
 
 export class CircularReferenceNodeParser implements SubNodeParser {
-    private circular = new Map<string, BaseType>();
+    protected circular = new Map<string, BaseType>();
 
-    public constructor(private childNodeParser: SubNodeParser) {}
+    public constructor(protected childNodeParser: SubNodeParser) {}
 
     public supportsNode(node: ts.Node): boolean {
         return this.childNodeParser.supportsNode(node);

--- a/src/CircularReferenceTypeFormatter.ts
+++ b/src/CircularReferenceTypeFormatter.ts
@@ -4,10 +4,10 @@ import { BaseType } from "./Type/BaseType";
 import { uniqueArray } from "./Utils/uniqueArray";
 
 export class CircularReferenceTypeFormatter implements SubTypeFormatter {
-    private definition = new Map<BaseType, Definition>();
-    private children = new Map<BaseType, BaseType[]>();
+    protected definition = new Map<BaseType, Definition>();
+    protected children = new Map<BaseType, BaseType[]>();
 
-    public constructor(private childTypeFormatter: SubTypeFormatter) {}
+    public constructor(protected childTypeFormatter: SubTypeFormatter) {}
 
     public supportsType(type: BaseType): boolean {
         return this.childTypeFormatter.supportsType(type);

--- a/src/ExposeNodeParser.ts
+++ b/src/ExposeNodeParser.ts
@@ -9,10 +9,10 @@ import { symbolAtNode } from "./Utils/symbolAtNode";
 
 export class ExposeNodeParser implements SubNodeParser {
     public constructor(
-        private typeChecker: ts.TypeChecker,
-        private subNodeParser: SubNodeParser,
-        private expose: "all" | "none" | "export",
-        private jsDoc: "none" | "extended" | "basic"
+        protected typeChecker: ts.TypeChecker,
+        protected subNodeParser: SubNodeParser,
+        protected expose: "all" | "none" | "export",
+        protected jsDoc: "none" | "extended" | "basic"
     ) {}
 
     public supportsNode(node: ts.Node): boolean {
@@ -33,7 +33,7 @@ export class ExposeNodeParser implements SubNodeParser {
         return new DefinitionType(this.getDefinitionName(node, context), baseType);
     }
 
-    private isExportNode(node: ts.Node): boolean {
+    protected isExportNode(node: ts.Node): boolean {
         if (this.expose === "all") {
             return node.kind !== ts.SyntaxKind.TypeLiteral;
         } else if (this.expose === "none") {
@@ -46,7 +46,7 @@ export class ExposeNodeParser implements SubNodeParser {
         return localSymbol ? "exportSymbol" in localSymbol : false;
     }
 
-    private getDefinitionName(node: ts.Node, context: Context): string {
+    protected getDefinitionName(node: ts.Node, context: Context): string {
         const symbol = symbolAtNode(node)!;
         const fullName = this.typeChecker.getFullyQualifiedName(symbol).replace(/^".*"\./, "");
         const argumentIds = context.getArguments().map((arg) => arg?.getName());

--- a/src/NodeParser/AnnotatedNodeParser.ts
+++ b/src/NodeParser/AnnotatedNodeParser.ts
@@ -11,7 +11,7 @@ import { DefinitionType } from "../Type/DefinitionType";
 import { UnionType } from "../Type/UnionType";
 
 export class AnnotatedNodeParser implements SubNodeParser {
-    public constructor(private childNodeParser: SubNodeParser, private annotationsReader: AnnotationsReader) {}
+    public constructor(protected childNodeParser: SubNodeParser, protected annotationsReader: AnnotationsReader) {}
 
     public supportsNode(node: ts.Node): boolean {
         return this.childNodeParser.supportsNode(node);
@@ -63,13 +63,13 @@ export class AnnotatedNodeParser implements SubNodeParser {
         return !annotations && !nullable ? baseType : new AnnotatedType(baseType, annotations || {}, nullable);
     }
 
-    private getNullable(annotatedNode: ts.Node) {
+    protected getNullable(annotatedNode: ts.Node) {
         return this.annotationsReader instanceof ExtendedAnnotationsReader
             ? this.annotationsReader.isNullable(annotatedNode)
             : false;
     }
 
-    private getAnnotatedNode(node: ts.Node): ts.Node {
+    protected getAnnotatedNode(node: ts.Node): ts.Node {
         if (!node.parent) {
             return node;
         } else if (node.parent.kind === ts.SyntaxKind.PropertySignature) {

--- a/src/NodeParser/ArrayLiteralExpressionNodeParser.ts
+++ b/src/NodeParser/ArrayLiteralExpressionNodeParser.ts
@@ -6,7 +6,7 @@ import { notUndefined } from "../Utils/notUndefined";
 import { TupleType } from "../Type/TupleType";
 
 export class ArrayLiteralExpressionNodeParser implements SubNodeParser {
-    public constructor(private childNodeParser: NodeParser) {}
+    public constructor(protected childNodeParser: NodeParser) {}
 
     public supportsNode(node: ts.ArrayLiteralExpression): boolean {
         return node.kind === ts.SyntaxKind.ArrayLiteralExpression;

--- a/src/NodeParser/ArrayNodeParser.ts
+++ b/src/NodeParser/ArrayNodeParser.ts
@@ -5,7 +5,7 @@ import { ArrayType } from "../Type/ArrayType";
 import { BaseType } from "../Type/BaseType";
 
 export class ArrayNodeParser implements SubNodeParser {
-    public constructor(private childNodeParser: NodeParser) {}
+    public constructor(protected childNodeParser: NodeParser) {}
 
     public supportsNode(node: ts.ArrayTypeNode): boolean {
         return node.kind === ts.SyntaxKind.ArrayType;

--- a/src/NodeParser/AsExpressionNodeParser.ts
+++ b/src/NodeParser/AsExpressionNodeParser.ts
@@ -5,7 +5,7 @@ import { SubNodeParser } from "../SubNodeParser";
 import { BaseType } from "../Type/BaseType";
 
 export class AsExpressionNodeParser implements SubNodeParser {
-    public constructor(private childNodeParser: NodeParser) {}
+    public constructor(protected childNodeParser: NodeParser) {}
 
     public supportsNode(node: ts.AsExpression): boolean {
         return node.kind === ts.SyntaxKind.AsExpression;

--- a/src/NodeParser/CallExpressionParser.ts
+++ b/src/NodeParser/CallExpressionParser.ts
@@ -8,7 +8,7 @@ import { LiteralType } from "../Type/LiteralType";
 import { SymbolType } from "../Type/SymbolType";
 
 export class CallExpressionParser implements SubNodeParser {
-    public constructor(private typeChecker: ts.TypeChecker, private childNodeParser: NodeParser) {}
+    public constructor(protected typeChecker: ts.TypeChecker, protected childNodeParser: NodeParser) {}
 
     public supportsNode(node: ts.CallExpression): boolean {
         return node.kind === ts.SyntaxKind.CallExpression;
@@ -34,7 +34,7 @@ export class CallExpressionParser implements SubNodeParser {
         return this.childNodeParser.createType(decl, subContext)!;
     }
 
-    private createSubContext(node: ts.CallExpression, parentContext: Context): Context {
+    protected createSubContext(node: ts.CallExpression, parentContext: Context): Context {
         const subContext = new Context(node);
 
         for (const arg of node.arguments) {

--- a/src/NodeParser/ConditionalTypeNodeParser.ts
+++ b/src/NodeParser/ConditionalTypeNodeParser.ts
@@ -7,7 +7,7 @@ import { narrowType } from "../Utils/narrowType";
 import { UnionType } from "../Type/UnionType";
 
 export class ConditionalTypeNodeParser implements SubNodeParser {
-    public constructor(private typeChecker: ts.TypeChecker, private childNodeParser: NodeParser) {}
+    public constructor(protected typeChecker: ts.TypeChecker, protected childNodeParser: NodeParser) {}
 
     public supportsNode(node: ts.ConditionalTypeNode): boolean {
         return node.kind === ts.SyntaxKind.ConditionalType;
@@ -57,7 +57,7 @@ export class ConditionalTypeNodeParser implements SubNodeParser {
      * @param node - The type node for which to return the type parameter name.
      * @return The type parameter name or null if specified type node is not a type parameter.
      */
-    private getTypeParameterName(node: ts.TypeNode): string | null {
+    protected getTypeParameterName(node: ts.TypeNode): string | null {
         if (ts.isTypeReferenceNode(node)) {
             const typeSymbol = this.typeChecker.getSymbolAtLocation(node.typeName)!;
             if (typeSymbol.flags & ts.SymbolFlags.TypeParameter) {
@@ -76,7 +76,7 @@ export class ConditionalTypeNodeParser implements SubNodeParser {
      * @param narrowedCheckType      - The narrowed down check type to use for the type parameter in sub parsers.
      * @return The created sub context.
      */
-    private createSubContext(
+    protected createSubContext(
         node: ts.ConditionalTypeNode,
         checkTypeParameterName: string,
         narrowedCheckType: BaseType,

--- a/src/NodeParser/EnumNodeParser.ts
+++ b/src/NodeParser/EnumNodeParser.ts
@@ -7,7 +7,7 @@ import { isNodeHidden } from "../Utils/isHidden";
 import { getKey } from "../Utils/nodeKey";
 
 export class EnumNodeParser implements SubNodeParser {
-    public constructor(private typeChecker: ts.TypeChecker) {}
+    public constructor(protected typeChecker: ts.TypeChecker) {}
 
     public supportsNode(node: ts.EnumDeclaration | ts.EnumMember): boolean {
         return node.kind === ts.SyntaxKind.EnumDeclaration || node.kind === ts.SyntaxKind.EnumMember;
@@ -23,7 +23,7 @@ export class EnumNodeParser implements SubNodeParser {
         );
     }
 
-    private getMemberValue(member: ts.EnumMember, index: number): EnumValue {
+    protected getMemberValue(member: ts.EnumMember, index: number): EnumValue {
         const constantValue = this.typeChecker.getConstantValue(member);
         if (constantValue !== undefined) {
             return constantValue;
@@ -38,7 +38,7 @@ export class EnumNodeParser implements SubNodeParser {
             return this.parseInitializer(initializer);
         }
     }
-    private parseInitializer(initializer: ts.Node): EnumValue {
+    protected parseInitializer(initializer: ts.Node): EnumValue {
         if (initializer.kind === ts.SyntaxKind.TrueKeyword) {
             return true;
         } else if (initializer.kind === ts.SyntaxKind.FalseKeyword) {

--- a/src/NodeParser/ExpressionWithTypeArgumentsNodeParser.ts
+++ b/src/NodeParser/ExpressionWithTypeArgumentsNodeParser.ts
@@ -4,7 +4,7 @@ import { SubNodeParser } from "../SubNodeParser";
 import { BaseType } from "../Type/BaseType";
 
 export class ExpressionWithTypeArgumentsNodeParser implements SubNodeParser {
-    public constructor(private typeChecker: ts.TypeChecker, private childNodeParser: NodeParser) {}
+    public constructor(protected typeChecker: ts.TypeChecker, protected childNodeParser: NodeParser) {}
 
     public supportsNode(node: ts.ExpressionWithTypeArguments): boolean {
         return node.kind === ts.SyntaxKind.ExpressionWithTypeArguments;
@@ -24,7 +24,7 @@ export class ExpressionWithTypeArgumentsNodeParser implements SubNodeParser {
         }
     }
 
-    private createSubContext(node: ts.ExpressionWithTypeArguments, parentContext: Context): Context {
+    protected createSubContext(node: ts.ExpressionWithTypeArguments, parentContext: Context): Context {
         const subContext = new Context(node);
         if (node.typeArguments?.length) {
             node.typeArguments.forEach((typeArg) => {

--- a/src/NodeParser/FunctionParser.ts
+++ b/src/NodeParser/FunctionParser.ts
@@ -12,7 +12,7 @@ import { DefinitionType } from "../Type/DefinitionType";
  * TODO: Parse `ReturnType` of the function?
  */
 export class FunctionParser implements SubNodeParser {
-    constructor(private childNodeParser: NodeParser) {}
+    constructor(protected childNodeParser: NodeParser) {}
 
     public supportsNode(node: ts.ArrowFunction | ts.FunctionDeclaration | ts.FunctionExpression): boolean {
         if (node.kind === ts.SyntaxKind.FunctionDeclaration) {

--- a/src/NodeParser/HiddenTypeNodeParser.ts
+++ b/src/NodeParser/HiddenTypeNodeParser.ts
@@ -5,7 +5,7 @@ import { BaseType } from "../Type/BaseType";
 import { isNodeHidden } from "../Utils/isHidden";
 
 export class HiddenNodeParser implements SubNodeParser {
-    public constructor(private typeChecker: ts.TypeChecker) {}
+    public constructor(protected typeChecker: ts.TypeChecker) {}
 
     public supportsNode(node: ts.KeywordTypeNode): boolean {
         return isNodeHidden(node);

--- a/src/NodeParser/IndexedAccessTypeNodeParser.ts
+++ b/src/NodeParser/IndexedAccessTypeNodeParser.ts
@@ -12,7 +12,7 @@ import { derefType } from "../Utils/derefType";
 import { getTypeByKey } from "../Utils/typeKeys";
 
 export class IndexedAccessTypeNodeParser implements SubNodeParser {
-    public constructor(private childNodeParser: NodeParser) {}
+    public constructor(protected childNodeParser: NodeParser) {}
 
     public supportsNode(node: ts.IndexedAccessTypeNode): boolean {
         return node.kind === ts.SyntaxKind.IndexedAccessType;

--- a/src/NodeParser/InterfaceAndClassNodeParser.ts
+++ b/src/NodeParser/InterfaceAndClassNodeParser.ts
@@ -12,9 +12,9 @@ import { notUndefined } from "../Utils/notUndefined";
 
 export class InterfaceAndClassNodeParser implements SubNodeParser {
     public constructor(
-        private typeChecker: ts.TypeChecker,
-        private childNodeParser: NodeParser,
-        private readonly additionalProperties: boolean
+        protected typeChecker: ts.TypeChecker,
+        protected childNodeParser: NodeParser,
+        protected readonly additionalProperties: boolean
     ) {}
 
     public supportsNode(node: ts.InterfaceDeclaration | ts.ClassDeclaration): boolean {
@@ -74,7 +74,7 @@ export class InterfaceAndClassNodeParser implements SubNodeParser {
      * @param node - The interface or class to check.
      * @return The array item type if node is an array, null otherwise.
      */
-    private getArrayItemType(node: ts.InterfaceDeclaration | ts.ClassDeclaration): ts.TypeNode | null {
+    protected getArrayItemType(node: ts.InterfaceDeclaration | ts.ClassDeclaration): ts.TypeNode | null {
         if (node.heritageClauses && node.heritageClauses.length === 1) {
             const clause = node.heritageClauses[0];
             if (clause.types.length === 1) {
@@ -91,7 +91,7 @@ export class InterfaceAndClassNodeParser implements SubNodeParser {
         return null;
     }
 
-    private getBaseTypes(node: ts.InterfaceDeclaration | ts.ClassDeclaration, context: Context): BaseType[] {
+    protected getBaseTypes(node: ts.InterfaceDeclaration | ts.ClassDeclaration, context: Context): BaseType[] {
         if (!node.heritageClauses) {
             return [];
         }
@@ -107,7 +107,7 @@ export class InterfaceAndClassNodeParser implements SubNodeParser {
         );
     }
 
-    private getProperties(
+    protected getProperties(
         node: ts.InterfaceDeclaration | ts.ClassDeclaration,
         context: Context
     ): ObjectProperty[] | undefined {
@@ -148,7 +148,7 @@ export class InterfaceAndClassNodeParser implements SubNodeParser {
         return properties;
     }
 
-    private getAdditionalProperties(
+    protected getAdditionalProperties(
         node: ts.InterfaceDeclaration | ts.ClassDeclaration,
         context: Context
     ): BaseType | boolean {
@@ -160,12 +160,12 @@ export class InterfaceAndClassNodeParser implements SubNodeParser {
         return this.childNodeParser.createType(indexSignature.type!, context) ?? this.additionalProperties;
     }
 
-    private getTypeId(node: ts.Node, context: Context): string {
+    protected getTypeId(node: ts.Node, context: Context): string {
         const nodeType = ts.isInterfaceDeclaration(node) ? "interface" : "class";
         return `${nodeType}-${getKey(node, context)}`;
     }
 
-    private getPropertyName(propertyName: PropertyName): string {
+    protected getPropertyName(propertyName: PropertyName): string {
         if (propertyName.kind === ts.SyntaxKind.ComputedPropertyName) {
             const symbol = this.typeChecker.getSymbolAtLocation(propertyName);
             if (symbol) {

--- a/src/NodeParser/IntersectionNodeParser.ts
+++ b/src/NodeParser/IntersectionNodeParser.ts
@@ -10,7 +10,7 @@ import { uniqueTypeArray } from "../Utils/uniqueTypeArray";
 import { UndefinedType } from "../Type/UndefinedType";
 
 export class IntersectionNodeParser implements SubNodeParser {
-    public constructor(private typeChecker: ts.TypeChecker, private childNodeParser: NodeParser) {}
+    public constructor(protected typeChecker: ts.TypeChecker, protected childNodeParser: NodeParser) {}
 
     public supportsNode(node: ts.IntersectionTypeNode): boolean {
         return node.kind === ts.SyntaxKind.IntersectionType;

--- a/src/NodeParser/LiteralNodeParser.ts
+++ b/src/NodeParser/LiteralNodeParser.ts
@@ -4,7 +4,7 @@ import { SubNodeParser } from "../SubNodeParser";
 import { BaseType } from "../Type/BaseType";
 
 export class LiteralNodeParser implements SubNodeParser {
-    public constructor(private childNodeParser: NodeParser) {}
+    public constructor(protected childNodeParser: NodeParser) {}
 
     public supportsNode(node: ts.LiteralTypeNode): boolean {
         return node.kind === ts.SyntaxKind.LiteralType;

--- a/src/NodeParser/MappedTypeNodeParser.ts
+++ b/src/NodeParser/MappedTypeNodeParser.ts
@@ -19,7 +19,7 @@ import { notUndefined } from "../Utils/notUndefined";
 import { SymbolType } from "../Type/SymbolType";
 
 export class MappedTypeNodeParser implements SubNodeParser {
-    public constructor(private childNodeParser: NodeParser, private readonly additionalProperties: boolean) {}
+    public constructor(protected childNodeParser: NodeParser, protected readonly additionalProperties: boolean) {}
 
     public supportsNode(node: ts.MappedTypeNode): boolean {
         return node.kind === ts.SyntaxKind.MappedType;
@@ -67,7 +67,7 @@ export class MappedTypeNodeParser implements SubNodeParser {
         }
     }
 
-    private getProperties(node: ts.MappedTypeNode, keyListType: UnionType, context: Context): ObjectProperty[] {
+    protected getProperties(node: ts.MappedTypeNode, keyListType: UnionType, context: Context): ObjectProperty[] {
         return keyListType
             .getTypes()
             .filter((type) => type instanceof LiteralType)
@@ -100,7 +100,7 @@ export class MappedTypeNodeParser implements SubNodeParser {
             }, []);
     }
 
-    private getValues(node: ts.MappedTypeNode, keyListType: EnumType, context: Context): ObjectProperty[] {
+    protected getValues(node: ts.MappedTypeNode, keyListType: EnumType, context: Context): ObjectProperty[] {
         return keyListType
             .getValues()
             .filter((value: EnumValue) => value != null)
@@ -119,7 +119,7 @@ export class MappedTypeNodeParser implements SubNodeParser {
             .filter(notUndefined);
     }
 
-    private getAdditionalProperties(
+    protected getAdditionalProperties(
         node: ts.MappedTypeNode,
         keyListType: UnionType,
         context: Context
@@ -135,7 +135,11 @@ export class MappedTypeNodeParser implements SubNodeParser {
         }
     }
 
-    private createSubContext(node: ts.MappedTypeNode, key: LiteralType | StringType, parentContext: Context): Context {
+    protected createSubContext(
+        node: ts.MappedTypeNode,
+        key: LiteralType | StringType,
+        parentContext: Context
+    ): Context {
         const subContext = new Context(node);
 
         parentContext.getParameters().forEach((parentParameter) => {

--- a/src/NodeParser/ObjectLiteralExpressionNodeParser.ts
+++ b/src/NodeParser/ObjectLiteralExpressionNodeParser.ts
@@ -7,7 +7,7 @@ import { getKey } from "../Utils/nodeKey";
 import { ObjectProperty, ObjectType } from "../Type/ObjectType";
 
 export class ObjectLiteralExpressionNodeParser implements SubNodeParser {
-    public constructor(private childNodeParser: NodeParser) {}
+    public constructor(protected childNodeParser: NodeParser) {}
 
     public supportsNode(node: ts.ObjectLiteralExpression): boolean {
         return node.kind === ts.SyntaxKind.ObjectLiteralExpression;

--- a/src/NodeParser/OptionalTypeNodeParser.ts
+++ b/src/NodeParser/OptionalTypeNodeParser.ts
@@ -5,7 +5,7 @@ import { BaseType } from "../Type/BaseType";
 import { OptionalType } from "../Type/OptionalType";
 
 export class OptionalTypeNodeParser implements SubNodeParser {
-    public constructor(private childNodeParser: NodeParser) {}
+    public constructor(protected childNodeParser: NodeParser) {}
     public supportsNode(node: ts.OptionalTypeNode): boolean {
         return node.kind === ts.SyntaxKind.OptionalType;
     }

--- a/src/NodeParser/ParameterParser.ts
+++ b/src/NodeParser/ParameterParser.ts
@@ -5,7 +5,7 @@ import { SubNodeParser } from "../SubNodeParser";
 import { BaseType } from "../Type/BaseType";
 
 export class ParameterParser implements SubNodeParser {
-    constructor(private childNodeParser: NodeParser) {}
+    constructor(protected childNodeParser: NodeParser) {}
 
     public supportsNode(node: ts.ParameterDeclaration): boolean {
         return node.kind === ts.SyntaxKind.Parameter;

--- a/src/NodeParser/ParenthesizedNodeParser.ts
+++ b/src/NodeParser/ParenthesizedNodeParser.ts
@@ -4,7 +4,7 @@ import { SubNodeParser } from "../SubNodeParser";
 import { BaseType } from "../Type/BaseType";
 
 export class ParenthesizedNodeParser implements SubNodeParser {
-    public constructor(private childNodeParser: NodeParser) {}
+    public constructor(protected childNodeParser: NodeParser) {}
 
     public supportsNode(node: ts.ParenthesizedTypeNode): boolean {
         return node.kind === ts.SyntaxKind.ParenthesizedType;

--- a/src/NodeParser/PrefixUnaryExpressionNodeParser.ts
+++ b/src/NodeParser/PrefixUnaryExpressionNodeParser.ts
@@ -5,7 +5,7 @@ import { BaseType } from "../Type/BaseType";
 import { LiteralType } from "../Type/LiteralType";
 
 export class PrefixUnaryExpressionNodeParser implements SubNodeParser {
-    public constructor(private childNodeParser: NodeParser) {}
+    public constructor(protected childNodeParser: NodeParser) {}
 
     public supportsNode(node: ts.PrefixUnaryExpression): boolean {
         return node.kind === ts.SyntaxKind.PrefixUnaryExpression;

--- a/src/NodeParser/PropertyAccessExpressionParser.ts
+++ b/src/NodeParser/PropertyAccessExpressionParser.ts
@@ -4,7 +4,7 @@ import { SubNodeParser } from "../SubNodeParser";
 import { BaseType } from "../Type/BaseType";
 
 export class PropertyAccessExpressionParser implements SubNodeParser {
-    public constructor(private typeChecker: ts.TypeChecker, private childNodeParser: NodeParser) {}
+    public constructor(protected typeChecker: ts.TypeChecker, protected childNodeParser: NodeParser) {}
 
     public supportsNode(node: ts.PropertyAccessExpression): boolean {
         return node.kind === ts.SyntaxKind.PropertyAccessExpression;

--- a/src/NodeParser/RestTypeNodeParser.ts
+++ b/src/NodeParser/RestTypeNodeParser.ts
@@ -6,7 +6,7 @@ import { BaseType } from "../Type/BaseType";
 import { RestType } from "../Type/RestType";
 
 export class RestTypeNodeParser implements SubNodeParser {
-    public constructor(private childNodeParser: NodeParser) {}
+    public constructor(protected childNodeParser: NodeParser) {}
     public supportsNode(node: ts.RestTypeNode): boolean {
         return node.kind === ts.SyntaxKind.RestType;
     }

--- a/src/NodeParser/TupleNodeParser.ts
+++ b/src/NodeParser/TupleNodeParser.ts
@@ -5,7 +5,7 @@ import { BaseType } from "../Type/BaseType";
 import { TupleType } from "../Type/TupleType";
 
 export class TupleNodeParser implements SubNodeParser {
-    public constructor(private typeChecker: ts.TypeChecker, private childNodeParser: NodeParser) {}
+    public constructor(protected typeChecker: ts.TypeChecker, protected childNodeParser: NodeParser) {}
 
     public supportsNode(node: ts.TupleTypeNode): boolean {
         return node.kind === ts.SyntaxKind.TupleType;

--- a/src/NodeParser/TypeAliasNodeParser.ts
+++ b/src/NodeParser/TypeAliasNodeParser.ts
@@ -7,7 +7,7 @@ import { ReferenceType } from "../Type/ReferenceType";
 import { getKey } from "../Utils/nodeKey";
 
 export class TypeAliasNodeParser implements SubNodeParser {
-    public constructor(private typeChecker: ts.TypeChecker, private childNodeParser: NodeParser) {}
+    public constructor(protected typeChecker: ts.TypeChecker, protected childNodeParser: NodeParser) {}
 
     public supportsNode(node: ts.TypeAliasDeclaration): boolean {
         return node.kind === ts.SyntaxKind.TypeAliasDeclaration;
@@ -44,11 +44,11 @@ export class TypeAliasNodeParser implements SubNodeParser {
         return new AliasType(id, type);
     }
 
-    private getTypeId(node: ts.TypeAliasDeclaration, context: Context): string {
+    protected getTypeId(node: ts.TypeAliasDeclaration, context: Context): string {
         return `alias-${getKey(node, context)}`;
     }
 
-    private getTypeName(node: ts.TypeAliasDeclaration, context: Context): string {
+    protected getTypeName(node: ts.TypeAliasDeclaration, context: Context): string {
         const argumentIds = context.getArguments().map((arg) => arg?.getName());
         const fullName = node.name.getText();
 

--- a/src/NodeParser/TypeLiteralNodeParser.ts
+++ b/src/NodeParser/TypeLiteralNodeParser.ts
@@ -8,7 +8,7 @@ import { isNodeHidden } from "../Utils/isHidden";
 import { getKey } from "../Utils/nodeKey";
 
 export class TypeLiteralNodeParser implements SubNodeParser {
-    public constructor(private childNodeParser: NodeParser, private readonly additionalProperties: boolean) {}
+    public constructor(protected childNodeParser: NodeParser, protected readonly additionalProperties: boolean) {}
 
     public supportsNode(node: ts.TypeLiteralNode): boolean {
         return node.kind === ts.SyntaxKind.TypeLiteral;
@@ -29,7 +29,7 @@ export class TypeLiteralNodeParser implements SubNodeParser {
         return new ObjectType(id, [], properties, this.getAdditionalProperties(node, context));
     }
 
-    private getProperties(node: ts.TypeLiteralNode, context: Context): ObjectProperty[] | undefined {
+    protected getProperties(node: ts.TypeLiteralNode, context: Context): ObjectProperty[] | undefined {
         let hasRequiredNever = false;
 
         const properties = node.members
@@ -56,7 +56,7 @@ export class TypeLiteralNodeParser implements SubNodeParser {
         return properties;
     }
 
-    private getAdditionalProperties(node: ts.TypeLiteralNode, context: Context): BaseType | boolean {
+    protected getAdditionalProperties(node: ts.TypeLiteralNode, context: Context): BaseType | boolean {
         const indexSignature = node.members.find(ts.isIndexSignatureDeclaration);
         if (!indexSignature) {
             return this.additionalProperties;
@@ -65,7 +65,7 @@ export class TypeLiteralNodeParser implements SubNodeParser {
         return this.childNodeParser.createType(indexSignature.type!, context) ?? this.additionalProperties;
     }
 
-    private getTypeId(node: ts.Node, context: Context): string {
+    protected getTypeId(node: ts.Node, context: Context): string {
         return `structure-${getKey(node, context)}`;
     }
 }

--- a/src/NodeParser/TypeOperatorNodeParser.ts
+++ b/src/NodeParser/TypeOperatorNodeParser.ts
@@ -11,7 +11,7 @@ import { derefType } from "../Utils/derefType";
 import { getTypeKeys } from "../Utils/typeKeys";
 
 export class TypeOperatorNodeParser implements SubNodeParser {
-    public constructor(private childNodeParser: NodeParser) {}
+    public constructor(protected childNodeParser: NodeParser) {}
 
     public supportsNode(node: ts.TypeOperatorNode): boolean {
         return node.kind === ts.SyntaxKind.TypeOperator;

--- a/src/NodeParser/TypeReferenceNodeParser.ts
+++ b/src/NodeParser/TypeReferenceNodeParser.ts
@@ -12,7 +12,7 @@ const invlidTypes: { [index: number]: boolean } = {
 };
 
 export class TypeReferenceNodeParser implements SubNodeParser {
-    public constructor(private typeChecker: ts.TypeChecker, private childNodeParser: NodeParser) {}
+    public constructor(protected typeChecker: ts.TypeChecker, protected childNodeParser: NodeParser) {}
 
     public supportsNode(node: ts.TypeReferenceNode): boolean {
         return node.kind === ts.SyntaxKind.TypeReference;
@@ -46,7 +46,7 @@ export class TypeReferenceNodeParser implements SubNodeParser {
         }
     }
 
-    private createSubContext(node: ts.TypeReferenceNode, parentContext: Context): Context {
+    protected createSubContext(node: ts.TypeReferenceNode, parentContext: Context): Context {
         const subContext = new Context(node);
         if (node.typeArguments?.length) {
             for (const typeArg of node.typeArguments) {

--- a/src/NodeParser/TypeofNodeParser.ts
+++ b/src/NodeParser/TypeofNodeParser.ts
@@ -9,7 +9,7 @@ import { getKey } from "../Utils/nodeKey";
 import { LiteralType } from "../Type/LiteralType";
 
 export class TypeofNodeParser implements SubNodeParser {
-    public constructor(private typeChecker: ts.TypeChecker, private childNodeParser: NodeParser) {}
+    public constructor(protected typeChecker: ts.TypeChecker, protected childNodeParser: NodeParser) {}
 
     public supportsNode(node: ts.TypeQueryNode): boolean {
         return node.kind === ts.SyntaxKind.TypeQuery;
@@ -43,7 +43,7 @@ export class TypeofNodeParser implements SubNodeParser {
         throw new LogicError(`Invalid type query "${valueDec.getFullText()}" (ts.SyntaxKind = ${valueDec.kind})`);
     }
 
-    private createObjectFromEnum(node: ts.EnumDeclaration, context: Context, reference?: ReferenceType): ObjectType {
+    protected createObjectFromEnum(node: ts.EnumDeclaration, context: Context, reference?: ReferenceType): ObjectType {
         const id = `typeof-enum-${getKey(node, context)}`;
         if (reference) {
             reference.setId(id);

--- a/src/NodeParser/UnionNodeParser.ts
+++ b/src/NodeParser/UnionNodeParser.ts
@@ -6,7 +6,7 @@ import { BaseType } from "../Type/BaseType";
 import { notUndefined } from "../Utils/notUndefined";
 
 export class UnionNodeParser implements SubNodeParser {
-    public constructor(private typeChecker: ts.TypeChecker, private childNodeParser: NodeParser) {}
+    public constructor(protected typeChecker: ts.TypeChecker, protected childNodeParser: NodeParser) {}
 
     public supportsNode(node: ts.UnionTypeNode): boolean {
         return node.kind === ts.SyntaxKind.UnionType;

--- a/src/TopRefNodeParser.ts
+++ b/src/TopRefNodeParser.ts
@@ -5,9 +5,9 @@ import { DefinitionType } from "./Type/DefinitionType";
 
 export class TopRefNodeParser implements NodeParser {
     public constructor(
-        private childNodeParser: NodeParser,
-        private fullName: string | undefined,
-        private topRef: boolean
+        protected childNodeParser: NodeParser,
+        protected fullName: string | undefined,
+        protected topRef: boolean
     ) {}
 
     public createType(node: ts.Node, context: Context): BaseType | undefined {

--- a/src/TypeFormatter/AliasTypeFormatter.ts
+++ b/src/TypeFormatter/AliasTypeFormatter.ts
@@ -5,7 +5,7 @@ import { BaseType } from "../Type/BaseType";
 import { TypeFormatter } from "../TypeFormatter";
 
 export class AliasTypeFormatter implements SubTypeFormatter {
-    public constructor(private childTypeFormatter: TypeFormatter) {}
+    public constructor(protected childTypeFormatter: TypeFormatter) {}
 
     public supportsType(type: AliasType): boolean {
         return type instanceof AliasType;

--- a/src/TypeFormatter/AnnotatedTypeFormatter.ts
+++ b/src/TypeFormatter/AnnotatedTypeFormatter.ts
@@ -44,7 +44,7 @@ export function makeNullable(def: Definition): Definition {
 }
 
 export class AnnotatedTypeFormatter implements SubTypeFormatter {
-    public constructor(private childTypeFormatter: TypeFormatter) {}
+    public constructor(protected childTypeFormatter: TypeFormatter) {}
 
     public supportsType(type: AnnotatedType): boolean {
         return type instanceof AnnotatedType;

--- a/src/TypeFormatter/DefinitionTypeFormatter.ts
+++ b/src/TypeFormatter/DefinitionTypeFormatter.ts
@@ -6,7 +6,7 @@ import { TypeFormatter } from "../TypeFormatter";
 import { uniqueArray } from "../Utils/uniqueArray";
 
 export class DefinitionTypeFormatter implements SubTypeFormatter {
-    public constructor(private childTypeFormatter: TypeFormatter, private encodeRefs: boolean) {}
+    public constructor(protected childTypeFormatter: TypeFormatter, protected encodeRefs: boolean) {}
 
     public supportsType(type: DefinitionType): boolean {
         return type instanceof DefinitionType;

--- a/src/TypeFormatter/IntersectionTypeFormatter.ts
+++ b/src/TypeFormatter/IntersectionTypeFormatter.ts
@@ -7,7 +7,7 @@ import { getAllOfDefinitionReducer } from "../Utils/allOfDefinition";
 import { uniqueArray } from "../Utils/uniqueArray";
 
 export class IntersectionTypeFormatter implements SubTypeFormatter {
-    public constructor(private childTypeFormatter: TypeFormatter) {}
+    public constructor(protected childTypeFormatter: TypeFormatter) {}
 
     public supportsType(type: IntersectionType): boolean {
         return type instanceof IntersectionType;

--- a/src/TypeFormatter/LiteralUnionTypeFormatter.ts
+++ b/src/TypeFormatter/LiteralUnionTypeFormatter.ts
@@ -32,13 +32,13 @@ export class LiteralUnionTypeFormatter implements SubTypeFormatter {
         return [];
     }
 
-    private isLiteralUnion(type: UnionType): boolean {
+    protected isLiteralUnion(type: UnionType): boolean {
         return type.getTypes().every((item) => item instanceof LiteralType || item instanceof NullType);
     }
-    private getLiteralValue(value: LiteralType | NullType): string | number | boolean | null {
+    protected getLiteralValue(value: LiteralType | NullType): string | number | boolean | null {
         return value instanceof LiteralType ? value.getValue() : null;
     }
-    private getLiteralType(value: LiteralType | NullType): RawTypeName {
+    protected getLiteralType(value: LiteralType | NullType): RawTypeName {
         return value instanceof LiteralType ? typeName(value.getValue()) : "null";
     }
 }

--- a/src/TypeFormatter/ObjectTypeFormatter.ts
+++ b/src/TypeFormatter/ObjectTypeFormatter.ts
@@ -15,7 +15,7 @@ import { StringMap } from "../Utils/StringMap";
 import { uniqueArray } from "../Utils/uniqueArray";
 
 export class ObjectTypeFormatter implements SubTypeFormatter {
-    public constructor(private childTypeFormatter: TypeFormatter) {}
+    public constructor(protected childTypeFormatter: TypeFormatter) {}
 
     public supportsType(type: ObjectType): boolean {
         return type instanceof ObjectType;
@@ -58,7 +58,7 @@ export class ObjectTypeFormatter implements SubTypeFormatter {
         return uniqueArray(children);
     }
 
-    private getObjectDefinition(type: ObjectType): Definition {
+    protected getObjectDefinition(type: ObjectType): Definition {
         const objectProperties = type.getProperties();
         const additionalProperties: BaseType | boolean = type.getAdditionalProperties();
 
@@ -95,7 +95,7 @@ export class ObjectTypeFormatter implements SubTypeFormatter {
         };
     }
 
-    private prepareObjectProperty(property: ObjectProperty): ObjectProperty {
+    protected prepareObjectProperty(property: ObjectProperty): ObjectProperty {
         const propertyType = property.getType();
         const propType = derefType(propertyType);
 

--- a/src/TypeFormatter/OptionalTypeFormatter.ts
+++ b/src/TypeFormatter/OptionalTypeFormatter.ts
@@ -5,7 +5,7 @@ import { OptionalType } from "../Type/OptionalType";
 import { TypeFormatter } from "../TypeFormatter";
 
 export class OptionalTypeFormatter implements SubTypeFormatter {
-    public constructor(private childTypeFormatter: TypeFormatter) {}
+    public constructor(protected childTypeFormatter: TypeFormatter) {}
 
     public supportsType(type: OptionalType): boolean {
         return type instanceof OptionalType;

--- a/src/TypeFormatter/PrimitiveUnionTypeFormatter.ts
+++ b/src/TypeFormatter/PrimitiveUnionTypeFormatter.ts
@@ -24,10 +24,10 @@ export class PrimitiveUnionTypeFormatter implements SubTypeFormatter {
         return [];
     }
 
-    private isPrimitiveUnion(type: UnionType): boolean {
+    protected isPrimitiveUnion(type: UnionType): boolean {
         return type.getTypes().every((item) => item instanceof PrimitiveType);
     }
-    private getPrimitiveType(item: BaseType): RawTypeName {
+    protected getPrimitiveType(item: BaseType): RawTypeName {
         if (item instanceof StringType) {
             return "string";
         } else if (item instanceof NumberType) {

--- a/src/TypeFormatter/ReferenceTypeFormatter.ts
+++ b/src/TypeFormatter/ReferenceTypeFormatter.ts
@@ -6,7 +6,7 @@ import { ReferenceType } from "../Type/ReferenceType";
 import { TypeFormatter } from "../TypeFormatter";
 
 export class ReferenceTypeFormatter implements SubTypeFormatter {
-    public constructor(private childTypeFormatter: TypeFormatter, private encodeRefs: boolean) {}
+    public constructor(protected childTypeFormatter: TypeFormatter, protected encodeRefs: boolean) {}
 
     public supportsType(type: ReferenceType): boolean {
         return type instanceof ReferenceType;
@@ -25,7 +25,7 @@ export class ReferenceTypeFormatter implements SubTypeFormatter {
             return this.childTypeFormatter.getChildren(referredType);
         }
 
-        // this means that the referred interface is private
+        // this means that the referred interface is protected
         // so we have to expose it in the schema definitions
         return this.childTypeFormatter.getChildren(new DefinitionType(type.getName(), type.getType()));
     }

--- a/src/TypeFormatter/RestTypeFormatter.ts
+++ b/src/TypeFormatter/RestTypeFormatter.ts
@@ -5,7 +5,7 @@ import { RestType } from "../Type/RestType";
 import { TypeFormatter } from "../TypeFormatter";
 
 export class RestTypeFormatter implements SubTypeFormatter {
-    public constructor(private childTypeFormatter: TypeFormatter) {}
+    public constructor(protected childTypeFormatter: TypeFormatter) {}
 
     public supportsType(type: RestType): boolean {
         return type instanceof RestType;

--- a/src/TypeFormatter/TupleTypeFormatter.ts
+++ b/src/TypeFormatter/TupleTypeFormatter.ts
@@ -9,7 +9,7 @@ import { notUndefined } from "../Utils/notUndefined";
 import { uniqueArray } from "../Utils/uniqueArray";
 
 export class TupleTypeFormatter implements SubTypeFormatter {
-    public constructor(private childTypeFormatter: TypeFormatter) {}
+    public constructor(protected childTypeFormatter: TypeFormatter) {}
 
     public supportsType(type: TupleType): boolean {
         return type instanceof TupleType;

--- a/src/TypeFormatter/UnionTypeFormatter.ts
+++ b/src/TypeFormatter/UnionTypeFormatter.ts
@@ -7,7 +7,7 @@ import { TypeFormatter } from "../TypeFormatter";
 import { uniqueArray } from "../Utils/uniqueArray";
 
 export class UnionTypeFormatter implements SubTypeFormatter {
-    public constructor(private childTypeFormatter: TypeFormatter) {}
+    public constructor(protected childTypeFormatter: TypeFormatter) {}
 
     public supportsType(type: UnionType): boolean {
         return type instanceof UnionType;


### PR DESCRIPTION
Fixes #1160

It just changes most scopes from `private` to `protected` to allow extended classes,
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.98.1-next.1`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: Remi Cattiau ([@loopingz](https://github.com/loopingz))
  
  :heart: Hadrien Milano ([@hmil](https://github.com/hmil))
  
  #### 🚀 Enhancement
  
  - feat: move private to protected to allow extending behavior [#1161](https://github.com/vega/ts-json-schema-generator/pull/1161) ([@loopingz](https://github.com/loopingz))
  - feat: add support for never type [#1154](https://github.com/vega/ts-json-schema-generator/pull/1154) ([@hmil](https://github.com/hmil))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.13.0 to 5.14.0 [#1157](https://github.com/vega/ts-json-schema-generator/pull/1157) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega from 5.21.0 to 5.22.0 [#1156](https://github.com/vega/ts-json-schema-generator/pull/1156) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.13.0 to 5.14.0 [#1158](https://github.com/vega/ts-json-schema-generator/pull/1158) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.10.0 to 8.11.0 [#1159](https://github.com/vega/ts-json-schema-generator/pull/1159) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.12.1 to 5.13.0 [#1144](https://github.com/vega/ts-json-schema-generator/pull/1144) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.32.6 to 10.34.1 [#1145](https://github.com/vega/ts-json-schema-generator/pull/1145) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.12.1 to 5.13.0 [#1146](https://github.com/vega/ts-json-schema-generator/pull/1146) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ts-node from 10.5.0 to 10.7.0 [#1147](https://github.com/vega/ts-json-schema-generator/pull/1147) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.32.6 to 10.34.1 [#1148](https://github.com/vega/ts-json-schema-generator/pull/1148) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.5.5 to 4.6.2 [#1149](https://github.com/vega/ts-json-schema-generator/pull/1149) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.32.6 to 10.34.1 [#1150](https://github.com/vega/ts-json-schema-generator/pull/1150) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 8.4.0 to 8.5.0 [#1151](https://github.com/vega/ts-json-schema-generator/pull/1151) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/checkout from 2 to 3 [#1143](https://github.com/vega/ts-json-schema-generator/pull/1143) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.12.0 to 5.12.1 [#1139](https://github.com/vega/ts-json-schema-generator/pull/1139) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.9.0 to 8.10.0 [#1138](https://github.com/vega/ts-json-schema-generator/pull/1138) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.18 to 17.0.21 [#1140](https://github.com/vega/ts-json-schema-generator/pull/1140) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 27.4.0 to 27.4.1 [#1141](https://github.com/vega/ts-json-schema-generator/pull/1141) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.12.0 to 5.12.1 [#1142](https://github.com/vega/ts-json-schema-generator/pull/1142) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/setup-node from 2.5.1 to 3 [#1137](https://github.com/vega/ts-json-schema-generator/pull/1137) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.11.0 to 5.12.0 [#1132](https://github.com/vega/ts-json-schema-generator/pull/1132) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.17.2 to 7.17.5 [#1133](https://github.com/vega/ts-json-schema-generator/pull/1133) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.17 to 17.0.18 [#1134](https://github.com/vega/ts-json-schema-generator/pull/1134) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.11.0 to 5.12.0 [#1135](https://github.com/vega/ts-json-schema-generator/pull/1135) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 8.3.0 to 8.4.0 [#1136](https://github.com/vega/ts-json-schema-generator/pull/1136) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 3
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Hadrien Milano ([@hmil](https://github.com/hmil))
  - Remi Cattiau ([@loopingz](https://github.com/loopingz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
