### PR TITLE
feat: support empty mapped types

### DIFF
--- a/src/NodeParser/MappedTypeNodeParser.ts
+++ b/src/NodeParser/MappedTypeNodeParser.ts
@@ -7,6 +7,7 @@ import { ArrayType } from "../Type/ArrayType";
 import { BaseType } from "../Type/BaseType";
 import { EnumType, EnumValue } from "../Type/EnumType";
 import { LiteralType } from "../Type/LiteralType";
+import { NeverType } from "../Type/NeverType";
 import { NumberType } from "../Type/NumberType";
 import { ObjectProperty, ObjectType } from "../Type/ObjectType";
 import { StringType } from "../Type/StringType";
@@ -58,6 +59,10 @@ export class MappedTypeNodeParser implements SubNodeParser {
             return type === undefined ? undefined : new ArrayType(type);
         } else if (keyListType instanceof EnumType) {
             return new ObjectType(id, [], this.getValues(node, keyListType, context), false);
+        } else if (keyListType instanceof NeverType) {
+            return new ObjectType(id, [], [], false);
+        } else if (keyListType === undefined) {
+            return new ObjectType(id, [], [], false);
         } else {
             throw new LogicError(
                 // eslint-disable-next-line max-len

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -95,6 +95,8 @@ describe("valid-data-type", () => {
     it("type-mapped-exclude", assertValidSchema("type-mapped-exclude", "MyObject", "extended"));
     it("type-mapped-double-exclude", assertValidSchema("type-mapped-double-exclude", "MyObject", "extended"));
     it("type-mapped-symbol", assertValidSchema("type-mapped-symbol", "MyObject"));
+    it("type-mapped-never", assertValidSchema("type-mapped-never", "MyObject"));
+    it("type-mapped-empty-exclude", assertValidSchema("type-mapped-empty-exclude", "MyObject"));
     it("type-mapped-annotated-string", assertValidSchema("type-mapped-annotated-string", "ExchangeRate", "extended"));
 
     it("type-conditional-simple", assertValidSchema("type-conditional-simple", "MyObject"));

--- a/test/valid-data/type-mapped-empty-exclude/main.ts
+++ b/test/valid-data/type-mapped-empty-exclude/main.ts
@@ -1,0 +1,1 @@
+export type MyObject = { [K in Exclude<"key", "key">]: never };

--- a/test/valid-data/type-mapped-empty-exclude/schema.json
+++ b/test/valid-data/type-mapped-empty-exclude/schema.json
@@ -1,0 +1,10 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/test/valid-data/type-mapped-never/main.ts
+++ b/test/valid-data/type-mapped-never/main.ts
@@ -1,0 +1,1 @@
+export type MyObject = { [K in never]: never };

--- a/test/valid-data/type-mapped-never/schema.json
+++ b/test/valid-data/type-mapped-never/schema.json
@@ -1,0 +1,10 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
Currently, types such as:
```typescript
export type MappedNever = {
  [K in never]?: never;
};
```
and
```typescript
export type MappedExclude = {
  [K in Exclude<"key", "key">]?: never;
};
```
Result in the respective errors :
```
Error: Unexpected key type "never" for type "{ [K in never]?: never }" (expected "UnionType" or "StringType")
```
and
```
Error: Unexpected key type "undefined" for type "{ [K in Exclude<"key", "key">]?: never }" (expected "UnionType" or "StringType")
```
Instead, both scenarios should result in an empty object. This change simply adds the needed clauses to handle these types in `MappedTypeNodeParser`.

Ideally, both cases are handled in a single clause, as the second example should be equal to the first (both result in a `never` key type). This is currently not the case, since resolving an empty union results in `undefined` instead of `new NeverType()`, as mentioned in [#1154 (comment)](https://github.com/vega/ts-json-schema-generator/pull/1154#issuecomment-1064933851). However, properly propagating `NeverType` is hard as it results in regressions, e.g. see https://github.com/vega/ts-json-schema-generator/pull/650#pullrequestreview-588419594. The second clause can probably be removed once these issues are solved.

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v1.1.0-next.5`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: null[@daanboer](https://github.com/daanboer)
  
  :heart: null[@filipomar](https://github.com/filipomar)
  
  :heart: Remi Cattiau ([@loopingz](https://github.com/loopingz))
  
  :heart: Hadrien Milano ([@hmil](https://github.com/hmil))
  
  #### 🚀 Enhancement
  
  - feat: support empty mapped types [#1261](https://github.com/vega/ts-json-schema-generator/pull/1261) ([@daanboer](https://github.com/daanboer))
  - feat: support for named tuple members [#1236](https://github.com/vega/ts-json-schema-generator/pull/1236) ([@filipomar](https://github.com/filipomar))
  - feat: adding support for intersection of arrays and tuples [#1237](https://github.com/vega/ts-json-schema-generator/pull/1237) ([@filipomar](https://github.com/filipomar) filipe.pomar@cybus.io)
  - feat: support $ref [#1208](https://github.com/vega/ts-json-schema-generator/pull/1208) ([@hmil](https://github.com/hmil))
  - feat: add basic support for example tag [#1200](https://github.com/vega/ts-json-schema-generator/pull/1200) ([@hmil](https://github.com/hmil))
  
  #### 🐛 Bug Fix
  
  - chore(deps): bump glob from 7.2.0 to 8.0.1 [#1221](https://github.com/vega/ts-json-schema-generator/pull/1221) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@domoritz](https://github.com/domoritz))
  - chore: remove Changelog [#1222](https://github.com/vega/ts-json-schema-generator/pull/1222) ([@domoritz](https://github.com/domoritz))
  - fix: add missing imports [#1184](https://github.com/vega/ts-json-schema-generator/pull/1184) ([@loopingz](https://github.com/loopingz))
  - fix: update package.json version [#1210](https://github.com/vega/ts-json-schema-generator/pull/1210) ([@hydrosquall](https://github.com/hydrosquall))
  - fix: preserve empty `@description` [#1177](https://github.com/vega/ts-json-schema-generator/pull/1177) ([@Jason3S](https://github.com/Jason3S))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.23.0 to 5.25.0 [#1252](https://github.com/vega/ts-json-schema-generator/pull/1252) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.17.10 to 7.18.0 [#1254](https://github.com/vega/ts-json-schema-generator/pull/1254) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.33 to 17.0.35 [#1251](https://github.com/vega/ts-json-schema-generator/pull/1251) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.36.5 to 10.37.0 [#1253](https://github.com/vega/ts-json-schema-generator/pull/1253) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ts-node from 10.7.0 to 10.8.0 [#1255](https://github.com/vega/ts-json-schema-generator/pull/1255) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.36.5 to 10.37.0 [#1256](https://github.com/vega/ts-json-schema-generator/pull/1256) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.23.0 to 5.25.0 [#1257](https://github.com/vega/ts-json-schema-generator/pull/1257) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.16.7 to 7.17.12 [#1258](https://github.com/vega/ts-json-schema-generator/pull/1258) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.36.5 to 10.37.0 [#1259](https://github.com/vega/ts-json-schema-generator/pull/1259) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.17.10 to 7.18.0 [#1260](https://github.com/vega/ts-json-schema-generator/pull/1260) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.22.0 to 5.23.0 [#1247](https://github.com/vega/ts-json-schema-generator/pull/1247) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.31 to 17.0.33 [#1245](https://github.com/vega/ts-json-schema-generator/pull/1245) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.22.0 to 5.23.0 [#1246](https://github.com/vega/ts-json-schema-generator/pull/1246) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 27.5.0 to 27.5.1 [#1248](https://github.com/vega/ts-json-schema-generator/pull/1248) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump glob from 8.0.1 to 8.0.3 [#1249](https://github.com/vega/ts-json-schema-generator/pull/1249) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.21.0 to 5.22.0 [#1240](https://github.com/vega/ts-json-schema-generator/pull/1240) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 27.4.1 to 27.5.0 [#1241](https://github.com/vega/ts-json-schema-generator/pull/1241) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.21.0 to 5.22.0 [#1242](https://github.com/vega/ts-json-schema-generator/pull/1242) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.14.0 to 8.15.0 [#1243](https://github.com/vega/ts-json-schema-generator/pull/1243) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 28.0.3 to 28.1.0 [#1244](https://github.com/vega/ts-json-schema-generator/pull/1244) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.30 to 17.0.31 [#1239](https://github.com/vega/ts-json-schema-generator/pull/1239) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 27.5.1 to 28.0.3 [#1232](https://github.com/vega/ts-json-schema-generator/pull/1232) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.17.9 to 7.17.10 [#1229](https://github.com/vega/ts-json-schema-generator/pull/1229) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.20.0 to 5.21.0 [#1233](https://github.com/vega/ts-json-schema-generator/pull/1233) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.25 to 17.0.30 [#1230](https://github.com/vega/ts-json-schema-generator/pull/1230) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.16.11 to 7.17.10 [#1231](https://github.com/vega/ts-json-schema-generator/pull/1231) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.6.3 to 4.6.4 [#1234](https://github.com/vega/ts-json-schema-generator/pull/1234) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.20.0 to 5.21.0 [#1235](https://github.com/vega/ts-json-schema-generator/pull/1235) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.19.0 to 5.20.0 [#1226](https://github.com/vega/ts-json-schema-generator/pull/1226) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.24 to 17.0.25 [#1224](https://github.com/vega/ts-json-schema-generator/pull/1224) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest-junit from 13.1.0 to 13.2.0 [#1225](https://github.com/vega/ts-json-schema-generator/pull/1225) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.19.0 to 5.20.0 [#1227](https://github.com/vega/ts-json-schema-generator/pull/1227) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.13.0 to 8.14.0 [#1228](https://github.com/vega/ts-json-schema-generator/pull/1228) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.18.0 to 5.19.0 [#1217](https://github.com/vega/ts-json-schema-generator/pull/1217) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 9.1.0 to 9.2.0 [#1218](https://github.com/vega/ts-json-schema-generator/pull/1218) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.23 to 17.0.24 [#1219](https://github.com/vega/ts-json-schema-generator/pull/1219) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.18.0 to 5.19.0 [#1220](https://github.com/vega/ts-json-schema-generator/pull/1220) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.17.0 to 5.18.0 [#1212](https://github.com/vega/ts-json-schema-generator/pull/1212) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.17.8 to 7.17.9 [#1213](https://github.com/vega/ts-json-schema-generator/pull/1213) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.12.0 to 8.13.0 [#1214](https://github.com/vega/ts-json-schema-generator/pull/1214) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.17.0 to 5.18.0 [#1215](https://github.com/vega/ts-json-schema-generator/pull/1215) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest-junit from 13.0.0 to 13.1.0 [#1216](https://github.com/vega/ts-json-schema-generator/pull/1216) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump codecov/codecov-action from 2.1.0 to 3 [#1211](https://github.com/vega/ts-json-schema-generator/pull/1211) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.16.0 to 5.17.0 [#1203](https://github.com/vega/ts-json-schema-generator/pull/1203) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.6.1 to 2.6.2 [#1204](https://github.com/vega/ts-json-schema-generator/pull/1204) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.16.0 to 5.17.0 [#1205](https://github.com/vega/ts-json-schema-generator/pull/1205) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.34.2 to 10.36.5 [#1197](https://github.com/vega/ts-json-schema-generator/pull/1197) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.15.0 to 5.16.0 [#1185](https://github.com/vega/ts-json-schema-generator/pull/1185) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump node-fetch from 2.6.6 to 2.6.7 [#1195](https://github.com/vega/ts-json-schema-generator/pull/1195) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump minimist from 1.2.5 to 1.2.6 [#1196](https://github.com/vega/ts-json-schema-generator/pull/1196) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump json5 from 2.2.0 to 2.2.1 [#1198](https://github.com/vega/ts-json-schema-generator/pull/1198) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.6.0 to 2.6.1 [#1199](https://github.com/vega/ts-json-schema-generator/pull/1199) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.11.0 to 8.12.0 [#1186](https://github.com/vega/ts-json-schema-generator/pull/1186) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.34.2 to 10.36.5 [#1187](https://github.com/vega/ts-json-schema-generator/pull/1187) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.34.2 to 10.36.5 [#1188](https://github.com/vega/ts-json-schema-generator/pull/1188) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.6.2 to 4.6.3 [#1189](https://github.com/vega/ts-json-schema-generator/pull/1189) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @types/json-schema from 7.0.10 to 7.0.11 [#1190](https://github.com/vega/ts-json-schema-generator/pull/1190) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 17.0.21 to 17.0.23 [#1191](https://github.com/vega/ts-json-schema-generator/pull/1191) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.15.0 to 5.16.0 [#1192](https://github.com/vega/ts-json-schema-generator/pull/1192) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega from 5.22.0 to 5.22.1 [#1193](https://github.com/vega/ts-json-schema-generator/pull/1193) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv from 8.10.0 to 8.11.0 [#1194](https://github.com/vega/ts-json-schema-generator/pull/1194) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 9
  
  - [@daanboer](https://github.com/daanboer)
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - [@filipomar](https://github.com/filipomar)
  - Cameron Yick ([@hydrosquall](https://github.com/hydrosquall))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
  - Filipe Pomar (filipe.pomar@cybus.io)
  - Hadrien Milano ([@hmil](https://github.com/hmil))
  - Jason Dent ([@Jason3S](https://github.com/Jason3S))
  - Remi Cattiau ([@loopingz](https://github.com/loopingz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
