### PR TITLE
feat: adding support for intersection of arrays and tuples

### DIFF
--- a/src/TypeFormatter/IntersectionTypeFormatter.ts
+++ b/src/TypeFormatter/IntersectionTypeFormatter.ts
@@ -18,10 +18,6 @@ export class IntersectionTypeFormatter implements SubTypeFormatter {
     public getDefinition(type: IntersectionType): Definition {
         const types = type.getTypes();
 
-        if (types.length <= 1) {
-            return this.childTypeFormatter.getDefinition(types[0]);
-        }
-
         const dependencies: Definition[] = [];
         const nonArrayLikeTypes: BaseType[] = [];
 

--- a/src/TypeFormatter/IntersectionTypeFormatter.ts
+++ b/src/TypeFormatter/IntersectionTypeFormatter.ts
@@ -16,27 +16,21 @@ export class IntersectionTypeFormatter implements SubTypeFormatter {
     }
 
     public getDefinition(type: IntersectionType): Definition {
-        const types = type.getTypes();
-
         const dependencies: Definition[] = [];
         const nonArrayLikeTypes: BaseType[] = [];
 
-        types.forEach((t) => {
+        for (const t of type.getTypes()) {
+            // Filter out Array like definitions that cannot be
+            // easily mergeable into a single json-schema object
             if (t instanceof ArrayType || t instanceof TupleType) {
-                /**
-                 * Arrays are not easily mergeable
-                 * So it's just easier to append their defs
-                 */
                 dependencies.push(this.childTypeFormatter.getDefinition(t));
             } else {
                 nonArrayLikeTypes.push(t);
             }
-        });
+        }
 
         if (nonArrayLikeTypes.length) {
-            /**
-             * There are non array (mergeable requirements)
-             */
+            // There are non array (mergeable requirements)
             dependencies.push(
                 nonArrayLikeTypes.reduce(getAllOfDefinitionReducer(this.childTypeFormatter), {
                     type: "object",

--- a/src/TypeFormatter/IntersectionTypeFormatter.ts
+++ b/src/TypeFormatter/IntersectionTypeFormatter.ts
@@ -22,8 +22,8 @@ export class IntersectionTypeFormatter implements SubTypeFormatter {
             return this.childTypeFormatter.getDefinition(types[0]);
         }
 
-        const requirements: Definition[] = [];
-        const otherTypes: BaseType[] = [];
+        const dependencies: Definition[] = [];
+        const nonArrayLikeTypes: BaseType[] = [];
 
         types.forEach((t) => {
             if (t instanceof ArrayType || t instanceof TupleType) {
@@ -31,25 +31,25 @@ export class IntersectionTypeFormatter implements SubTypeFormatter {
                  * Arrays are not easily mergeable
                  * So it's just easier to append their defs
                  */
-                requirements.push(this.childTypeFormatter.getDefinition(t));
+                dependencies.push(this.childTypeFormatter.getDefinition(t));
             } else {
-                otherTypes.push(t);
+                nonArrayLikeTypes.push(t);
             }
         });
 
-        if (otherTypes.length) {
+        if (nonArrayLikeTypes.length) {
             /**
              * There are non array (mergeable requirements)
              */
-            requirements.push(
-                otherTypes.reduce(getAllOfDefinitionReducer(this.childTypeFormatter), {
+            dependencies.push(
+                nonArrayLikeTypes.reduce(getAllOfDefinitionReducer(this.childTypeFormatter), {
                     type: "object",
                     additionalProperties: false,
                 })
             );
         }
 
-        return requirements.length === 1 ? requirements[0] : { allOf: requirements };
+        return dependencies.length === 1 ? dependencies[0] : { allOf: dependencies };
     }
 
     public getChildren(type: IntersectionType): BaseType[] {

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -36,6 +36,7 @@ describe("valid-data-type", () => {
     it("type-union", assertValidSchema("type-union", "TypeUnion"));
     it("type-union-tagged", assertValidSchema("type-union-tagged", "Shape"));
     it("type-intersection", assertValidSchema("type-intersection", "MyObject"));
+    it("type-intersection-with-arrays", assertValidSchema("type-intersection-with-arrays", "*"));
     it("type-intersection-conflict", assertValidSchema("type-intersection-conflict", "MyObject"));
     it("type-intersection-partial-conflict", assertValidSchema("type-intersection-partial-conflict", "MyType"));
     it("type-intersection-partial-conflict-ref", assertValidSchema("type-intersection-partial-conflict", "MyType"));

--- a/test/valid-data/type-intersection-with-arrays/main.ts
+++ b/test/valid-data/type-intersection-with-arrays/main.ts
@@ -1,0 +1,5 @@
+export type NonEmptyNumberArrayVariationOne = [number, ...number[]] & number[];
+
+type NonEmptyGenericArrayVariationOne<T> = [T, ...T[]] & T[];
+
+export type NonEmptyNumberArrayVariationTwo = NonEmptyGenericArrayVariationOne<number>;

--- a/test/valid-data/type-intersection-with-arrays/schema.json
+++ b/test/valid-data/type-intersection-with-arrays/schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "NonEmptyNumberArrayVariationOne": {
+      "allOf": [
+        {
+          "items": {
+            "type": "number"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "NonEmptyNumberArrayVariationTwo": {
+      "allOf": [
+        {
+          "items": {
+            "type": "number"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adding support for intersection of arrays and tupples such as:

```typescript
type NonEmptyArray<T> = [T, ...T[]] & T[];
```

Types originally from [here](https://stackoverflow.com/questions/56006111/is-it-possible-to-define-a-non-empty-array-type-in-typescript).
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v1.1.0-next.3`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: null[@filipomar](https://github.com/filipomar)
  
  :heart: Remi Cattiau ([@loopingz](https://github.com/loopingz))
  
  :heart: Hadrien Milano ([@hmil](https://github.com/hmil))
  
  #### 🚀 Enhancement
  
  - feat: adding support for intersection of arrays and tuples [#1237](https://github.com/vega/ts-json-schema-generator/pull/1237) ([@filipomar](https://github.com/filipomar) filipe.pomar@cybus.io)
  - feat: support $ref [#1208](https://github.com/vega/ts-json-schema-generator/pull/1208) ([@hmil](https://github.com/hmil))
  - feat: add basic support for example tag [#1200](https://github.com/vega/ts-json-schema-generator/pull/1200) ([@hmil](https://github.com/hmil))
  
  #### 🐛 Bug Fix
  
  - chore(deps): bump glob from 7.2.0 to 8.0.1 [#1221](https://github.com/vega/ts-json-schema-generator/pull/1221) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@domoritz](https://github.com/domoritz))
  - chore: remove Changelog [#1222](https://github.com/vega/ts-json-schema-generator/pull/1222) ([@domoritz](https://github.com/domoritz))
  - fix: add missing imports [#1184](https://github.com/vega/ts-json-schema-generator/pull/1184) ([@loopingz](https://github.com/loopingz))
  - fix: update package.json version [#1210](https://github.com/vega/ts-json-schema-generator/pull/1210) ([@hydrosquall](https://github.com/hydrosquall))
  - fix: preserve empty `@description` [#1177](https://github.com/vega/ts-json-schema-generator/pull/1177) ([@Jason3S](https://github.com/Jason3S))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump jest from 27.5.1 to 28.0.3 [#1232](https://github.com/vega/ts-json-schema-generator/pull/1232) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.17.9 to 7.17.10 [#1229](https://github.com/vega/ts-json-schema-generator/pull/1229) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.20.0 to 5.21.0 [#1233](https://github.com/vega/ts-json-schema-generator/pull/1233) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.25 to 17.0.30 [#1230](https://github.com/vega/ts-json-schema-generator/pull/1230) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.16.11 to 7.17.10 [#1231](https://github.com/vega/ts-json-schema-generator/pull/1231) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.6.3 to 4.6.4 [#1234](https://github.com/vega/ts-json-schema-generator/pull/1234) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.20.0 to 5.21.0 [#1235](https://github.com/vega/ts-json-schema-generator/pull/1235) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.19.0 to 5.20.0 [#1226](https://github.com/vega/ts-json-schema-generator/pull/1226) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.24 to 17.0.25 [#1224](https://github.com/vega/ts-json-schema-generator/pull/1224) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest-junit from 13.1.0 to 13.2.0 [#1225](https://github.com/vega/ts-json-schema-generator/pull/1225) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.19.0 to 5.20.0 [#1227](https://github.com/vega/ts-json-schema-generator/pull/1227) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.13.0 to 8.14.0 [#1228](https://github.com/vega/ts-json-schema-generator/pull/1228) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.18.0 to 5.19.0 [#1217](https://github.com/vega/ts-json-schema-generator/pull/1217) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 9.1.0 to 9.2.0 [#1218](https://github.com/vega/ts-json-schema-generator/pull/1218) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.23 to 17.0.24 [#1219](https://github.com/vega/ts-json-schema-generator/pull/1219) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.18.0 to 5.19.0 [#1220](https://github.com/vega/ts-json-schema-generator/pull/1220) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.17.0 to 5.18.0 [#1212](https://github.com/vega/ts-json-schema-generator/pull/1212) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.17.8 to 7.17.9 [#1213](https://github.com/vega/ts-json-schema-generator/pull/1213) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.12.0 to 8.13.0 [#1214](https://github.com/vega/ts-json-schema-generator/pull/1214) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.17.0 to 5.18.0 [#1215](https://github.com/vega/ts-json-schema-generator/pull/1215) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest-junit from 13.0.0 to 13.1.0 [#1216](https://github.com/vega/ts-json-schema-generator/pull/1216) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump codecov/codecov-action from 2.1.0 to 3 [#1211](https://github.com/vega/ts-json-schema-generator/pull/1211) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.16.0 to 5.17.0 [#1203](https://github.com/vega/ts-json-schema-generator/pull/1203) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.6.1 to 2.6.2 [#1204](https://github.com/vega/ts-json-schema-generator/pull/1204) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.16.0 to 5.17.0 [#1205](https://github.com/vega/ts-json-schema-generator/pull/1205) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.34.2 to 10.36.5 [#1197](https://github.com/vega/ts-json-schema-generator/pull/1197) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.15.0 to 5.16.0 [#1185](https://github.com/vega/ts-json-schema-generator/pull/1185) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump node-fetch from 2.6.6 to 2.6.7 [#1195](https://github.com/vega/ts-json-schema-generator/pull/1195) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump minimist from 1.2.5 to 1.2.6 [#1196](https://github.com/vega/ts-json-schema-generator/pull/1196) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump json5 from 2.2.0 to 2.2.1 [#1198](https://github.com/vega/ts-json-schema-generator/pull/1198) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.6.0 to 2.6.1 [#1199](https://github.com/vega/ts-json-schema-generator/pull/1199) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.11.0 to 8.12.0 [#1186](https://github.com/vega/ts-json-schema-generator/pull/1186) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.34.2 to 10.36.5 [#1187](https://github.com/vega/ts-json-schema-generator/pull/1187) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.34.2 to 10.36.5 [#1188](https://github.com/vega/ts-json-schema-generator/pull/1188) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.6.2 to 4.6.3 [#1189](https://github.com/vega/ts-json-schema-generator/pull/1189) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @types/json-schema from 7.0.10 to 7.0.11 [#1190](https://github.com/vega/ts-json-schema-generator/pull/1190) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.21 to 17.0.23 [#1191](https://github.com/vega/ts-json-schema-generator/pull/1191) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.15.0 to 5.16.0 [#1192](https://github.com/vega/ts-json-schema-generator/pull/1192) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega from 5.22.0 to 5.22.1 [#1193](https://github.com/vega/ts-json-schema-generator/pull/1193) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv from 8.10.0 to 8.11.0 [#1194](https://github.com/vega/ts-json-schema-generator/pull/1194) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 8
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - [@filipomar](https://github.com/filipomar)
  - Cameron Yick ([@hydrosquall](https://github.com/hydrosquall))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
  - Filipe Pomar (filipe.pomar@cybus.io)
  - Hadrien Milano ([@hmil](https://github.com/hmil))
  - Jason Dent ([@Jason3S](https://github.com/Jason3S))
  - Remi Cattiau ([@loopingz](https://github.com/loopingz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
