### PR TITLE
feat: support $ref

### DIFF
--- a/src/AnnotationsReader/BasicAnnotationsReader.ts
+++ b/src/AnnotationsReader/BasicAnnotationsReader.ts
@@ -5,7 +5,7 @@ import { Annotations } from "../Type/AnnotatedType";
 import { symbolAtNode } from "../Utils/symbolAtNode";
 
 export class BasicAnnotationsReader implements AnnotationsReader {
-    private static requiresDollar = new Set<string>(["id", "comment"]);
+    private static requiresDollar = new Set<string>(["id", "comment", "ref"]);
     private static textTags = new Set<string>([
         "title",
         "description",
@@ -13,6 +13,7 @@ export class BasicAnnotationsReader implements AnnotationsReader {
 
         "format",
         "pattern",
+        "ref",
 
         // New since draft-07:
         "comment",
@@ -56,7 +57,7 @@ export class BasicAnnotationsReader implements AnnotationsReader {
         "deprecated",
     ]);
 
-    public constructor(private extraTags?: Set<string>) {}
+    public constructor(private extraTags?: Set<string>) { }
 
     public getAnnotations(node: ts.Node): Annotations | undefined {
         const symbol = symbolAtNode(node);

--- a/src/AnnotationsReader/BasicAnnotationsReader.ts
+++ b/src/AnnotationsReader/BasicAnnotationsReader.ts
@@ -57,7 +57,7 @@ export class BasicAnnotationsReader implements AnnotationsReader {
         "deprecated",
     ]);
 
-    public constructor(private extraTags?: Set<string>) { }
+    public constructor(private extraTags?: Set<string>) {}
 
     public getAnnotations(node: ts.Node): Annotations | undefined {
         const symbol = symbolAtNode(node);

--- a/src/TypeFormatter/AnnotatedTypeFormatter.ts
+++ b/src/TypeFormatter/AnnotatedTypeFormatter.ts
@@ -50,9 +50,15 @@ export class AnnotatedTypeFormatter implements SubTypeFormatter {
         return type instanceof AnnotatedType;
     }
     public getDefinition(type: AnnotatedType): Definition {
+        const annotations = type.getAnnotations();
+
+        if ("$ref" in annotations) {
+            return annotations;
+        }
+
         const def: Definition = {
             ...this.childTypeFormatter.getDefinition(type.getType()),
-            ...type.getAnnotations(),
+            ...annotations,
         };
 
         if ("$ref" in def && "type" in def) {

--- a/src/TypeFormatter/AnnotatedTypeFormatter.ts
+++ b/src/TypeFormatter/AnnotatedTypeFormatter.ts
@@ -50,15 +50,9 @@ export class AnnotatedTypeFormatter implements SubTypeFormatter {
         return type instanceof AnnotatedType;
     }
     public getDefinition(type: AnnotatedType): Definition {
-        const annotations = type.getAnnotations();
-
-        if ("$ref" in annotations) {
-            return annotations;
-        }
-
         const def: Definition = {
             ...this.childTypeFormatter.getDefinition(type.getType()),
-            ...annotations,
+            ...type.getAnnotations(),
         };
 
         if ("$ref" in def && "type" in def) {

--- a/src/Utils/removeUnreachable.ts
+++ b/src/Utils/removeUnreachable.ts
@@ -2,6 +2,8 @@ import { JSONSchema7Definition } from "json-schema";
 import { Definition } from "../Schema/Definition";
 import { StringMap } from "./StringMap";
 
+const DEFINITION_OFFSET = "#/definitions/".length;
+
 function addReachable(
     definition: Definition | JSONSchema7Definition,
     definitions: StringMap<Definition>,
@@ -12,9 +14,9 @@ function addReachable(
     }
 
     if (definition.$ref) {
-        const typeName = decodeURIComponent(definition.$ref.slice(14));
-        if (reachable.has(typeName)) {
-            // we've already processed this definition
+        const typeName = decodeURIComponent(definition.$ref.slice(DEFINITION_OFFSET));
+        if (reachable.has(typeName) || !isLocalRef(definition.$ref)) {
+            // we've already processed this definition, or this definition refers to an external schema
             return;
         }
         reachable.add(typeName);
@@ -78,4 +80,8 @@ export function removeUnreachable(
     }
 
     return out;
+}
+
+function isLocalRef(ref: string) {
+    return ref.charAt(0) === "#";
 }

--- a/test/valid-data-annotations.test.ts
+++ b/test/valid-data-annotations.test.ts
@@ -39,5 +39,7 @@ describe("valid-data-annotations", () => {
 
     it("annotation-readOnly", assertValidSchema("annotation-readOnly", "MyObject", "basic"));
 
+    it("annotation-ref", assertValidSchema("annotation-ref", "MyObject", "extended"));
+
     it("annotation-writeOnly", assertValidSchema("annotation-writeOnly", "MyObject", "basic"));
 });

--- a/test/valid-data/annotation-ref/main.ts
+++ b/test/valid-data/annotation-ref/main.ts
@@ -1,11 +1,17 @@
 
 export interface MyObject {
     /**
+     * Nested description
+     *
+     * @title Nested title
      * @ref http://json-schema.org/draft-07/schema#
      */
     nested: MyNestedObject
 
     /**
+     * MyObject description
+     *
+     * @title MyObject title
      * @ref http://json-schema.org/draft-07/schema#
      */
     myObject: { [key: string]: string };

--- a/test/valid-data/annotation-ref/main.ts
+++ b/test/valid-data/annotation-ref/main.ts
@@ -1,0 +1,12 @@
+
+export interface MyObject {
+    /**
+     * @ref http://json-schema.org/draft-07/schema#
+     */
+    nested: MyNestedObject
+}
+
+export interface MyNestedObject {
+    foo: string;
+    bar: number;
+}

--- a/test/valid-data/annotation-ref/main.ts
+++ b/test/valid-data/annotation-ref/main.ts
@@ -4,6 +4,11 @@ export interface MyObject {
      * @ref http://json-schema.org/draft-07/schema#
      */
     nested: MyNestedObject
+
+    /**
+     * @ref http://json-schema.org/draft-07/schema#
+     */
+    myObject: { [key: string]: string };
 }
 
 export interface MyNestedObject {

--- a/test/valid-data/annotation-ref/schema.json
+++ b/test/valid-data/annotation-ref/schema.json
@@ -7,10 +7,13 @@
       "properties": {
         "nested": {
           "$ref": "http://json-schema.org/draft-07/schema#"
+        },
+        "myObject": {
+          "$ref": "http://json-schema.org/draft-07/schema#"
         }
       },
       "required": [
-        "nested"
+        "nested", "myObject"
       ],
       "type": "object"
     }

--- a/test/valid-data/annotation-ref/schema.json
+++ b/test/valid-data/annotation-ref/schema.json
@@ -6,10 +6,14 @@
       "additionalProperties": false,
       "properties": {
         "nested": {
-          "$ref": "http://json-schema.org/draft-07/schema#"
+          "$ref": "http://json-schema.org/draft-07/schema#",
+          "title": "Nested title",
+          "description": "Nested description"
         },
         "myObject": {
-          "$ref": "http://json-schema.org/draft-07/schema#"
+          "$ref": "http://json-schema.org/draft-07/schema#",
+          "title": "MyObject title",
+          "description": "MyObject description"
         }
       },
       "required": [

--- a/test/valid-data/annotation-ref/schema.json
+++ b/test/valid-data/annotation-ref/schema.json
@@ -1,0 +1,18 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "nested": {
+          "$ref": "http://json-schema.org/draft-07/schema#"
+        }
+      },
+      "required": [
+        "nested"
+      ],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
fixes #1207 
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v1.1.0-next.0`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Hadrien Milano ([@hmil](https://github.com/hmil)), for all your work!
  
  #### 🚀 Enhancement
  
  - feat: support $ref [#1208](https://github.com/vega/ts-json-schema-generator/pull/1208) ([@hmil](https://github.com/hmil))
  - feat: add basic support for example tag [#1200](https://github.com/vega/ts-json-schema-generator/pull/1200) ([@hmil](https://github.com/hmil))
  
  #### 🐛 Bug Fix
  
  - fix: update package.json version [#1210](https://github.com/vega/ts-json-schema-generator/pull/1210) ([@hydrosquall](https://github.com/hydrosquall))
  - fix: preserve empty `@description` [#1177](https://github.com/vega/ts-json-schema-generator/pull/1177) ([@Jason3S](https://github.com/Jason3S))
  
  #### 🔩 Dependency Updates
  
  - chore(deps): bump codecov/codecov-action from 2.1.0 to 3 [#1211](https://github.com/vega/ts-json-schema-generator/pull/1211) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.16.0 to 5.17.0 [#1203](https://github.com/vega/ts-json-schema-generator/pull/1203) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.6.1 to 2.6.2 [#1204](https://github.com/vega/ts-json-schema-generator/pull/1204) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.16.0 to 5.17.0 [#1205](https://github.com/vega/ts-json-schema-generator/pull/1205) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.34.2 to 10.36.5 [#1197](https://github.com/vega/ts-json-schema-generator/pull/1197) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.15.0 to 5.16.0 [#1185](https://github.com/vega/ts-json-schema-generator/pull/1185) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump node-fetch from 2.6.6 to 2.6.7 [#1195](https://github.com/vega/ts-json-schema-generator/pull/1195) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump minimist from 1.2.5 to 1.2.6 [#1196](https://github.com/vega/ts-json-schema-generator/pull/1196) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump json5 from 2.2.0 to 2.2.1 [#1198](https://github.com/vega/ts-json-schema-generator/pull/1198) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.6.0 to 2.6.1 [#1199](https://github.com/vega/ts-json-schema-generator/pull/1199) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.11.0 to 8.12.0 [#1186](https://github.com/vega/ts-json-schema-generator/pull/1186) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.34.2 to 10.36.5 [#1187](https://github.com/vega/ts-json-schema-generator/pull/1187) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.34.2 to 10.36.5 [#1188](https://github.com/vega/ts-json-schema-generator/pull/1188) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.6.2 to 4.6.3 [#1189](https://github.com/vega/ts-json-schema-generator/pull/1189) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @types/json-schema from 7.0.10 to 7.0.11 [#1190](https://github.com/vega/ts-json-schema-generator/pull/1190) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.21 to 17.0.23 [#1191](https://github.com/vega/ts-json-schema-generator/pull/1191) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.15.0 to 5.16.0 [#1192](https://github.com/vega/ts-json-schema-generator/pull/1192) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega from 5.22.0 to 5.22.1 [#1193](https://github.com/vega/ts-json-schema-generator/pull/1193) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv from 8.10.0 to 8.11.0 [#1194](https://github.com/vega/ts-json-schema-generator/pull/1194) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 4
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Cameron Yick ([@hydrosquall](https://github.com/hydrosquall))
  - Hadrien Milano ([@hmil](https://github.com/hmil))
  - Jason Dent ([@Jason3S](https://github.com/Jason3S))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
