### PR TITLE
feat: add basic support for example tag

### DIFF
--- a/src/AnnotationsReader/ExtendedAnnotationsReader.ts
+++ b/src/AnnotationsReader/ExtendedAnnotationsReader.ts
@@ -89,7 +89,6 @@ export class ExtendedAnnotationsReader extends BasicAnnotationsReader {
 
         const examples: unknown[] = [];
         for (const example of jsDocTags.filter((tag) => tag.name === "example")) {
-            console.log(JSON.stringify(example.text));
             const text = (example.text ?? []).map((part) => part.text).join("");
             try {
                 examples.push(json5.parse(text));

--- a/src/AnnotationsReader/ExtendedAnnotationsReader.ts
+++ b/src/AnnotationsReader/ExtendedAnnotationsReader.ts
@@ -1,3 +1,4 @@
+import json5 from "json5";
 import ts from "typescript";
 import { Annotations } from "../Type/AnnotatedType";
 import { symbolAtNode } from "../Utils/symbolAtNode";
@@ -12,6 +13,7 @@ export class ExtendedAnnotationsReader extends BasicAnnotationsReader {
         const annotations: Annotations = {
             ...this.getDescriptionAnnotation(node),
             ...this.getTypeAnnotation(node),
+            ...this.getExampleAnnotation(node),
             ...super.getAnnotations(node),
         };
         return Object.keys(annotations).length ? annotations : undefined;
@@ -69,5 +71,39 @@ export class ExtendedAnnotationsReader extends BasicAnnotationsReader {
 
         const text = (jsDocTag.text ?? []).map((part) => part.text).join("");
         return { type: text };
+    }
+    /**
+     * Attempts to gather examples from the @-example jsdoc tag.
+     * See https://tsdoc.org/pages/tags/example/
+     */
+    private getExampleAnnotation(node: ts.Node): Annotations | undefined {
+        const symbol = symbolAtNode(node);
+        if (!symbol) {
+            return undefined;
+        }
+
+        const jsDocTags: ts.JSDocTagInfo[] = symbol.getJsDocTags();
+        if (!jsDocTags || !jsDocTags.length) {
+            return undefined;
+        }
+
+        const examples: unknown[] = [];
+        for (const example of jsDocTags.filter((tag) => tag.name === "example")) {
+            console.log(JSON.stringify(example.text));
+            const text = (example.text ?? []).map((part) => part.text).join("");
+            try {
+                examples.push(json5.parse(text));
+            } catch (e) {
+                // ignore examples which don't parse to valid JSON
+                // This could be improved to support a broader range of usages,
+                // such as if the example has a title (as explained in the tsdoc spec).
+            }
+        }
+
+        if (examples.length === 0) {
+            return undefined;
+        }
+
+        return { examples };
     }
 }

--- a/test/valid-data-annotations.test.ts
+++ b/test/valid-data-annotations.test.ts
@@ -33,6 +33,8 @@ describe("valid-data-annotations", () => {
 
     it("annotation-comment", assertValidSchema("annotation-comment", "MyObject", "extended"));
 
+    it("annotation-example", assertValidSchema("annotation-example", "MyObject", "extended"));
+
     it("annotation-id", assertValidSchema("annotation-id", "MyObject", "extended", [], "Test"));
 
     it("annotation-readOnly", assertValidSchema("annotation-readOnly", "MyObject", "basic"));

--- a/test/valid-data/annotation-example/main.ts
+++ b/test/valid-data/annotation-example/main.ts
@@ -1,0 +1,32 @@
+/**
+ * @example
+ * {
+ *     "nested": "hello"
+ * }
+ *
+ * @example Another example
+ * {
+ *     "nested": "world"
+ * }
+ * @example Last example
+ * ```ts
+ * {
+ *     "nested": "world"
+ * }
+ * ```
+ */
+export interface MyObject {
+    /**
+     * @example
+     *     "Hello world"
+     * @example
+     *     "This string rocks"
+     */
+    nested: MyNestedObject
+}
+
+/**
+ * @example With a string
+ *      "Hello string"
+ */
+export type MyNestedObject = string;

--- a/test/valid-data/annotation-example/main.ts
+++ b/test/valid-data/annotation-example/main.ts
@@ -4,11 +4,11 @@
  *     "nested": "hello"
  * }
  *
- * @example Another example
+ * @example An invalid example
  * {
  *     "nested": "world"
  * }
- * @example Last example
+ * @example Another invalid example
  * ```ts
  * {
  *     "nested": "world"

--- a/test/valid-data/annotation-example/schema.json
+++ b/test/valid-data/annotation-example/schema.json
@@ -1,0 +1,28 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyNestedObject": {
+      "type": "string"
+    },
+    "MyObject": {
+      "examples": [
+        { "nested": "hello" }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "nested": {
+          "examples": [
+            "Hello world",
+            "This string rocks"
+          ],
+          "$ref": "#/definitions/MyNestedObject"
+        }
+      },
+      "required": [
+        "nested"
+      ],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
fix #1201
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v1.0.1-next.1`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Hadrien Milano ([@hmil](https://github.com/hmil)), for all your work!
  
  #### 🚀 Enhancement
  
  - feat: add basic support for example tag [#1200](https://github.com/vega/ts-json-schema-generator/pull/1200) ([@hmil](https://github.com/hmil))
  
  #### 🐛 Bug Fix
  
  - fix: preserve empty `@description` [#1177](https://github.com/vega/ts-json-schema-generator/pull/1177) ([@Jason3S](https://github.com/Jason3S))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.34.2 to 10.36.5 [#1197](https://github.com/vega/ts-json-schema-generator/pull/1197) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.15.0 to 5.16.0 [#1185](https://github.com/vega/ts-json-schema-generator/pull/1185) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump node-fetch from 2.6.6 to 2.6.7 [#1195](https://github.com/vega/ts-json-schema-generator/pull/1195) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump minimist from 1.2.5 to 1.2.6 [#1196](https://github.com/vega/ts-json-schema-generator/pull/1196) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump json5 from 2.2.0 to 2.2.1 [#1198](https://github.com/vega/ts-json-schema-generator/pull/1198) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.6.0 to 2.6.1 [#1199](https://github.com/vega/ts-json-schema-generator/pull/1199) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.11.0 to 8.12.0 [#1186](https://github.com/vega/ts-json-schema-generator/pull/1186) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.34.2 to 10.36.5 [#1187](https://github.com/vega/ts-json-schema-generator/pull/1187) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.34.2 to 10.36.5 [#1188](https://github.com/vega/ts-json-schema-generator/pull/1188) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.6.2 to 4.6.3 [#1189](https://github.com/vega/ts-json-schema-generator/pull/1189) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @types/json-schema from 7.0.10 to 7.0.11 [#1190](https://github.com/vega/ts-json-schema-generator/pull/1190) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.21 to 17.0.23 [#1191](https://github.com/vega/ts-json-schema-generator/pull/1191) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.15.0 to 5.16.0 [#1192](https://github.com/vega/ts-json-schema-generator/pull/1192) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega from 5.22.0 to 5.22.1 [#1193](https://github.com/vega/ts-json-schema-generator/pull/1193) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv from 8.10.0 to 8.11.0 [#1194](https://github.com/vega/ts-json-schema-generator/pull/1194) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 3
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Hadrien Milano ([@hmil](https://github.com/hmil))
  - Jason Dent ([@Jason3S](https://github.com/Jason3S))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
