### PR TITLE
feat: support template literals as types.

### DIFF
--- a/factory/parser.ts
+++ b/factory/parser.ts
@@ -39,6 +39,7 @@ import { PrefixUnaryExpressionNodeParser } from "../src/NodeParser/PrefixUnaryEx
 import { PropertyAccessExpressionParser } from "../src/NodeParser/PropertyAccessExpressionParser";
 import { RestTypeNodeParser } from "../src/NodeParser/RestTypeNodeParser";
 import { StringLiteralNodeParser } from "../src/NodeParser/StringLiteralNodeParser";
+import { StringTemplateLiteralNodeParser } from "../src/NodeParser/StringTemplateLiteralNodeParser";
 import { StringTypeNodeParser } from "../src/NodeParser/StringTypeNodeParser";
 import { SymbolTypeNodeParser } from "../src/NodeParser/SymbolTypeNodeParser";
 import { TupleNodeParser } from "../src/NodeParser/TupleNodeParser";
@@ -102,6 +103,7 @@ export function createParser(program: ts.Program, config: Config, augmentor?: Pa
         .addNodeParser(new FunctionParser(chainNodeParser))
         .addNodeParser(withJsDoc(new ParameterParser(chainNodeParser)))
         .addNodeParser(new StringLiteralNodeParser())
+        .addNodeParser(new StringTemplateLiteralNodeParser(chainNodeParser))
         .addNodeParser(new NumberLiteralNodeParser())
         .addNodeParser(new BooleanLiteralNodeParser())
         .addNodeParser(new NullLiteralNodeParser())

--- a/src/NodeParser/StringTemplateLiteralNodeParser.ts
+++ b/src/NodeParser/StringTemplateLiteralNodeParser.ts
@@ -20,16 +20,13 @@ export class StringTemplateLiteralNodeParser implements SubNodeParser {
             return new LiteralType(node.text);
         }
         const prefix = node.head.text;
-        const matrix: string[][] = [[prefix]];
-
-        for (const span of node.templateSpans) {
-            const suffix = span.literal.text;
-
-            const type = this.childNodeParser.createType(span.type, context);
-            const literals = [...extractLiterals(type)];
-
-            matrix.push(literals.map((value) => value + suffix));
-        }
+        const matrix: string[][] = [[prefix]].concat(
+            node.templateSpans.map((span) => {
+                const suffix = span.literal.text;
+                const type = this.childNodeParser.createType(span.type, context);
+                return [...extractLiterals(type)].map((value) => value + suffix);
+            })
+        );
 
         const expandedLiterals = expand(matrix);
 
@@ -44,8 +41,9 @@ export class StringTemplateLiteralNodeParser implements SubNodeParser {
 }
 
 function expand(matrix: string[][]): string[] {
-    if (!matrix.length) return [];
-    if (matrix.length === 1) return matrix[0];
+    if (matrix.length === 1) {
+        return matrix[0];
+    }
     const head = matrix[0];
     const nested = expand(matrix.slice(1));
     const combined = head.map((prefix) => nested.map((suffix) => prefix + suffix));

--- a/src/NodeParser/StringTemplateLiteralNodeParser.ts
+++ b/src/NodeParser/StringTemplateLiteralNodeParser.ts
@@ -1,0 +1,73 @@
+import ts from "typescript";
+import { UnknownTypeError } from "../Error/UnknownTypeError";
+import { Context, NodeParser } from "../NodeParser";
+import { SubNodeParser } from "../SubNodeParser";
+import { AliasType } from "../Type/AliasType";
+import { BaseType } from "../Type/BaseType";
+import { LiteralType } from "../Type/LiteralType";
+import { UnionType } from "../Type/UnionType";
+
+export class StringTemplateLiteralNodeParser implements SubNodeParser {
+    public constructor(protected childNodeParser: NodeParser) {}
+
+    public supportsNode(node: ts.NoSubstitutionTemplateLiteral | ts.TemplateLiteralTypeNode): boolean {
+        return (
+            node.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral || node.kind === ts.SyntaxKind.TemplateLiteralType
+        );
+    }
+    public createType(node: ts.NoSubstitutionTemplateLiteral | ts.TemplateLiteralTypeNode, context: Context): BaseType {
+        if (node.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral) {
+            return new LiteralType(node.text);
+        }
+        const prefix = node.head.text;
+        const matrix: string[][] = [[prefix]];
+
+        for (const span of node.templateSpans) {
+            const suffix = span.literal.text;
+
+            const type = this.childNodeParser.createType(span.type, context);
+            const literals = [...extractLiterals(type)];
+
+            matrix.push(literals.map((value) => value + suffix));
+        }
+
+        const expandedLiterals = expand(matrix);
+
+        const expandedTypes = expandedLiterals.map((literal) => new LiteralType(literal));
+
+        if (expandedTypes.length === 1) {
+            return expandedTypes[0];
+        }
+
+        return new UnionType(expandedTypes);
+    }
+}
+
+function expand(matrix: string[][]): string[] {
+    if (!matrix.length) return [];
+    if (matrix.length === 1) return matrix[0];
+    const head = matrix[0];
+    const nested = expand(matrix.slice(1));
+    const combined = head.map((prefix) => nested.map((suffix) => prefix + suffix));
+    return ([] as string[]).concat(...combined);
+}
+
+function* extractLiterals(type: BaseType | undefined): Iterable<string> {
+    if (!type) return;
+    if (type instanceof LiteralType) {
+        yield type.getValue().toString();
+        return;
+    }
+    if (type instanceof UnionType) {
+        for (const t of type.getTypes()) {
+            yield* extractLiterals(t);
+        }
+        return;
+    }
+    if (type instanceof AliasType) {
+        yield* extractLiterals(type.getType());
+        return;
+    }
+
+    throw new UnknownTypeError(type);
+}

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -37,6 +37,8 @@ describe("valid-data-other", () => {
     it("string-literals", assertValidSchema("string-literals", "MyObject"));
     it("string-literals-inline", assertValidSchema("string-literals-inline", "MyObject"));
     it("string-literals-null", assertValidSchema("string-literals-null", "MyObject"));
+    it("string-template-literals", assertValidSchema("string-template-literals", "MyObject"));
+    it("string-template-expression-literals", assertValidSchema("string-template-expression-literals", "MyObject"));
 
     it("namespace-deep-1", assertValidSchema("namespace-deep-1", "RootNamespace.Def"));
     it("namespace-deep-2", assertValidSchema("namespace-deep-2", "RootNamespace.SubNamespace.HelperA"));

--- a/test/valid-data/string-template-expression-literals/main.ts
+++ b/test/valid-data/string-template-expression-literals/main.ts
@@ -1,8 +1,10 @@
 type OK = "ok";
 type Result = OK | "fail" | `abort`;
 type PrivateResultId = `__${Result}_id`;
+type OK_ID = `id_${OK}`;
 
 export interface MyObject {
     foo: Result;
     _foo: PrivateResultId;
+    ok: OK_ID;
 }

--- a/test/valid-data/string-template-expression-literals/main.ts
+++ b/test/valid-data/string-template-expression-literals/main.ts
@@ -1,0 +1,8 @@
+type OK = "ok";
+type Result = OK | "fail" | `abort`;
+type PrivateResultId = `__${Result}_id`;
+
+export interface MyObject {
+    foo: Result;
+    _foo: PrivateResultId;
+}

--- a/test/valid-data/string-template-expression-literals/schema.json
+++ b/test/valid-data/string-template-expression-literals/schema.json
@@ -1,0 +1,32 @@
+{
+    "$ref": "#/definitions/MyObject",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "MyObject": {
+            "additionalProperties": false,
+            "properties": {
+                "_foo": {
+                    "enum": [
+                        "__ok_id",
+                        "__fail_id",
+                        "__abort_id"
+                    ],
+                    "type": "string"
+                },
+                "foo": {
+                    "enum": [
+                        "ok",
+                        "fail",
+                        "abort"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "foo",
+                "_foo"
+            ],
+            "type": "object"
+        }
+    }
+}

--- a/test/valid-data/string-template-expression-literals/schema.json
+++ b/test/valid-data/string-template-expression-literals/schema.json
@@ -20,11 +20,16 @@
                         "abort"
                     ],
                     "type": "string"
+                },
+                "ok": {
+                    "const": "id_ok",
+                    "type": "string"
                 }
             },
             "required": [
                 "foo",
-                "_foo"
+                "_foo",
+                "ok"
             ],
             "type": "object"
         }

--- a/test/valid-data/string-template-literals/main.ts
+++ b/test/valid-data/string-template-literals/main.ts
@@ -1,0 +1,5 @@
+type Result = "ok" | "fail" | `abort`;
+
+export interface MyObject {
+    foo: Result;
+}

--- a/test/valid-data/string-template-literals/schema.json
+++ b/test/valid-data/string-template-literals/schema.json
@@ -1,0 +1,23 @@
+{
+    "$ref": "#/definitions/MyObject",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "MyObject": {
+            "additionalProperties": false,
+            "properties": {
+                "foo": {
+                    "enum": [
+                        "ok",
+                        "fail",
+                        "abort"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "foo"
+            ],
+            "type": "object"
+        }
+    }
+}


### PR DESCRIPTION
This PR is to add support for Template Literals.

See: [TypeScript: Documentation - Template Literal Types](https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html)

I'll add support later for [Intrinsic String Manipulation Types](https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html#intrinsic-string-manipulation-types)

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.98.1-next.2`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: Jason Dent ([@Jason3S](https://github.com/Jason3S))
  
  :heart: Remi Cattiau ([@loopingz](https://github.com/loopingz))
  
  :heart: Hadrien Milano ([@hmil](https://github.com/hmil))
  
  #### 🚀 Enhancement
  
  - feat: support template literals as types. [#1171](https://github.com/vega/ts-json-schema-generator/pull/1171) ([@Jason3S](https://github.com/Jason3S))
  - feat: move private to protected to allow extending behavior [#1161](https://github.com/vega/ts-json-schema-generator/pull/1161) ([@loopingz](https://github.com/loopingz))
  - feat: add support for never type [#1154](https://github.com/vega/ts-json-schema-generator/pull/1154) ([@hmil](https://github.com/hmil))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.14.0 to 5.15.0 [#1164](https://github.com/vega/ts-json-schema-generator/pull/1164) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.17.5 to 7.17.8 [#1162](https://github.com/vega/ts-json-schema-generator/pull/1162) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.34.1 to 10.34.2 [#1163](https://github.com/vega/ts-json-schema-generator/pull/1163) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.5.1 to 2.6.0 [#1165](https://github.com/vega/ts-json-schema-generator/pull/1165) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @types/json-schema from 7.0.9 to 7.0.10 [#1166](https://github.com/vega/ts-json-schema-generator/pull/1166) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.34.1 to 10.34.2 [#1167](https://github.com/vega/ts-json-schema-generator/pull/1167) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.14.0 to 5.15.0 [#1168](https://github.com/vega/ts-json-schema-generator/pull/1168) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 9.0.0 to 9.1.0 [#1169](https://github.com/vega/ts-json-schema-generator/pull/1169) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.34.1 to 10.34.2 [#1170](https://github.com/vega/ts-json-schema-generator/pull/1170) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.13.0 to 5.14.0 [#1157](https://github.com/vega/ts-json-schema-generator/pull/1157) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega from 5.21.0 to 5.22.0 [#1156](https://github.com/vega/ts-json-schema-generator/pull/1156) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.13.0 to 5.14.0 [#1158](https://github.com/vega/ts-json-schema-generator/pull/1158) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.10.0 to 8.11.0 [#1159](https://github.com/vega/ts-json-schema-generator/pull/1159) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.12.1 to 5.13.0 [#1144](https://github.com/vega/ts-json-schema-generator/pull/1144) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.32.6 to 10.34.1 [#1145](https://github.com/vega/ts-json-schema-generator/pull/1145) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.12.1 to 5.13.0 [#1146](https://github.com/vega/ts-json-schema-generator/pull/1146) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ts-node from 10.5.0 to 10.7.0 [#1147](https://github.com/vega/ts-json-schema-generator/pull/1147) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.32.6 to 10.34.1 [#1148](https://github.com/vega/ts-json-schema-generator/pull/1148) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.5.5 to 4.6.2 [#1149](https://github.com/vega/ts-json-schema-generator/pull/1149) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.32.6 to 10.34.1 [#1150](https://github.com/vega/ts-json-schema-generator/pull/1150) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 8.4.0 to 8.5.0 [#1151](https://github.com/vega/ts-json-schema-generator/pull/1151) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/checkout from 2 to 3 [#1143](https://github.com/vega/ts-json-schema-generator/pull/1143) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.12.0 to 5.12.1 [#1139](https://github.com/vega/ts-json-schema-generator/pull/1139) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.9.0 to 8.10.0 [#1138](https://github.com/vega/ts-json-schema-generator/pull/1138) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.18 to 17.0.21 [#1140](https://github.com/vega/ts-json-schema-generator/pull/1140) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 27.4.0 to 27.4.1 [#1141](https://github.com/vega/ts-json-schema-generator/pull/1141) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.12.0 to 5.12.1 [#1142](https://github.com/vega/ts-json-schema-generator/pull/1142) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/setup-node from 2.5.1 to 3 [#1137](https://github.com/vega/ts-json-schema-generator/pull/1137) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.11.0 to 5.12.0 [#1132](https://github.com/vega/ts-json-schema-generator/pull/1132) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.17.2 to 7.17.5 [#1133](https://github.com/vega/ts-json-schema-generator/pull/1133) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.17 to 17.0.18 [#1134](https://github.com/vega/ts-json-schema-generator/pull/1134) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.11.0 to 5.12.0 [#1135](https://github.com/vega/ts-json-schema-generator/pull/1135) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 8.3.0 to 8.4.0 [#1136](https://github.com/vega/ts-json-schema-generator/pull/1136) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 4
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Hadrien Milano ([@hmil](https://github.com/hmil))
  - Jason Dent ([@Jason3S](https://github.com/Jason3S))
  - Remi Cattiau ([@loopingz](https://github.com/loopingz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
