### PR TITLE
feat!: allow JSDoc tags without explicit value (e.g. `@deprecated`) to default to `true`

### DIFF
--- a/src/AnnotationsReader/BasicAnnotationsReader.ts
+++ b/src/AnnotationsReader/BasicAnnotationsReader.ts
@@ -86,7 +86,7 @@ export class BasicAnnotationsReader implements AnnotationsReader {
 
     private parseJsDocTag(jsDocTag: ts.JSDocTagInfo): any {
         // Tags without explicit value (e.g. `@deprecated`) default to `true`.
-        const text = jsDocTag.text ? jsDocTag.text.map((part) => part.text).join("") : "true";
+        const text = jsDocTag.text?.map((part) => part.text).join("") || "true";
 
         if (BasicAnnotationsReader.textTags.has(jsDocTag.name)) {
             return text;

--- a/src/AnnotationsReader/BasicAnnotationsReader.ts
+++ b/src/AnnotationsReader/BasicAnnotationsReader.ts
@@ -85,7 +85,9 @@ export class BasicAnnotationsReader implements AnnotationsReader {
     }
 
     private parseJsDocTag(jsDocTag: ts.JSDocTagInfo): any {
-        const text = (jsDocTag.text ?? []).map((part) => part.text).join("");
+        // Tags without explicit value (e.g. `@deprecated`) default to `true`.
+        const text = jsDocTag.text ? jsDocTag.text.map((part) => part.text).join("") : "true";
+
         if (BasicAnnotationsReader.textTags.has(jsDocTag.name)) {
             return text;
         } else if (BasicAnnotationsReader.jsonTags.has(jsDocTag.name)) {
@@ -97,6 +99,7 @@ export class BasicAnnotationsReader implements AnnotationsReader {
             return undefined;
         }
     }
+
     private parseJson(value: string): any {
         try {
             return json5.parse(value);

--- a/test/valid-data-annotations.test.ts
+++ b/test/valid-data-annotations.test.ts
@@ -4,6 +4,7 @@ describe("valid-data-annotations", () => {
     it(
         "annotation-custom",
         assertValidSchema("annotation-custom", "MyObject", "basic", [
+            "customBooleanProperty",
             "customNumberProperty",
             "customStringProperty",
             "customComplexProperty",
@@ -18,15 +19,19 @@ describe("valid-data-annotations", () => {
         assertValidSchema("annotation-empty", "MyObject", "extended", ["customEmptyAnnotation"])
     );
     it(
-        "annotation-deprecated-empty-basic",
-        assertValidSchema("annotation-deprecated-empty", "MyObject", "basic", ["customEmptyAnnotation"])
+        "annotation-deprecated-basic",
+        assertValidSchema("annotation-deprecated", "MyObject", "basic", ["deprecationMessage"])
     );
     it(
-        "annotation-deprecated-empty-extended",
-        assertValidSchema("annotation-deprecated-empty", "MyObject", "extended", ["customEmptyAnnotation"])
+        "annotation-deprecated-extended",
+        assertValidSchema("annotation-deprecated", "MyObject", "extended", ["deprecationMessage"])
     );
 
     it("annotation-comment", assertValidSchema("annotation-comment", "MyObject", "extended"));
 
     it("annotation-id", assertValidSchema("annotation-id", "MyObject", "extended", [], "Test"));
+
+    it("annotation-readOnly", assertValidSchema("annotation-readOnly", "MyObject", "basic"));
+
+    it("annotation-writeOnly", assertValidSchema("annotation-writeOnly", "MyObject", "basic"));
 });

--- a/test/valid-data/annotation-custom/main.ts
+++ b/test/valid-data/annotation-custom/main.ts
@@ -1,4 +1,5 @@
 /**
+ * @customBooleanProperty false
  * @customNumberProperty 14
  * @customStringProperty "string-value"
  * @customComplexProperty { "a": 1, "b": 2 }

--- a/test/valid-data/annotation-custom/schema.json
+++ b/test/valid-data/annotation-custom/schema.json
@@ -4,6 +4,7 @@
   "definitions": {
     "MyObject": {
       "additionalProperties": false,
+      "customBooleanProperty": false,
       "customComplexProperty": {
         "a": 1,
         "b": 2

--- a/test/valid-data/annotation-deprecated-empty/main.ts
+++ b/test/valid-data/annotation-deprecated-empty/main.ts
@@ -1,4 +1,0 @@
-/**
- * @deprecated
- */
-export interface MyObject {}

--- a/test/valid-data/annotation-deprecated/main.ts
+++ b/test/valid-data/annotation-deprecated/main.ts
@@ -1,0 +1,9 @@
+/**
+ * @deprecated
+ * @deprecationMessage Use `NewMyObject` instead.
+ */
+export interface MyObject {
+    one?: string;
+    /** @deprecated */
+    two?: number;
+}

--- a/test/valid-data/annotation-deprecated/schema.json
+++ b/test/valid-data/annotation-deprecated/schema.json
@@ -1,0 +1,21 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "deprecated": true,
+      "deprecationMessage": "Use `NewMyObject` instead.",
+      "properties": {
+        "one": {
+          "type": "string"
+        },
+        "two": {
+          "deprecated": true,
+          "type": "number"
+        }
+      },
+      "type": "object"
+    }
+  }
+}

--- a/test/valid-data/annotation-readOnly/main.ts
+++ b/test/valid-data/annotation-readOnly/main.ts
@@ -1,0 +1,5 @@
+export interface MyObject {
+    one?: string;
+    /** @readOnly */
+    two?: number;
+}

--- a/test/valid-data/annotation-readOnly/schema.json
+++ b/test/valid-data/annotation-readOnly/schema.json
@@ -4,7 +4,15 @@
   "definitions": {
     "MyObject": {
       "additionalProperties": false,
-      "customEmptyAnnotation": true,
+      "properties": {
+        "one": {
+          "type": "string"
+        },
+        "two": {
+          "readOnly": true,
+          "type": "number"
+        }
+      },
       "type": "object"
     }
   }

--- a/test/valid-data/annotation-writeOnly/main.ts
+++ b/test/valid-data/annotation-writeOnly/main.ts
@@ -1,0 +1,5 @@
+export interface MyObject {
+    one?: string;
+    /** @writeOnly */
+    two?: number;
+}

--- a/test/valid-data/annotation-writeOnly/schema.json
+++ b/test/valid-data/annotation-writeOnly/schema.json
@@ -4,7 +4,15 @@
   "definitions": {
     "MyObject": {
       "additionalProperties": false,
-      "deprecated": "",
+      "properties": {
+        "one": {
+          "type": "string"
+        },
+        "two": {
+          "type": "number",
+          "writeOnly": true
+        }
+      },
       "type": "object"
     }
   }


### PR DESCRIPTION
Fixes #1012

As it is mentioned in the issue, currently a tag without explicit value defaults to an empty string. For example, `@deprecated` results in: `"deprecated": ""`.

What if tags without value would default to `true` instead? On surface this feels like right pattern which reflects actual usage. For instance, this generator has own `@nullable` tag, which is assumed to be `@nullable true`. Similarly TypeScript has `@deprecated`, `@internal`.

Also I added tests for `@readOnly`, `@writeOnly`, which could work in the same way.

Just an idea. Could anything get broken?
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.98.1-next.4`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: Tom Mrazauskas ([@mrazauskas](https://github.com/mrazauskas))
  
  :heart: Jason Dent ([@Jason3S](https://github.com/Jason3S))
  
  :heart: Remi Cattiau ([@loopingz](https://github.com/loopingz))
  
  :heart: Hadrien Milano ([@hmil](https://github.com/hmil))
  
  #### 🚀 Enhancement
  
  - feat: support key remapping via `as` [#1174](https://github.com/vega/ts-json-schema-generator/pull/1174) ([@Jason3S](https://github.com/Jason3S))
  - feat: support intrinsic string manipulation types [#1173](https://github.com/vega/ts-json-schema-generator/pull/1173) ([@Jason3S](https://github.com/Jason3S))
  - feat: support template literals as types. [#1171](https://github.com/vega/ts-json-schema-generator/pull/1171) ([@Jason3S](https://github.com/Jason3S))
  - feat: move private to protected to allow extending behavior [#1161](https://github.com/vega/ts-json-schema-generator/pull/1161) ([@loopingz](https://github.com/loopingz))
  - feat: add support for never type [#1154](https://github.com/vega/ts-json-schema-generator/pull/1154) ([@hmil](https://github.com/hmil))
  
  #### 🐛 Bug Fix
  
  - feat!: allow JSDoc tags without explicit value (e.g. `@deprecated`) to default to `true` [#1172](https://github.com/vega/ts-json-schema-generator/pull/1172) ([@mrazauskas](https://github.com/mrazauskas))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.14.0 to 5.15.0 [#1164](https://github.com/vega/ts-json-schema-generator/pull/1164) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.17.5 to 7.17.8 [#1162](https://github.com/vega/ts-json-schema-generator/pull/1162) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.34.1 to 10.34.2 [#1163](https://github.com/vega/ts-json-schema-generator/pull/1163) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.5.1 to 2.6.0 [#1165](https://github.com/vega/ts-json-schema-generator/pull/1165) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @types/json-schema from 7.0.9 to 7.0.10 [#1166](https://github.com/vega/ts-json-schema-generator/pull/1166) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.34.1 to 10.34.2 [#1167](https://github.com/vega/ts-json-schema-generator/pull/1167) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.14.0 to 5.15.0 [#1168](https://github.com/vega/ts-json-schema-generator/pull/1168) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 9.0.0 to 9.1.0 [#1169](https://github.com/vega/ts-json-schema-generator/pull/1169) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.34.1 to 10.34.2 [#1170](https://github.com/vega/ts-json-schema-generator/pull/1170) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.13.0 to 5.14.0 [#1157](https://github.com/vega/ts-json-schema-generator/pull/1157) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega from 5.21.0 to 5.22.0 [#1156](https://github.com/vega/ts-json-schema-generator/pull/1156) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.13.0 to 5.14.0 [#1158](https://github.com/vega/ts-json-schema-generator/pull/1158) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.10.0 to 8.11.0 [#1159](https://github.com/vega/ts-json-schema-generator/pull/1159) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.12.1 to 5.13.0 [#1144](https://github.com/vega/ts-json-schema-generator/pull/1144) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.32.6 to 10.34.1 [#1145](https://github.com/vega/ts-json-schema-generator/pull/1145) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.12.1 to 5.13.0 [#1146](https://github.com/vega/ts-json-schema-generator/pull/1146) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ts-node from 10.5.0 to 10.7.0 [#1147](https://github.com/vega/ts-json-schema-generator/pull/1147) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.32.6 to 10.34.1 [#1148](https://github.com/vega/ts-json-schema-generator/pull/1148) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.5.5 to 4.6.2 [#1149](https://github.com/vega/ts-json-schema-generator/pull/1149) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.32.6 to 10.34.1 [#1150](https://github.com/vega/ts-json-schema-generator/pull/1150) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 8.4.0 to 8.5.0 [#1151](https://github.com/vega/ts-json-schema-generator/pull/1151) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/checkout from 2 to 3 [#1143](https://github.com/vega/ts-json-schema-generator/pull/1143) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.12.0 to 5.12.1 [#1139](https://github.com/vega/ts-json-schema-generator/pull/1139) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.9.0 to 8.10.0 [#1138](https://github.com/vega/ts-json-schema-generator/pull/1138) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.18 to 17.0.21 [#1140](https://github.com/vega/ts-json-schema-generator/pull/1140) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 27.4.0 to 27.4.1 [#1141](https://github.com/vega/ts-json-schema-generator/pull/1141) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.12.0 to 5.12.1 [#1142](https://github.com/vega/ts-json-schema-generator/pull/1142) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/setup-node from 2.5.1 to 3 [#1137](https://github.com/vega/ts-json-schema-generator/pull/1137) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.11.0 to 5.12.0 [#1132](https://github.com/vega/ts-json-schema-generator/pull/1132) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.17.2 to 7.17.5 [#1133](https://github.com/vega/ts-json-schema-generator/pull/1133) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.17 to 17.0.18 [#1134](https://github.com/vega/ts-json-schema-generator/pull/1134) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.11.0 to 5.12.0 [#1135](https://github.com/vega/ts-json-schema-generator/pull/1135) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 8.3.0 to 8.4.0 [#1136](https://github.com/vega/ts-json-schema-generator/pull/1136) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 5
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Hadrien Milano ([@hmil](https://github.com/hmil))
  - Jason Dent ([@Jason3S](https://github.com/Jason3S))
  - Remi Cattiau ([@loopingz](https://github.com/loopingz))
  - Tom Mrazauskas ([@mrazauskas](https://github.com/mrazauskas))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
