### PR TITLE
feat: support for named tuple members

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Inspired by [`YousefED/typescript-json-schema`](https://github.com/YousefED/type
 
 ## Contributors
 
-This project is made possible by a [community of contributors](https://github.com/vega/ts-json-schema-generator/graphs/contributors). We welcome contributions of any kind (issues, code, documentation, examples, tests,...). Please read our [code of conduct](https://github.com/vega/vega/blob/master/CODE_OF_CONDUCT.md).
+This project is made possible by a [community of contributors](https://github.com/vega/ts-json-schema-generator/graphs/contributors). We welcome contributions of any kind (issues, code, documentation, examples, tests,...). Please read our [code of conduct](https://vega.github.io/vega/about/code-of-conduct).
 
 ## CLI Usage
 

--- a/factory/parser.ts
+++ b/factory/parser.ts
@@ -27,6 +27,7 @@ import { IntersectionNodeParser } from "../src/NodeParser/IntersectionNodeParser
 import { IntrinsicNodeParser } from "../src/NodeParser/IntrinsicNodeParser";
 import { LiteralNodeParser } from "../src/NodeParser/LiteralNodeParser";
 import { MappedTypeNodeParser } from "../src/NodeParser/MappedTypeNodeParser";
+import { NamedTupleMemberNodeParser } from "../src/NodeParser/NamedTupleMemberNodeParser";
 import { NeverTypeNodeParser } from "../src/NodeParser/NeverTypeNodeParser";
 import { NullLiteralNodeParser } from "../src/NodeParser/NullLiteralNodeParser";
 import { NumberLiteralNodeParser } from "../src/NodeParser/NumberLiteralNodeParser";
@@ -130,6 +131,7 @@ export function createParser(program: ts.Program, config: Config, augmentor?: Pa
         .addNodeParser(new UnionNodeParser(typeChecker, chainNodeParser))
         .addNodeParser(new IntersectionNodeParser(typeChecker, chainNodeParser))
         .addNodeParser(new TupleNodeParser(typeChecker, chainNodeParser))
+        .addNodeParser(new NamedTupleMemberNodeParser(chainNodeParser))
         .addNodeParser(new OptionalTypeNodeParser(chainNodeParser))
         .addNodeParser(new RestTypeNodeParser(chainNodeParser))
 

--- a/src/Error/UnknownNodeError.ts
+++ b/src/Error/UnknownNodeError.ts
@@ -3,7 +3,7 @@ import { BaseError } from "./BaseError";
 
 export class UnknownNodeError extends BaseError {
     public constructor(private node: ts.Node, private reference?: ts.Node) {
-        super(`Unknown node "${node.getFullText()}`);
+        super(`Unknown node "${node.getFullText()}" of kind "${ts.SyntaxKind[node.kind]}"`);
     }
 
     public getNode(): ts.Node {

--- a/src/NodeParser/NamedTupleMemberNodeParser.ts
+++ b/src/NodeParser/NamedTupleMemberNodeParser.ts
@@ -1,0 +1,26 @@
+import ts from "typescript";
+import { Context, NodeParser } from "../NodeParser";
+import { SubNodeParser } from "../SubNodeParser";
+import { AnnotatedType } from "../Type/AnnotatedType";
+import { ArrayType } from "../Type/ArrayType";
+import { BaseType } from "../Type/BaseType";
+import { ReferenceType } from "../Type/ReferenceType";
+import { RestType } from "../Type/RestType";
+
+export class NamedTupleMemberNodeParser implements SubNodeParser {
+    public constructor(protected childNodeParser: NodeParser) {}
+
+    public supportsNode(node: ts.TypeNode): boolean {
+        return node.kind === ts.SyntaxKind.NamedTupleMember;
+    }
+
+    public createType(node: ts.NamedTupleMember, context: Context, reference?: ReferenceType): BaseType | undefined {
+        const baseType = this.childNodeParser.createType(node.type, context, reference);
+
+        if (baseType instanceof ArrayType && node.getChildAt(0).kind === ts.SyntaxKind.DotDotDotToken) {
+            return new RestType(baseType, node.name.text);
+        }
+
+        return baseType && new AnnotatedType(baseType, { title: node.name.text }, false);
+    }
+}

--- a/src/Type/RestType.ts
+++ b/src/Type/RestType.ts
@@ -2,12 +2,16 @@ import { ArrayType } from "./ArrayType";
 import { BaseType } from "./BaseType";
 
 export class RestType extends BaseType {
-    public constructor(private item: ArrayType) {
+    public constructor(private item: ArrayType, private title: string | null = null) {
         super();
     }
 
     public getId(): string {
-        return `...${this.item.getId()}`;
+        return `...${this.item.getId()}${this.title || ""}`;
+    }
+
+    public getTitle(): string | null {
+        return this.title;
     }
 
     public getType(): ArrayType {

--- a/src/TypeFormatter/RestTypeFormatter.ts
+++ b/src/TypeFormatter/RestTypeFormatter.ts
@@ -7,12 +7,21 @@ import { TypeFormatter } from "../TypeFormatter";
 export class RestTypeFormatter implements SubTypeFormatter {
     public constructor(protected childTypeFormatter: TypeFormatter) {}
 
-    public supportsType(type: RestType): boolean {
+    public supportsType(type: BaseType): boolean {
         return type instanceof RestType;
     }
+
     public getDefinition(type: RestType): Definition {
-        return this.childTypeFormatter.getDefinition(type.getType());
+        const definition = this.childTypeFormatter.getDefinition(type.getType());
+        const title = type.getTitle();
+
+        if (title !== null && typeof definition.items === "object") {
+            return { ...definition, items: { ...definition.items, title } };
+        }
+
+        return definition;
     }
+
     public getChildren(type: RestType): BaseType[] {
         return this.childTypeFormatter.getChildren(type.getType());
     }

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -27,6 +27,7 @@ describe("valid-data-type", () => {
     it("type-aliases-tuple-optional-items", assertValidSchema("type-aliases-tuple-optional-items", "MyTuple"));
     it("type-aliases-tuple-rest", assertValidSchema("type-aliases-tuple-rest", "MyTuple"));
     it("type-aliases-tuple-only-rest", assertValidSchema("type-aliases-tuple-only-rest", "MyTuple"));
+    it("type-named-tuple-member", assertValidSchema("type-named-tuple-member", "*"));
 
     it("type-maps", assertValidSchema("type-maps", "MyObject"));
     it("type-primitives", assertValidSchema("type-primitives", "MyObject"));

--- a/test/valid-data/type-named-tuple-member/main.ts
+++ b/test/valid-data/type-named-tuple-member/main.ts
@@ -1,0 +1,13 @@
+export type MyNamedUniformTuple = [first: string, second: string];
+
+export type MyNamedTuple = [first: string, second: number];
+
+export type MyNamedUniformTupleWithRest = [first: number, second: number, ...third: number[]];
+
+export type MyNamedTupleWithRest = [first: string, second: number, ...third: string[]];
+
+export type MyNamedNestedArrayWithinTuple = [first: string, second: number, third: string[]];
+
+export type MyNamedNestedArrayWithinTupleWithRest = [first: string, second: number, ...third: string[][]];
+
+export type MyNamedTupleWithOnlyRest = [...first: number[]];

--- a/test/valid-data/type-named-tuple-member/schema.json
+++ b/test/valid-data/type-named-tuple-member/schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyNamedUniformTuple": {
+      "items": [
+        {
+          "title": "first",
+          "type": "string"
+        },
+        {
+          "title": "second",
+          "type": "string"
+        }
+      ],
+      "minItems": 2,
+      "maxItems": 2,
+      "type": "array"
+    },
+    "MyNamedTuple": {
+      "items": [
+        {
+          "title": "first",
+          "type": "string"
+        },
+        {
+          "title": "second",
+          "type": "number"
+        }
+      ],
+      "maxItems": 2,
+      "minItems": 2,
+      "type": "array"
+    },
+    "MyNamedUniformTupleWithRest": {
+      "additionalItems": {
+        "title": "third",
+        "type": "number"
+      },
+      "items": [
+        {
+          "title": "first",
+          "type": "number"
+        },
+        {
+          "title": "second",
+          "type": "number"
+        }
+      ],
+      "minItems": 2,
+      "type": "array"
+    },
+    "MyNamedTupleWithRest": {
+      "additionalItems": {
+        "title": "third",
+        "type": "string"
+      },
+      "items": [
+        {
+          "title": "first",
+          "type": "string"
+        },
+        {
+          "title": "second",
+          "type": "number"
+        }
+      ],
+      "minItems": 2,
+      "type": "array"
+    },
+    "MyNamedNestedArrayWithinTuple": {
+      "items": [
+        {
+          "title": "first",
+          "type": "string"
+        },
+        {
+          "title": "second",
+          "type": "number"
+        },
+        {
+          "items": {
+            "type": "string"
+          },
+          "title": "third",
+          "type": "array"
+        }
+      ],
+      "maxItems": 3,
+      "minItems": 3,
+      "type": "array"
+    },
+    "MyNamedNestedArrayWithinTupleWithRest": {
+      "additionalItems": {
+        "title": "third",
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "items": [
+        {
+          "title": "first",
+          "type": "string"
+        },
+        {
+          "title": "second",
+          "type": "number"
+        }
+      ],
+      "minItems": 2,
+      "type": "array"
+    },
+    "MyNamedTupleWithOnlyRest": {
+      "items": {
+        "title": "first",
+        "type": "number"
+      },
+      "minItems": 0,
+      "type": "array"
+    }
+  }
+}


### PR DESCRIPTION
- Fixes lack of named tuples mentioned [here](https://github.com/vega/ts-json-schema-generator/issues/548), but does **not** add titles to named variadic tuples rest element.
- Fixes broken url on documentation
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v1.1.0-next.4`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: null[@filipomar](https://github.com/filipomar)
  
  :heart: Remi Cattiau ([@loopingz](https://github.com/loopingz))
  
  :heart: Hadrien Milano ([@hmil](https://github.com/hmil))
  
  #### 🚀 Enhancement
  
  - feat: support for named tuple members [#1236](https://github.com/vega/ts-json-schema-generator/pull/1236) ([@filipomar](https://github.com/filipomar))
  - feat: adding support for intersection of arrays and tuples [#1237](https://github.com/vega/ts-json-schema-generator/pull/1237) ([@filipomar](https://github.com/filipomar) filipe.pomar@cybus.io)
  - feat: support $ref [#1208](https://github.com/vega/ts-json-schema-generator/pull/1208) ([@hmil](https://github.com/hmil))
  - feat: add basic support for example tag [#1200](https://github.com/vega/ts-json-schema-generator/pull/1200) ([@hmil](https://github.com/hmil))
  
  #### 🐛 Bug Fix
  
  - chore(deps): bump glob from 7.2.0 to 8.0.1 [#1221](https://github.com/vega/ts-json-schema-generator/pull/1221) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@domoritz](https://github.com/domoritz))
  - chore: remove Changelog [#1222](https://github.com/vega/ts-json-schema-generator/pull/1222) ([@domoritz](https://github.com/domoritz))
  - fix: add missing imports [#1184](https://github.com/vega/ts-json-schema-generator/pull/1184) ([@loopingz](https://github.com/loopingz))
  - fix: update package.json version [#1210](https://github.com/vega/ts-json-schema-generator/pull/1210) ([@hydrosquall](https://github.com/hydrosquall))
  - fix: preserve empty `@description` [#1177](https://github.com/vega/ts-json-schema-generator/pull/1177) ([@Jason3S](https://github.com/Jason3S))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.23.0 to 5.25.0 [#1252](https://github.com/vega/ts-json-schema-generator/pull/1252) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.17.10 to 7.18.0 [#1254](https://github.com/vega/ts-json-schema-generator/pull/1254) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.33 to 17.0.35 [#1251](https://github.com/vega/ts-json-schema-generator/pull/1251) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.36.5 to 10.37.0 [#1253](https://github.com/vega/ts-json-schema-generator/pull/1253) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ts-node from 10.7.0 to 10.8.0 [#1255](https://github.com/vega/ts-json-schema-generator/pull/1255) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.36.5 to 10.37.0 [#1256](https://github.com/vega/ts-json-schema-generator/pull/1256) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.23.0 to 5.25.0 [#1257](https://github.com/vega/ts-json-schema-generator/pull/1257) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.16.7 to 7.17.12 [#1258](https://github.com/vega/ts-json-schema-generator/pull/1258) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.36.5 to 10.37.0 [#1259](https://github.com/vega/ts-json-schema-generator/pull/1259) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.17.10 to 7.18.0 [#1260](https://github.com/vega/ts-json-schema-generator/pull/1260) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.22.0 to 5.23.0 [#1247](https://github.com/vega/ts-json-schema-generator/pull/1247) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.31 to 17.0.33 [#1245](https://github.com/vega/ts-json-schema-generator/pull/1245) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.22.0 to 5.23.0 [#1246](https://github.com/vega/ts-json-schema-generator/pull/1246) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 27.5.0 to 27.5.1 [#1248](https://github.com/vega/ts-json-schema-generator/pull/1248) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump glob from 8.0.1 to 8.0.3 [#1249](https://github.com/vega/ts-json-schema-generator/pull/1249) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.21.0 to 5.22.0 [#1240](https://github.com/vega/ts-json-schema-generator/pull/1240) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 27.4.1 to 27.5.0 [#1241](https://github.com/vega/ts-json-schema-generator/pull/1241) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.21.0 to 5.22.0 [#1242](https://github.com/vega/ts-json-schema-generator/pull/1242) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.14.0 to 8.15.0 [#1243](https://github.com/vega/ts-json-schema-generator/pull/1243) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 28.0.3 to 28.1.0 [#1244](https://github.com/vega/ts-json-schema-generator/pull/1244) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.30 to 17.0.31 [#1239](https://github.com/vega/ts-json-schema-generator/pull/1239) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 27.5.1 to 28.0.3 [#1232](https://github.com/vega/ts-json-schema-generator/pull/1232) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.17.9 to 7.17.10 [#1229](https://github.com/vega/ts-json-schema-generator/pull/1229) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.20.0 to 5.21.0 [#1233](https://github.com/vega/ts-json-schema-generator/pull/1233) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.25 to 17.0.30 [#1230](https://github.com/vega/ts-json-schema-generator/pull/1230) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.16.11 to 7.17.10 [#1231](https://github.com/vega/ts-json-schema-generator/pull/1231) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.6.3 to 4.6.4 [#1234](https://github.com/vega/ts-json-schema-generator/pull/1234) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.20.0 to 5.21.0 [#1235](https://github.com/vega/ts-json-schema-generator/pull/1235) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.19.0 to 5.20.0 [#1226](https://github.com/vega/ts-json-schema-generator/pull/1226) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.24 to 17.0.25 [#1224](https://github.com/vega/ts-json-schema-generator/pull/1224) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest-junit from 13.1.0 to 13.2.0 [#1225](https://github.com/vega/ts-json-schema-generator/pull/1225) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.19.0 to 5.20.0 [#1227](https://github.com/vega/ts-json-schema-generator/pull/1227) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.13.0 to 8.14.0 [#1228](https://github.com/vega/ts-json-schema-generator/pull/1228) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.18.0 to 5.19.0 [#1217](https://github.com/vega/ts-json-schema-generator/pull/1217) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 9.1.0 to 9.2.0 [#1218](https://github.com/vega/ts-json-schema-generator/pull/1218) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.23 to 17.0.24 [#1219](https://github.com/vega/ts-json-schema-generator/pull/1219) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.18.0 to 5.19.0 [#1220](https://github.com/vega/ts-json-schema-generator/pull/1220) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.17.0 to 5.18.0 [#1212](https://github.com/vega/ts-json-schema-generator/pull/1212) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.17.8 to 7.17.9 [#1213](https://github.com/vega/ts-json-schema-generator/pull/1213) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.12.0 to 8.13.0 [#1214](https://github.com/vega/ts-json-schema-generator/pull/1214) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.17.0 to 5.18.0 [#1215](https://github.com/vega/ts-json-schema-generator/pull/1215) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest-junit from 13.0.0 to 13.1.0 [#1216](https://github.com/vega/ts-json-schema-generator/pull/1216) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump codecov/codecov-action from 2.1.0 to 3 [#1211](https://github.com/vega/ts-json-schema-generator/pull/1211) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.16.0 to 5.17.0 [#1203](https://github.com/vega/ts-json-schema-generator/pull/1203) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.6.1 to 2.6.2 [#1204](https://github.com/vega/ts-json-schema-generator/pull/1204) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.16.0 to 5.17.0 [#1205](https://github.com/vega/ts-json-schema-generator/pull/1205) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.34.2 to 10.36.5 [#1197](https://github.com/vega/ts-json-schema-generator/pull/1197) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.15.0 to 5.16.0 [#1185](https://github.com/vega/ts-json-schema-generator/pull/1185) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump node-fetch from 2.6.6 to 2.6.7 [#1195](https://github.com/vega/ts-json-schema-generator/pull/1195) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump minimist from 1.2.5 to 1.2.6 [#1196](https://github.com/vega/ts-json-schema-generator/pull/1196) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump json5 from 2.2.0 to 2.2.1 [#1198](https://github.com/vega/ts-json-schema-generator/pull/1198) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.6.0 to 2.6.1 [#1199](https://github.com/vega/ts-json-schema-generator/pull/1199) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.11.0 to 8.12.0 [#1186](https://github.com/vega/ts-json-schema-generator/pull/1186) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.34.2 to 10.36.5 [#1187](https://github.com/vega/ts-json-schema-generator/pull/1187) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.34.2 to 10.36.5 [#1188](https://github.com/vega/ts-json-schema-generator/pull/1188) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.6.2 to 4.6.3 [#1189](https://github.com/vega/ts-json-schema-generator/pull/1189) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @types/json-schema from 7.0.10 to 7.0.11 [#1190](https://github.com/vega/ts-json-schema-generator/pull/1190) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.21 to 17.0.23 [#1191](https://github.com/vega/ts-json-schema-generator/pull/1191) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.15.0 to 5.16.0 [#1192](https://github.com/vega/ts-json-schema-generator/pull/1192) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega from 5.22.0 to 5.22.1 [#1193](https://github.com/vega/ts-json-schema-generator/pull/1193) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv from 8.10.0 to 8.11.0 [#1194](https://github.com/vega/ts-json-schema-generator/pull/1194) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 8
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - [@filipomar](https://github.com/filipomar)
  - Cameron Yick ([@hydrosquall](https://github.com/hydrosquall))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
  - Filipe Pomar (filipe.pomar@cybus.io)
  - Hadrien Milano ([@hmil](https://github.com/hmil))
  - Jason Dent ([@Jason3S](https://github.com/Jason3S))
  - Remi Cattiau ([@loopingz](https://github.com/loopingz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
