### PR TITLE
feat: support key remapping via `as`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,10 @@ indent_size = 4
 indent_style = space
 indent_size = 4
 
+[test/**/schema.json]
+indent_style = space
+indent_size = 2
+
 [{package.json,azure-pipelines.yml}]
 indent_style = space
 indent_size = 2

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,33 @@
     "version": "0.2.0",
     "configurations": [
         {
+            //
+            // Helps with debugging parsing.
+            // - Set break points in the code
+            // - Open the file you want to parse: test/**/main.ts
+            // - F5 to run the debugger.
+            "name": "Debug Test Case",
+            "type": "node",
+            "request": "launch",
+            "runtimeExecutable": "node",
+            "runtimeArgs": [
+                "--nolazy",
+                "-r",
+                "ts-node/register"
+            ],
+            "args": [
+                "ts-json-schema-generator.ts",
+                "-p",
+                "${file}"
+            ],
+            "cwd": "${workspaceFolder}",
+            "internalConsoleOptions": "openOnSessionStart",
+            "skipFiles": [
+                "<node_internals>/**",
+                "node_modules/**"
+            ]
+        },
+        {
             "type": "node",
             "request": "attach",
             "name": "Attach",

--- a/factory/parser.ts
+++ b/factory/parser.ts
@@ -24,6 +24,7 @@ import { HiddenNodeParser } from "../src/NodeParser/HiddenTypeNodeParser";
 import { IndexedAccessTypeNodeParser } from "../src/NodeParser/IndexedAccessTypeNodeParser";
 import { InterfaceAndClassNodeParser } from "../src/NodeParser/InterfaceAndClassNodeParser";
 import { IntersectionNodeParser } from "../src/NodeParser/IntersectionNodeParser";
+import { IntrinsicNodeParser } from "../src/NodeParser/IntrinsicNodeParser";
 import { LiteralNodeParser } from "../src/NodeParser/LiteralNodeParser";
 import { MappedTypeNodeParser } from "../src/NodeParser/MappedTypeNodeParser";
 import { NeverTypeNodeParser } from "../src/NodeParser/NeverTypeNodeParser";
@@ -104,6 +105,7 @@ export function createParser(program: ts.Program, config: Config, augmentor?: Pa
         .addNodeParser(withJsDoc(new ParameterParser(chainNodeParser)))
         .addNodeParser(new StringLiteralNodeParser())
         .addNodeParser(new StringTemplateLiteralNodeParser(chainNodeParser))
+        .addNodeParser(new IntrinsicNodeParser())
         .addNodeParser(new NumberLiteralNodeParser())
         .addNodeParser(new BooleanLiteralNodeParser())
         .addNodeParser(new NullLiteralNodeParser())

--- a/src/NodeParser/IntrinsicNodeParser.ts
+++ b/src/NodeParser/IntrinsicNodeParser.ts
@@ -1,0 +1,44 @@
+import ts from "typescript";
+import { LogicError } from "../Error/LogicError";
+import { UnknownNodeError } from "../Error/UnknownNodeError";
+import { Context } from "../NodeParser";
+import { SubNodeParser } from "../SubNodeParser";
+import { BaseType } from "../Type/BaseType";
+import { LiteralType } from "../Type/LiteralType";
+import { UnionType } from "../Type/UnionType";
+import { extractLiterals } from "../Utils/extractLiterals";
+
+export const intrinsicMethods: Record<string, ((v: string) => string) | undefined> = {
+    Uppercase: (v) => v.toUpperCase(),
+    Lowercase: (v) => v.toLowerCase(),
+    Capitalize: (v) => v[0].toUpperCase() + v.slice(1),
+    Uncapitalize: (v) => v[0].toLowerCase() + v.slice(1),
+};
+
+export class IntrinsicNodeParser implements SubNodeParser {
+    public supportsNode(node: ts.KeywordTypeNode): boolean {
+        return node.kind === ts.SyntaxKind.IntrinsicKeyword;
+    }
+    public createType(node: ts.KeywordTypeNode, context: Context): BaseType | undefined {
+        const methodName = getParentName(node);
+        const method = intrinsicMethods[methodName];
+        if (!method) {
+            throw new LogicError(`Unknown intrinsic method: ${methodName}`);
+        }
+        const literals = extractLiterals(context.getArguments()[0])
+            .map(method)
+            .map((literal) => new LiteralType(literal));
+        if (literals.length === 1) {
+            return literals[0];
+        }
+        return new UnionType(literals);
+    }
+}
+
+function getParentName(node: ts.KeywordTypeNode): string {
+    const parent = node.parent;
+    if (!ts.isTypeAliasDeclaration(parent)) {
+        throw new UnknownNodeError(parent, node);
+    }
+    return parent.name.text;
+}

--- a/src/NodeParser/StringTemplateLiteralNodeParser.ts
+++ b/src/NodeParser/StringTemplateLiteralNodeParser.ts
@@ -1,11 +1,10 @@
 import ts from "typescript";
-import { UnknownTypeError } from "../Error/UnknownTypeError";
 import { Context, NodeParser } from "../NodeParser";
 import { SubNodeParser } from "../SubNodeParser";
-import { AliasType } from "../Type/AliasType";
 import { BaseType } from "../Type/BaseType";
 import { LiteralType } from "../Type/LiteralType";
 import { UnionType } from "../Type/UnionType";
+import { extractLiterals } from "../Utils/extractLiterals";
 
 export class StringTemplateLiteralNodeParser implements SubNodeParser {
     public constructor(protected childNodeParser: NodeParser) {}
@@ -24,7 +23,7 @@ export class StringTemplateLiteralNodeParser implements SubNodeParser {
             node.templateSpans.map((span) => {
                 const suffix = span.literal.text;
                 const type = this.childNodeParser.createType(span.type, context);
-                return [...extractLiterals(type)].map((value) => value + suffix);
+                return extractLiterals(type).map((value) => value + suffix);
             })
         );
 
@@ -48,24 +47,4 @@ function expand(matrix: string[][]): string[] {
     const nested = expand(matrix.slice(1));
     const combined = head.map((prefix) => nested.map((suffix) => prefix + suffix));
     return ([] as string[]).concat(...combined);
-}
-
-function* extractLiterals(type: BaseType | undefined): Iterable<string> {
-    if (!type) return;
-    if (type instanceof LiteralType) {
-        yield type.getValue().toString();
-        return;
-    }
-    if (type instanceof UnionType) {
-        for (const t of type.getTypes()) {
-            yield* extractLiterals(t);
-        }
-        return;
-    }
-    if (type instanceof AliasType) {
-        yield* extractLiterals(type.getType());
-        return;
-    }
-
-    throw new UnknownTypeError(type);
 }

--- a/src/Utils/assert.ts
+++ b/src/Utils/assert.ts
@@ -1,0 +1,7 @@
+import { LogicError } from "../Error/LogicError";
+
+export default function assert(value: unknown, message: string): asserts value {
+    if (!value) {
+        throw new LogicError(message);
+    }
+}

--- a/src/Utils/extractLiterals.ts
+++ b/src/Utils/extractLiterals.ts
@@ -1,0 +1,31 @@
+import { UnknownTypeError } from "../Error/UnknownTypeError";
+import { AliasType } from "../Type/AliasType";
+import { BaseType } from "../Type/BaseType";
+import { LiteralType } from "../Type/LiteralType";
+import { UnionType } from "../Type/UnionType";
+
+function* _extractLiterals(type: BaseType | undefined): Iterable<string> {
+    if (!type) {
+        return;
+    }
+    if (type instanceof LiteralType) {
+        yield type.getValue().toString();
+        return;
+    }
+    if (type instanceof UnionType) {
+        for (const t of type.getTypes()) {
+            yield* _extractLiterals(t);
+        }
+        return;
+    }
+    if (type instanceof AliasType) {
+        yield* _extractLiterals(type.getType());
+        return;
+    }
+
+    throw new UnknownTypeError(type);
+}
+
+export function extractLiterals(type: BaseType | undefined): string[] {
+    return [..._extractLiterals(type)];
+}

--- a/test/unit/assert.test.ts
+++ b/test/unit/assert.test.ts
@@ -1,0 +1,25 @@
+import { LogicError } from "../../src/Error/LogicError";
+import assert from "../../src/Utils/assert";
+
+describe("validate assert", () => {
+    it.each`
+        value
+        ${"hello"}
+        ${1}
+        ${true}
+        ${{}}
+    `("success $value", ({ value }) => {
+        expect(() => assert(value, "message")).not.toThrow();
+    });
+
+    it.each`
+        value
+        ${""}
+        ${0}
+        ${false}
+        ${undefined}
+        ${null}
+    `("fail $value", ({ value }) => {
+        expect(() => assert(value, "failed to be true")).toThrowError(LogicError);
+    });
+});

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -36,6 +36,7 @@ describe("valid-data-other", () => {
 
     it("string-literals", assertValidSchema("string-literals", "MyObject"));
     it("string-literals-inline", assertValidSchema("string-literals-inline", "MyObject"));
+    it("string-literals-intrinsic", assertValidSchema("string-literals-intrinsic", "MyObject"));
     it("string-literals-null", assertValidSchema("string-literals-null", "MyObject"));
     it("string-template-literals", assertValidSchema("string-template-literals", "MyObject"));
     it("string-template-expression-literals", assertValidSchema("string-template-expression-literals", "MyObject"));

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -76,6 +76,8 @@ describe("valid-data-type", () => {
     it("type-keyof-object-function", assertValidSchema("type-keyof-object-function", "MyType"));
     it("type-mapped-simple", assertValidSchema("type-mapped-simple", "MyObject"));
     it("type-mapped-index", assertValidSchema("type-mapped-index", "MyObject"));
+    it("type-mapped-index-as", assertValidSchema("type-mapped-index-as", "MyObject"));
+    it("type-mapped-index-as-template", assertValidSchema("type-mapped-index-as-template", "MyObject"));
     it("type-mapped-literal", assertValidSchema("type-mapped-literal", "MyObject"));
     it("type-mapped-generic", assertValidSchema("type-mapped-generic", "MyObject"));
     it("type-mapped-native", assertValidSchema("type-mapped-native", "MyObject"));

--- a/test/valid-data/string-literals-intrinsic/main.ts
+++ b/test/valid-data/string-literals-intrinsic/main.ts
@@ -1,4 +1,5 @@
-type Result = "ok" | "fail" | "ABORT" | "Success";
+type Abort = "abort";
+type Result = "ok" | "fail" | Uppercase<Abort> | "Success";
 type ResultUpper = Uppercase<Result>;
 type ResultLower = Lowercase<ResultUpper>;
 type ResultCapitalize = Capitalize<Result>;

--- a/test/valid-data/string-literals-intrinsic/main.ts
+++ b/test/valid-data/string-literals-intrinsic/main.ts
@@ -1,0 +1,13 @@
+type Result = "ok" | "fail" | "ABORT" | "Success";
+type ResultUpper = Uppercase<Result>;
+type ResultLower = Lowercase<ResultUpper>;
+type ResultCapitalize = Capitalize<Result>;
+type ResultUncapitalize = Uncapitalize<ResultCapitalize>;
+
+export interface MyObject {
+    result: Result;
+    resultUpper: ResultUpper;
+    resultLower: ResultLower;
+    resultCapitalize: ResultCapitalize;
+    resultUncapitalize: ResultUncapitalize;
+}

--- a/test/valid-data/string-literals-intrinsic/schema.json
+++ b/test/valid-data/string-literals-intrinsic/schema.json
@@ -1,0 +1,64 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "result": {
+          "enum": [
+            "ok",
+            "fail",
+            "ABORT",
+            "Success"
+          ],
+          "type": "string"
+        },
+        "resultCapitalize": {
+          "enum": [
+            "Ok",
+            "Fail",
+            "ABORT",
+            "Success"
+          ],
+          "type": "string"
+        },
+        "resultLower": {
+          "enum": [
+            "ok",
+            "fail",
+            "abort",
+            "success"
+          ],
+          "type": "string"
+        },
+        "resultUncapitalize": {
+          "enum": [
+            "ok",
+            "fail",
+            "aBORT",
+            "success"
+          ],
+          "type": "string"
+        },
+        "resultUpper": {
+          "enum": [
+            "OK",
+            "FAIL",
+            "ABORT",
+            "SUCCESS"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "result",
+        "resultUpper",
+        "resultLower",
+        "resultCapitalize",
+        "resultUncapitalize"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/test/valid-data/type-mapped-index-as-template/main.ts
+++ b/test/valid-data/type-mapped-index-as-template/main.ts
@@ -1,0 +1,9 @@
+interface Message {
+    id: number;
+    name: string;
+    title: string;
+}
+
+export type MyObject = {
+    [K in keyof Message as `message${Capitalize<K>}`]: Message[K];
+};

--- a/test/valid-data/type-mapped-index-as-template/schema.json
+++ b/test/valid-data/type-mapped-index-as-template/schema.json
@@ -1,0 +1,26 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "messageId": {
+          "type": "number"
+        },
+        "messageName": {
+          "type": "string"
+        },
+        "messageTitle": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "messageId",
+        "messageName",
+        "messageTitle"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/test/valid-data/type-mapped-index-as/main.ts
+++ b/test/valid-data/type-mapped-index-as/main.ts
@@ -1,0 +1,8 @@
+interface SomeInterface {
+    foo: 12;
+    bar: "baz";
+}
+
+export type MyObject = {
+    [K in keyof SomeInterface as Capitalize<K>]: `${K}.${SomeInterface[K]}`;
+};

--- a/test/valid-data/type-mapped-index-as/schema.json
+++ b/test/valid-data/type-mapped-index-as/schema.json
@@ -1,0 +1,24 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "Bar": {
+          "const": "bar.baz",
+          "type": "string"
+        },
+        "Foo": {
+          "const": "foo.12",
+          "type": "string"
+        }
+      },
+      "required": [
+        "Foo",
+        "Bar"
+      ],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
See: See: [TypeScript: Documentation - Key Remapping via
`as`](https://www.typescriptlang.org/docs/handbook/2/mapped-types.html#key-remapping-via-as)


Depends upon #1173 
