### PR TITLE
feat: support inferred types in conditionals

### DIFF
--- a/factory/parser.ts
+++ b/factory/parser.ts
@@ -22,6 +22,7 @@ import { FunctionNodeParser } from "../src/NodeParser/FunctionNodeParser";
 import { FunctionParser } from "../src/NodeParser/FunctionParser";
 import { HiddenNodeParser } from "../src/NodeParser/HiddenTypeNodeParser";
 import { IndexedAccessTypeNodeParser } from "../src/NodeParser/IndexedAccessTypeNodeParser";
+import { InferTypeNodeParser } from "../src/NodeParser/InferTypeNodeParser";
 import { InterfaceAndClassNodeParser } from "../src/NodeParser/InterfaceAndClassNodeParser";
 import { IntersectionNodeParser } from "../src/NodeParser/IntersectionNodeParser";
 import { IntrinsicNodeParser } from "../src/NodeParser/IntrinsicNodeParser";
@@ -121,6 +122,8 @@ export function createParser(program: ts.Program, config: Config, augmentor?: Pa
 
         .addNodeParser(new TypeReferenceNodeParser(typeChecker, chainNodeParser))
         .addNodeParser(new ExpressionWithTypeArgumentsNodeParser(typeChecker, chainNodeParser))
+
+        .addNodeParser(new InferTypeNodeParser(typeChecker, chainNodeParser))
 
         .addNodeParser(new IndexedAccessTypeNodeParser(chainNodeParser))
         .addNodeParser(new TypeofNodeParser(typeChecker, chainNodeParser))

--- a/src/ChainNodeParser.ts
+++ b/src/ChainNodeParser.ts
@@ -40,7 +40,6 @@ export class ChainNodeParser implements SubNodeParser, MutableParser {
     protected getNodeParser(node: ts.Node, context: Context): SubNodeParser {
         for (const nodeParser of this.nodeParsers) {
             if (nodeParser.supportsNode(node)) {
-                console.log(nodeParser.constructor.name);
                 return nodeParser;
             }
         }

--- a/src/ChainNodeParser.ts
+++ b/src/ChainNodeParser.ts
@@ -40,6 +40,7 @@ export class ChainNodeParser implements SubNodeParser, MutableParser {
     protected getNodeParser(node: ts.Node, context: Context): SubNodeParser {
         for (const nodeParser of this.nodeParsers) {
             if (nodeParser.supportsNode(node)) {
+                console.log(nodeParser.constructor.name);
                 return nodeParser;
             }
         }

--- a/src/NodeParser/ConditionalTypeNodeParser.ts
+++ b/src/NodeParser/ConditionalTypeNodeParser.ts
@@ -18,8 +18,11 @@ export class ConditionalTypeNodeParser implements SubNodeParser {
         const extendsType = this.childNodeParser.createType(node.extendsType, context);
         const checkTypeParameterName = this.getTypeParameterName(node.checkType);
 
-        // console.log(checkTye);
+        // console.log("checkType");
+        // console.log(checkType);
+        // console.log("extendsType");
         // console.log(extendsType);
+        // console.log("checkTypeParameterName");
         // console.log(checkTypeParameterName);
 
         // If check-type is not a type parameter then condition is very simple, no type narrowing needed
@@ -29,27 +32,37 @@ export class ConditionalTypeNodeParser implements SubNodeParser {
         }
 
         // Narrow down check type for both condition branches
-        const trueCheckType = narrowType(checkType, (type) => isAssignableTo(extendsType, type));
-        console.log(trueCheckType);
+        let inferMap = new Map();
+        const trueCheckType = narrowType(checkType, (type) => resolveInfer(extendsType, type, new Set(), inferMap));
+        // console.log(`trueCheckType: ${trueCheckType}`);
+        // console.log(trueCheckType);
         // console.log(node.trueType);
-        const falseCheckType = narrowType(checkType, (type) => !isAssignableTo(extendsType, type));
+        const falseCheckType = narrowType(checkType, (type) => !resolveInfer(extendsType, type, new Set(), new Map()));
+        // console.log(`falseCheckType: ${falseCheckType}`);
         // console.log(falseCheckType);
 
         // Follow the relevant branches and return the results from them
         const results: BaseType[] = [];
         if (trueCheckType !== undefined) {
-            console.log("TRUE");
+            // console.log("TRUE");
             // console.log(resolveInfer(extendsType, checkType, new Set()));
+            // console.log(node.trueType);
             const result = this.childNodeParser.createType(
                 node.trueType,
-                this.createSubContext(node, checkTypeParameterName, trueCheckType, context)
+                this.createSubContext(node, checkTypeParameterName, trueCheckType, context, inferMap)
             );
+            // console.log(result);
             if (result) {
                 results.push(result);
             }
         }
         if (falseCheckType !== undefined) {
-            console.log("FALSE");
+            // console.log("FALSE");
+            // console.log(context.getParameters());
+            // if (context.getParameters().length == 1) {
+            //     console.log(context.getArgument("T"));
+            //     console.log(inferMap)
+            // }
             const result = this.childNodeParser.createType(
                 node.falseType,
                 this.createSubContext(node, checkTypeParameterName, falseCheckType, context)
@@ -90,7 +103,8 @@ export class ConditionalTypeNodeParser implements SubNodeParser {
         node: ts.ConditionalTypeNode,
         checkTypeParameterName: string,
         narrowedCheckType: BaseType,
-        parentContext: Context
+        parentContext: Context,
+        inferMap: Map<string, BaseType> = new Map()
     ): Context {
         const subContext = new Context(node);
 
@@ -98,9 +112,15 @@ export class ConditionalTypeNodeParser implements SubNodeParser {
         subContext.pushParameter(checkTypeParameterName);
         subContext.pushArgument(narrowedCheckType);
 
+        inferMap.forEach((value, key) => {
+            subContext.pushParameter(key);
+            subContext.pushArgument(value);
+        });
+
         // Copy all other type parameters from parent context
+        // TODO: Check whether this is correct
         parentContext.getParameters().forEach((parentParameter) => {
-            if (parentParameter !== checkTypeParameterName) {
+            if (parentParameter !== checkTypeParameterName && !(parentParameter in inferMap)) {
                 subContext.pushParameter(parentParameter);
                 subContext.pushArgument(parentContext.getArgument(parentParameter));
             }

--- a/src/NodeParser/ConditionalTypeNodeParser.ts
+++ b/src/NodeParser/ConditionalTypeNodeParser.ts
@@ -108,17 +108,19 @@ export class ConditionalTypeNodeParser implements SubNodeParser {
     ): Context {
         const subContext = new Context(node);
 
-        // Set new narrowed type for check type parameter
-        subContext.pushParameter(checkTypeParameterName);
-        subContext.pushArgument(narrowedCheckType);
-
+        // Newly inferred types take precedence over check and parent types.
         inferMap.forEach((value, key) => {
             subContext.pushParameter(key);
             subContext.pushArgument(value);
         });
 
+        // Set new narrowed type for check type parameter
+        if (!(checkTypeParameterName in inferMap)) {
+            subContext.pushParameter(checkTypeParameterName);
+            subContext.pushArgument(narrowedCheckType);
+        }
+
         // Copy all other type parameters from parent context
-        // TODO: Check whether this is correct
         parentContext.getParameters().forEach((parentParameter) => {
             if (parentParameter !== checkTypeParameterName && !(parentParameter in inferMap)) {
                 subContext.pushParameter(parentParameter);

--- a/src/NodeParser/ConditionalTypeNodeParser.ts
+++ b/src/NodeParser/ConditionalTypeNodeParser.ts
@@ -2,7 +2,7 @@ import ts from "typescript";
 import { Context, NodeParser } from "../NodeParser";
 import { SubNodeParser } from "../SubNodeParser";
 import { BaseType } from "../Type/BaseType";
-import { isAssignableTo } from "../Utils/isAssignableTo";
+import { isAssignableTo, resolveInfer } from "../Utils/isAssignableTo";
 import { narrowType } from "../Utils/narrowType";
 import { UnionType } from "../Type/UnionType";
 
@@ -18,9 +18,9 @@ export class ConditionalTypeNodeParser implements SubNodeParser {
         const extendsType = this.childNodeParser.createType(node.extendsType, context);
         const checkTypeParameterName = this.getTypeParameterName(node.checkType);
 
-        console.log(checkType);
-        console.log(extendsType);
-        console.log(checkTypeParameterName);
+        // console.log(checkTye);
+        // console.log(extendsType);
+        // console.log(checkTypeParameterName);
 
         // If check-type is not a type parameter then condition is very simple, no type narrowing needed
         if (checkTypeParameterName == null) {
@@ -31,6 +31,7 @@ export class ConditionalTypeNodeParser implements SubNodeParser {
         // Narrow down check type for both condition branches
         const trueCheckType = narrowType(checkType, (type) => isAssignableTo(extendsType, type));
         console.log(trueCheckType);
+        // console.log(node.trueType);
         const falseCheckType = narrowType(checkType, (type) => !isAssignableTo(extendsType, type));
         // console.log(falseCheckType);
 
@@ -38,6 +39,7 @@ export class ConditionalTypeNodeParser implements SubNodeParser {
         const results: BaseType[] = [];
         if (trueCheckType !== undefined) {
             console.log("TRUE");
+            // console.log(resolveInfer(extendsType, checkType, new Set()));
             const result = this.childNodeParser.createType(
                 node.trueType,
                 this.createSubContext(node, checkTypeParameterName, trueCheckType, context)

--- a/src/NodeParser/ConditionalTypeNodeParser.ts
+++ b/src/NodeParser/ConditionalTypeNodeParser.ts
@@ -18,13 +18,6 @@ export class ConditionalTypeNodeParser implements SubNodeParser {
         const extendsType = this.childNodeParser.createType(node.extendsType, context);
         const checkTypeParameterName = this.getTypeParameterName(node.checkType);
 
-        // console.log("checkType");
-        // console.log(checkType);
-        // console.log("extendsType");
-        // console.log(extendsType);
-        // console.log("checkTypeParameterName");
-        // console.log(checkTypeParameterName);
-
         // If check-type is not a type parameter then condition is very simple, no type narrowing needed
         if (checkTypeParameterName == null) {
             const result = isAssignableTo(extendsType, checkType);
@@ -34,35 +27,20 @@ export class ConditionalTypeNodeParser implements SubNodeParser {
         // Narrow down check type for both condition branches
         let inferMap = new Map();
         const trueCheckType = narrowType(checkType, (type) => isAssignableTo(extendsType, type, new Set(), inferMap));
-        // console.log(`trueCheckType: ${trueCheckType}`);
-        // console.log(trueCheckType);
-        // console.log(node.trueType);
         const falseCheckType = narrowType(checkType, (type) => !isAssignableTo(extendsType, type, new Set(), new Map()));
-        // console.log(`falseCheckType: ${falseCheckType}`);
-        // console.log(falseCheckType);
 
         // Follow the relevant branches and return the results from them
         const results: BaseType[] = [];
         if (trueCheckType !== undefined) {
-            // console.log("TRUE");
-            // console.log(resolveInfer(extendsType, checkType, new Set()));
-            // console.log(node.trueType);
             const result = this.childNodeParser.createType(
                 node.trueType,
                 this.createSubContext(node, checkTypeParameterName, trueCheckType, context, inferMap)
             );
-            // console.log(result);
             if (result) {
                 results.push(result);
             }
         }
         if (falseCheckType !== undefined) {
-            // console.log("FALSE");
-            // console.log(context.getParameters());
-            // if (context.getParameters().length == 1) {
-            //     console.log(context.getArgument("T"));
-            //     console.log(inferMap)
-            // }
             const result = this.childNodeParser.createType(
                 node.falseType,
                 this.createSubContext(node, checkTypeParameterName, falseCheckType, context)

--- a/src/NodeParser/ConditionalTypeNodeParser.ts
+++ b/src/NodeParser/ConditionalTypeNodeParser.ts
@@ -25,7 +25,7 @@ export class ConditionalTypeNodeParser implements SubNodeParser {
         }
 
         // Narrow down check type for both condition branches
-        let inferMap = new Map();
+        const inferMap = new Map();
         const trueCheckType = narrowType(checkType, (type) => isAssignableTo(extendsType, type, inferMap));
         const falseCheckType = narrowType(checkType, (type) => !isAssignableTo(extendsType, type));
 

--- a/src/NodeParser/ConditionalTypeNodeParser.ts
+++ b/src/NodeParser/ConditionalTypeNodeParser.ts
@@ -2,7 +2,7 @@ import ts from "typescript";
 import { Context, NodeParser } from "../NodeParser";
 import { SubNodeParser } from "../SubNodeParser";
 import { BaseType } from "../Type/BaseType";
-import { isAssignableTo, resolveInfer } from "../Utils/isAssignableTo";
+import { isAssignableTo } from "../Utils/isAssignableTo";
 import { narrowType } from "../Utils/narrowType";
 import { UnionType } from "../Type/UnionType";
 
@@ -33,11 +33,11 @@ export class ConditionalTypeNodeParser implements SubNodeParser {
 
         // Narrow down check type for both condition branches
         let inferMap = new Map();
-        const trueCheckType = narrowType(checkType, (type) => resolveInfer(extendsType, type, new Set(), inferMap));
+        const trueCheckType = narrowType(checkType, (type) => isAssignableTo(extendsType, type, new Set(), inferMap));
         // console.log(`trueCheckType: ${trueCheckType}`);
         // console.log(trueCheckType);
         // console.log(node.trueType);
-        const falseCheckType = narrowType(checkType, (type) => !resolveInfer(extendsType, type, new Set(), new Map()));
+        const falseCheckType = narrowType(checkType, (type) => !isAssignableTo(extendsType, type, new Set(), new Map()));
         // console.log(`falseCheckType: ${falseCheckType}`);
         // console.log(falseCheckType);
 

--- a/src/NodeParser/ConditionalTypeNodeParser.ts
+++ b/src/NodeParser/ConditionalTypeNodeParser.ts
@@ -26,8 +26,8 @@ export class ConditionalTypeNodeParser implements SubNodeParser {
 
         // Narrow down check type for both condition branches
         let inferMap = new Map();
-        const trueCheckType = narrowType(checkType, (type) => isAssignableTo(extendsType, type, new Set(), inferMap));
-        const falseCheckType = narrowType(checkType, (type) => !isAssignableTo(extendsType, type, new Set(), new Map()));
+        const trueCheckType = narrowType(checkType, (type) => isAssignableTo(extendsType, type, inferMap));
+        const falseCheckType = narrowType(checkType, (type) => !isAssignableTo(extendsType, type));
 
         // Follow the relevant branches and return the results from them
         const results: BaseType[] = [];

--- a/src/NodeParser/ConditionalTypeNodeParser.ts
+++ b/src/NodeParser/ConditionalTypeNodeParser.ts
@@ -18,6 +18,10 @@ export class ConditionalTypeNodeParser implements SubNodeParser {
         const extendsType = this.childNodeParser.createType(node.extendsType, context);
         const checkTypeParameterName = this.getTypeParameterName(node.checkType);
 
+        console.log(checkType);
+        console.log(extendsType);
+        console.log(checkTypeParameterName);
+
         // If check-type is not a type parameter then condition is very simple, no type narrowing needed
         if (checkTypeParameterName == null) {
             const result = isAssignableTo(extendsType, checkType);
@@ -26,11 +30,14 @@ export class ConditionalTypeNodeParser implements SubNodeParser {
 
         // Narrow down check type for both condition branches
         const trueCheckType = narrowType(checkType, (type) => isAssignableTo(extendsType, type));
+        console.log(trueCheckType);
         const falseCheckType = narrowType(checkType, (type) => !isAssignableTo(extendsType, type));
+        // console.log(falseCheckType);
 
         // Follow the relevant branches and return the results from them
         const results: BaseType[] = [];
         if (trueCheckType !== undefined) {
+            console.log("TRUE");
             const result = this.childNodeParser.createType(
                 node.trueType,
                 this.createSubContext(node, checkTypeParameterName, trueCheckType, context)
@@ -40,6 +47,7 @@ export class ConditionalTypeNodeParser implements SubNodeParser {
             }
         }
         if (falseCheckType !== undefined) {
+            console.log("FALSE");
             const result = this.childNodeParser.createType(
                 node.falseType,
                 this.createSubContext(node, checkTypeParameterName, falseCheckType, context)

--- a/src/NodeParser/InferTypeNodeParser.ts
+++ b/src/NodeParser/InferTypeNodeParser.ts
@@ -1,16 +1,8 @@
 import ts from "typescript";
 import { Context, NodeParser } from "../NodeParser";
 import { SubNodeParser } from "../SubNodeParser";
-// import { AnnotatedType } from "../Type/AnnotatedType";
-// import { ArrayType } from "../Type/ArrayType";
 import { BaseType } from "../Type/BaseType";
 import { InferType } from "../Type/InferType";
-// import { StringType } from "../Type/StringType";
-
-// const invlidTypes: { [index: number]: boolean } = {
-//     [ts.SyntaxKind.ModuleDeclaration]: true,
-//     [ts.SyntaxKind.VariableDeclaration]: true,
-// };
 
 export class InferTypeNodeParser implements SubNodeParser {
     public constructor(protected typeChecker: ts.TypeChecker, protected childNodeParser: NodeParser) {}
@@ -19,49 +11,7 @@ export class InferTypeNodeParser implements SubNodeParser {
         return node.kind === ts.SyntaxKind.InferType;
     }
 
-    public createType(node: ts.InferTypeNode, context: Context): BaseType | undefined {
-        // console.dir(context, { depth: null });
-        // console.log(node.typeParameter.name);
-        // console.log(context.getArguments()[0].type.types[0].properties);
-        // console.log(context.getReference());
-        // console.log(this.typeChecker.getSymbolAtLocation(context.getReference()!));
-        // console.log(context.getArgument("T"));
+    public createType(node: ts.InferTypeNode, _context: Context): BaseType | undefined {
         return new InferType(node.typeParameter.name.escapedText.toString());
-        // const typeSymbol = this.typeChecker.getSymbolAtLocation(node.typeName)!;
-        // if (typeSymbol.flags & ts.SymbolFlags.Alias) {
-        //     const aliasedSymbol = this.typeChecker.getAliasedSymbol(typeSymbol);
-        //     return this.childNodeParser.createType(
-        //         aliasedSymbol.declarations!.filter((n: ts.Declaration) => !invlidTypes[n.kind])[0],
-        //         this.createSubContext(node, context)
-        //     );
-        // } else if (typeSymbol.flags & ts.SymbolFlags.TypeParameter) {
-        //     return context.getArgument(typeSymbol.name);
-        // } else if (typeSymbol.name === "Array" || typeSymbol.name === "ReadonlyArray") {
-        //     const type = this.createSubContext(node, context).getArguments()[0];
-        //     if (type === undefined) {
-        //         return undefined;
-        //     }
-        //     return new ArrayType(type);
-        // } else if (typeSymbol.name === "Date") {
-        //     return new AnnotatedType(new StringType(), { format: "date-time" }, false);
-        // } else if (typeSymbol.name === "RegExp") {
-        //     return new AnnotatedType(new StringType(), { format: "regex" }, false);
-        // } else {
-        //     return this.childNodeParser.createType(
-        //         typeSymbol.declarations!.filter((n: ts.Declaration) => !invlidTypes[n.kind])[0],
-        //         this.createSubContext(node, context)
-        //     );
-        // }
-    }
-
-    protected createSubContext(node: ts.TypeReferenceNode, parentContext: Context): Context {
-        const subContext = new Context(node);
-        if (node.typeArguments?.length) {
-            for (const typeArg of node.typeArguments) {
-                const type = this.childNodeParser.createType(typeArg, parentContext);
-                subContext.pushArgument(type);
-            }
-        }
-        return subContext;
     }
 }

--- a/src/NodeParser/InferTypeNodeParser.ts
+++ b/src/NodeParser/InferTypeNodeParser.ts
@@ -1,0 +1,67 @@
+import ts from "typescript";
+import { Context, NodeParser } from "../NodeParser";
+import { SubNodeParser } from "../SubNodeParser";
+// import { AnnotatedType } from "../Type/AnnotatedType";
+// import { ArrayType } from "../Type/ArrayType";
+import { BaseType } from "../Type/BaseType";
+import { InferType } from "../Type/InferType";
+// import { StringType } from "../Type/StringType";
+
+// const invlidTypes: { [index: number]: boolean } = {
+//     [ts.SyntaxKind.ModuleDeclaration]: true,
+//     [ts.SyntaxKind.VariableDeclaration]: true,
+// };
+
+export class InferTypeNodeParser implements SubNodeParser {
+    public constructor(protected typeChecker: ts.TypeChecker, protected childNodeParser: NodeParser) {}
+
+    public supportsNode(node: ts.InferTypeNode): boolean {
+        return node.kind === ts.SyntaxKind.InferType;
+    }
+
+    public createType(node: ts.InferTypeNode, context: Context): BaseType | undefined {
+        // console.dir(context, { depth: null });
+        // console.log(node.typeParameter.name);
+        // console.log(context.getArguments()[0].type.types[0].properties);
+        // console.log(context.getReference());
+        // console.log(this.typeChecker.getSymbolAtLocation(context.getReference()!));
+        // console.log(context.getArgument("T"));
+        return new InferType(node.typeParameter.name.escapedText.toString());
+        // const typeSymbol = this.typeChecker.getSymbolAtLocation(node.typeName)!;
+        // if (typeSymbol.flags & ts.SymbolFlags.Alias) {
+        //     const aliasedSymbol = this.typeChecker.getAliasedSymbol(typeSymbol);
+        //     return this.childNodeParser.createType(
+        //         aliasedSymbol.declarations!.filter((n: ts.Declaration) => !invlidTypes[n.kind])[0],
+        //         this.createSubContext(node, context)
+        //     );
+        // } else if (typeSymbol.flags & ts.SymbolFlags.TypeParameter) {
+        //     return context.getArgument(typeSymbol.name);
+        // } else if (typeSymbol.name === "Array" || typeSymbol.name === "ReadonlyArray") {
+        //     const type = this.createSubContext(node, context).getArguments()[0];
+        //     if (type === undefined) {
+        //         return undefined;
+        //     }
+        //     return new ArrayType(type);
+        // } else if (typeSymbol.name === "Date") {
+        //     return new AnnotatedType(new StringType(), { format: "date-time" }, false);
+        // } else if (typeSymbol.name === "RegExp") {
+        //     return new AnnotatedType(new StringType(), { format: "regex" }, false);
+        // } else {
+        //     return this.childNodeParser.createType(
+        //         typeSymbol.declarations!.filter((n: ts.Declaration) => !invlidTypes[n.kind])[0],
+        //         this.createSubContext(node, context)
+        //     );
+        // }
+    }
+
+    protected createSubContext(node: ts.TypeReferenceNode, parentContext: Context): Context {
+        const subContext = new Context(node);
+        if (node.typeArguments?.length) {
+            for (const typeArg of node.typeArguments) {
+                const type = this.childNodeParser.createType(typeArg, parentContext);
+                subContext.pushArgument(type);
+            }
+        }
+        return subContext;
+    }
+}

--- a/src/NodeParser/MappedTypeNodeParser.ts
+++ b/src/NodeParser/MappedTypeNodeParser.ts
@@ -87,7 +87,7 @@ export class MappedTypeNodeParser implements SubNodeParser {
     protected getProperties(node: ts.MappedTypeNode, keyListType: UnionType, context: Context): ObjectProperty[] {
         return keyListType
             .getTypes()
-            .filter((type) => type instanceof LiteralType)
+            .filter((type): type is LiteralType => type instanceof LiteralType)
             .reduce((result: ObjectProperty[], key: LiteralType) => {
                 const namedKey = this.mapKey(node, key, context);
                 const propertyType = this.childNodeParser.createType(

--- a/src/NodeParser/RestTypeNodeParser.ts
+++ b/src/NodeParser/RestTypeNodeParser.ts
@@ -3,7 +3,9 @@ import { Context, NodeParser } from "../NodeParser";
 import { SubNodeParser } from "../SubNodeParser";
 import { ArrayType } from "../Type/ArrayType";
 import { BaseType } from "../Type/BaseType";
+import { InferType } from "../Type/InferType";
 import { RestType } from "../Type/RestType";
+import { TupleType } from "../Type/TupleType";
 
 export class RestTypeNodeParser implements SubNodeParser {
     public constructor(protected childNodeParser: NodeParser) {}
@@ -11,6 +13,6 @@ export class RestTypeNodeParser implements SubNodeParser {
         return node.kind === ts.SyntaxKind.RestType;
     }
     public createType(node: ts.RestTypeNode, context: Context): BaseType {
-        return new RestType(this.childNodeParser.createType(node.type, context) as ArrayType);
+        return new RestType(this.childNodeParser.createType(node.type, context) as ArrayType | InferType | TupleType);
     }
 }

--- a/src/Type/InferType.ts
+++ b/src/Type/InferType.ts
@@ -1,0 +1,43 @@
+import { BaseType } from "./BaseType";
+
+export class InferType extends BaseType {
+    // private type: BaseType;
+    // private id: string | null;
+    // private name: string | null;
+
+    constructor(private name: string) {
+        super();
+    }
+
+    public getId(): string {
+        // if (this.id == null) {
+        //     throw new Error("Infer type ID not set yet");
+        // }
+        return this.name;
+    }
+
+    // public setId(id: string) {
+    //     this.id = id;
+    // }
+
+    public getName(): string {
+        if (this.name == null) {
+            throw new Error("Infer type name not set yet");
+        }
+        return this.name;
+    }
+
+    // public setName(name: string) {
+    //     this.name = name;
+    // }
+
+    // public getType(): BaseType {
+    //     return this.type;
+    // }
+
+    // public setType(type: BaseType): void {
+    //     this.type = type;
+    //     this.setId(type.getId());
+    //     this.setName(type.getName());
+    // }
+}

--- a/src/Type/InferType.ts
+++ b/src/Type/InferType.ts
@@ -1,9 +1,12 @@
 import { BaseType } from "./BaseType";
 
 export class InferType extends BaseType {
-    private type: BaseType | null;
-    private id: string | null;
-    private name: string | null;
+    // private id: string | null;
+    // private name: string | null;
+
+    constructor(private id: string) {
+        super();
+    }
 
     public getId(): string {
         if (this.id == null) {
@@ -12,31 +15,28 @@ export class InferType extends BaseType {
         return this.id;
     }
 
-    public setId(id: string) {
-        this.id = id;
-    }
+    // public setId(id: string) {
+    //     this.id = id;
+    // }
 
     public getName(): string {
-        if (this.name == null) {
-            throw new Error("Infer type name not set yet.");
-        }
-        return this.name;
+        return this.getId();
     }
 
-    public setName(name: string) {
-        this.name = name;
-    }
+    // public setName(name: string) {
+    //     this.name = name;
+    // }
 
-    public getType(): BaseType {
-        if (this.type == null) {
-            throw new Error("Infer type not set yet.");
-        }
-        return this.type;
-    }
+    // public getType(): BaseType {
+    //     if (this.type == null) {
+    //         throw new Error("Infer type not set yet.");
+    //     }
+    //     return this.type;
+    // }
 
-    public setType(type: BaseType): void {
-        this.type = type;
-        this.setId(type.getId());
-        this.setName(type.getName());
-    }
+    // public setType(type: BaseType): void {
+    //     this.type = type;
+    //     this.setId(type.getId());
+    //     this.setName(type.getName());
+    // }
 }

--- a/src/Type/InferType.ts
+++ b/src/Type/InferType.ts
@@ -1,42 +1,11 @@
 import { BaseType } from "./BaseType";
 
 export class InferType extends BaseType {
-    // private id: string | null;
-    // private name: string | null;
-
     constructor(private id: string) {
         super();
     }
 
     public getId(): string {
-        if (this.id == null) {
-            throw new Error("Infer type ID not set yet");
-        }
         return this.id;
     }
-
-    // public setId(id: string) {
-    //     this.id = id;
-    // }
-
-    public getName(): string {
-        return this.getId();
-    }
-
-    // public setName(name: string) {
-    //     this.name = name;
-    // }
-
-    // public getType(): BaseType {
-    //     if (this.type == null) {
-    //         throw new Error("Infer type not set yet.");
-    //     }
-    //     return this.type;
-    // }
-
-    // public setType(type: BaseType): void {
-    //     this.type = type;
-    //     this.setId(type.getId());
-    //     this.setName(type.getName());
-    // }
 }

--- a/src/Type/InferType.ts
+++ b/src/Type/InferType.ts
@@ -1,43 +1,42 @@
 import { BaseType } from "./BaseType";
 
 export class InferType extends BaseType {
-    // private type: BaseType;
-    // private id: string | null;
-    // private name: string | null;
-
-    constructor(private name: string) {
-        super();
-    }
+    private type: BaseType | null;
+    private id: string | null;
+    private name: string | null;
 
     public getId(): string {
-        // if (this.id == null) {
-        //     throw new Error("Infer type ID not set yet");
-        // }
-        return this.name;
+        if (this.id == null) {
+            throw new Error("Infer type ID not set yet");
+        }
+        return this.id;
     }
 
-    // public setId(id: string) {
-    //     this.id = id;
-    // }
+    public setId(id: string) {
+        this.id = id;
+    }
 
     public getName(): string {
         if (this.name == null) {
-            throw new Error("Infer type name not set yet");
+            throw new Error("Infer type name not set yet.");
         }
         return this.name;
     }
 
-    // public setName(name: string) {
-    //     this.name = name;
-    // }
+    public setName(name: string) {
+        this.name = name;
+    }
 
-    // public getType(): BaseType {
-    //     return this.type;
-    // }
+    public getType(): BaseType {
+        if (this.type == null) {
+            throw new Error("Infer type not set yet.");
+        }
+        return this.type;
+    }
 
-    // public setType(type: BaseType): void {
-    //     this.type = type;
-    //     this.setId(type.getId());
-    //     this.setName(type.getName());
-    // }
+    public setType(type: BaseType): void {
+        this.type = type;
+        this.setId(type.getId());
+        this.setName(type.getName());
+    }
 }

--- a/src/Type/RestType.ts
+++ b/src/Type/RestType.ts
@@ -1,8 +1,10 @@
 import { ArrayType } from "./ArrayType";
 import { BaseType } from "./BaseType";
+import { InferType } from "./InferType";
+import { TupleType } from "./TupleType";
 
 export class RestType extends BaseType {
-    public constructor(private item: ArrayType, private title: string | null = null) {
+    public constructor(private item: ArrayType | InferType | TupleType, private title: string | null = null) {
         super();
     }
 
@@ -14,7 +16,7 @@ export class RestType extends BaseType {
         return this.title;
     }
 
-    public getType(): ArrayType {
+    public getType(): ArrayType | InferType | TupleType {
         return this.item;
     }
 }

--- a/src/Type/TupleType.ts
+++ b/src/Type/TupleType.ts
@@ -7,9 +7,6 @@ export class TupleType extends BaseType {
     public constructor(types: Array<BaseType | undefined>) {
         super();
 
-        // console.log(`Tuple type length: ${types.length}`);
-        // console.log(types)
-
         let resolved_types: Array<BaseType | undefined> = [];
 
         types.forEach((type) => {
@@ -24,9 +21,6 @@ export class TupleType extends BaseType {
                 resolved_types.push(type);
             }
         });
-
-        // console.log("Resolved types")
-        // console.log(resolved_types)
 
         this.types = resolved_types;
     }

--- a/src/Type/TupleType.ts
+++ b/src/Type/TupleType.ts
@@ -1,15 +1,41 @@
 import { BaseType } from "./BaseType";
+import { RestType } from "./RestType";
 
 export class TupleType extends BaseType {
-    public constructor(private types: readonly (BaseType | undefined)[]) {
+    private types: Readonly<Array<BaseType | undefined>>;
+
+    public constructor(types: Array<BaseType | undefined>) {
         super();
+
+        // console.log(`Tuple type length: ${types.length}`);
+        // console.log(types)
+
+        let resolved_types: Array<BaseType | undefined> = [];
+
+        types.forEach((type) => {
+            if (type instanceof RestType) {
+                const inner_type = type.getType();
+                if (inner_type instanceof TupleType) {
+                    resolved_types = resolved_types.concat(inner_type.getTypes());
+                } else {
+                    resolved_types.push(type);
+                }
+            } else {
+                resolved_types.push(type);
+            }
+        });
+
+        // console.log("Resolved types")
+        // console.log(resolved_types)
+
+        this.types = resolved_types;
     }
 
     public getId(): string {
         return `[${this.types.map((item) => item?.getId() ?? "never").join(",")}]`;
     }
 
-    public getTypes(): readonly (BaseType | undefined)[] {
+    public getTypes(): Readonly<Array<BaseType | undefined>> {
         return this.types;
     }
 }

--- a/src/TypeFormatter/TupleTypeFormatter.ts
+++ b/src/TypeFormatter/TupleTypeFormatter.ts
@@ -17,7 +17,7 @@ export class TupleTypeFormatter implements SubTypeFormatter {
     }
 
     public getDefinition(type: TupleType): Definition {
-        const subTypes = type.getNormalizedTypes().filter(notUndefined);
+        const subTypes = type.getTypes().filter(notUndefined);
 
         const requiredElements = subTypes.filter((t) => !(t instanceof OptionalType) && !(t instanceof RestType));
         const optionalElements = subTypes.filter((t): t is OptionalType => t instanceof OptionalType);

--- a/src/Utils/isAssignableTo.ts
+++ b/src/Utils/isAssignableTo.ts
@@ -196,12 +196,7 @@ export function isAssignableTo(
         const targetMembers = getObjectProperties(target);
         if (targetMembers.length === 0) {
             // When target object is empty then anything except null and undefined can be assigned to it
-            return !isAssignableTo(
-                new UnionType([new UndefinedType(), new NullType()]).normalize(),
-                source,
-                inferMap,
-                insideTypes
-            );
+            return !isAssignableTo(new UnionType([new UndefinedType(), new NullType()]), source, inferMap, insideTypes);
         } else if (source instanceof ObjectType) {
             const sourceMembers = getObjectProperties(source);
 

--- a/src/Utils/isAssignableTo.ts
+++ b/src/Utils/isAssignableTo.ts
@@ -108,8 +108,8 @@ export function isAssignableTo(
 
     // Infer type can become anything
     if (target instanceof InferType) {
-        let infer = inferMap.get(target.getName());
         const key = target.getName();
+        const infer = inferMap.get(key);
 
         if (infer === undefined) {
             inferMap.set(key, source);
@@ -262,7 +262,7 @@ export function isAssignableTo(
                 if (i == numTarget - 1) {
                     if (numTarget <= numSource + 1) {
                         if (targetMember instanceof RestType) {
-                            let remaining: Array<BaseType | undefined> = [];
+                            const remaining: Array<BaseType | undefined> = [];
                             for (let j = i; j < numSource; j++) {
                                 remaining.push(sourceMembers[j]);
                             }

--- a/src/Utils/isAssignableTo.ts
+++ b/src/Utils/isAssignableTo.ts
@@ -85,187 +85,187 @@ function getPrimitiveType(value: LiteralValue) {
  * @param insideTypes - Optional parameter used internally to solve circular dependencies.
  * @return True if source type is assignable to target type.
  */
+// export function isAssignableTo(
+//     target: BaseType | undefined,
+//     source: BaseType | undefined,
+//     insideTypes: Set<BaseType> = new Set()
+// ): boolean {
+//     // Dereference source and target
+//     // console.log("DEREF");
+//     source = derefType(source);
+//     // console.log(source);
+//     target = derefType(target);
+//     // console.log(target);
+
+//     // Type "never" can be assigned to anything
+//     if (source === undefined) {
+//         return true;
+//     }
+
+//     // Nothing can be assigned to undefined (e.g. never-type)
+//     if (target === undefined) {
+//         return false;
+//     }
+
+//     // Infer type can become anything
+//     if (target instanceof InferType) {
+//         // console.log("Reached infer");
+//         // context.pushArgument(source);
+//         // context.pushParameter(target.getName());
+//         return true;
+//     }
+
+//     // Check for simple type equality
+//     if (source.getId() === target.getId()) {
+//         return true;
+//     }
+
+//     /** Don't check types when already inside them. This solves circular dependencies. */
+//     if (insideTypes.has(source) || insideTypes.has(target)) {
+//         return true;
+//     }
+
+//     // Assigning from or to any-type is always possible
+//     if (source instanceof AnyType || target instanceof AnyType) {
+//         return true;
+//     }
+
+//     // assigning to unknown type is always possible
+//     if (target instanceof UnknownType) {
+//         return true;
+//     }
+
+//     // 'null', or 'undefined' can be assigned to the void
+//     if (target instanceof VoidType) {
+//         return source instanceof NullType || source instanceof UndefinedType;
+//     }
+
+//     // Union and enum type is assignable to target when all types in the union/enum are assignable to it
+//     if (source instanceof UnionType || source instanceof EnumType) {
+//         return source.getTypes().every((type) => isAssignableTo(target, type, insideTypes));
+//     }
+
+//     // When source is an intersection type then it can be assigned to target if any of the sub types matches. Object
+//     // types within the intersection must be combined first
+//     if (source instanceof IntersectionType) {
+//         return combineIntersectingTypes(source).some((type) => isAssignableTo(target, type, insideTypes));
+//     }
+
+//     // For arrays check if item types are assignable
+//     if (target instanceof ArrayType) {
+//         const targetItemType = target.getItem();
+//         if (source instanceof ArrayType) {
+//             return isAssignableTo(targetItemType, source.getItem(), insideTypes);
+//         } else if (source instanceof TupleType) {
+//             return source.getTypes().every((type) => isAssignableTo(targetItemType, type, insideTypes));
+//         } else {
+//             return false;
+//         }
+//     }
+
+//     // When target is a union or enum type then check if source type can be assigned to any variant
+//     if (target instanceof UnionType || target instanceof EnumType) {
+//         return target.getTypes().some((type) => isAssignableTo(type, source, insideTypes));
+//     }
+
+//     // When target is an intersection type then source can be assigned to it if it matches all sub types. Object
+//     // types within the intersection must be combined first
+//     if (target instanceof IntersectionType) {
+//         return combineIntersectingTypes(target).every((type) => isAssignableTo(type, source, insideTypes));
+//     }
+
+//     // Check literal types
+//     if (source instanceof LiteralType) {
+//         return isAssignableTo(target, getPrimitiveType(source.getValue()));
+//     }
+
+//     if (target instanceof ObjectType) {
+//         // primitives are not assignable to `object`
+//         if (
+//             target.getNonPrimitive() &&
+//             (source instanceof NumberType || source instanceof StringType || source instanceof BooleanType)
+//         ) {
+//             return false;
+//         }
+
+//         const targetMembers = getObjectProperties(target);
+//         if (targetMembers.length === 0) {
+//             // When target object is empty then anything except null and undefined can be assigned to it
+//             return !isAssignableTo(new UnionType([new UndefinedType(), new NullType()]), source, insideTypes);
+//         } else if (source instanceof ObjectType) {
+//             const sourceMembers = getObjectProperties(source);
+
+//             // Check if target has properties in common with source
+//             const inCommon = targetMembers.some((targetMember) =>
+//                 sourceMembers.some((sourceMember) => targetMember.getName() === sourceMember.getName())
+//             );
+
+//             return (
+//                 targetMembers.every((targetMember) => {
+//                     // Make sure that every required property in target type is present
+//                     const sourceMember = sourceMembers.find((member) => targetMember.getName() === member.getName());
+//                     return sourceMember == null ? inCommon && !targetMember.isRequired() : true;
+//                 }) &&
+//                 sourceMembers.every((sourceMember) => {
+//                     const targetMember = targetMembers.find((member) => member.getName() === sourceMember.getName());
+//                     if (targetMember == null) {
+//                         return true;
+//                     }
+//                     return isAssignableTo(
+//                         targetMember.getType(),
+//                         sourceMember.getType(),
+//                         new Set(insideTypes).add(source!).add(target!)
+//                     );
+//                 })
+//             );
+//         }
+
+//         const isArrayLikeType = source instanceof ArrayType || source instanceof TupleType;
+//         if (isArrayLikeType) {
+//             const lengthPropType = targetMembers
+//                 .find((prop) => prop.getName() === "length" && prop.isRequired())
+//                 ?.getType();
+
+//             if (source instanceof ArrayType) {
+//                 return lengthPropType instanceof NumberType;
+//             }
+
+//             if (source instanceof TupleType) {
+//                 if (lengthPropType instanceof LiteralType) {
+//                     const types = source.getTypes();
+//                     const lengthPropValue = lengthPropType.getValue();
+//                     return types.length === lengthPropValue;
+//                 }
+//             }
+//         }
+//     }
+
+//     // Check if tuple types are compatible
+//     if (target instanceof TupleType) {
+//         if (source instanceof TupleType) {
+//             const sourceMembers = source.getTypes();
+//             return target.getTypes().every((targetMember, i) => {
+//                 const sourceMember = sourceMembers[i];
+//                 if (targetMember instanceof OptionalType) {
+//                     if (sourceMember) {
+//                         return (
+//                             isAssignableTo(targetMember, sourceMember, insideTypes) ||
+//                             isAssignableTo(targetMember.getType(), sourceMember, insideTypes)
+//                         );
+//                     } else {
+//                         return true;
+//                     }
+//                 } else {
+//                     return isAssignableTo(targetMember, sourceMember, insideTypes);
+//                 }
+//             });
+//         }
+//     }
+
+//     return false;
+// }
+
 export function isAssignableTo(
-    target: BaseType | undefined,
-    source: BaseType | undefined,
-    insideTypes: Set<BaseType> = new Set()
-): boolean {
-    // Dereference source and target
-    // console.log("DEREF");
-    source = derefType(source);
-    // console.log(source);
-    target = derefType(target);
-    // console.log(target);
-
-    // Type "never" can be assigned to anything
-    if (source === undefined) {
-        return true;
-    }
-
-    // Nothing can be assigned to undefined (e.g. never-type)
-    if (target === undefined) {
-        return false;
-    }
-
-    // Infer type can become anything
-    if (target instanceof InferType) {
-        // console.log("Reached infer");
-        // context.pushArgument(source);
-        // context.pushParameter(target.getName());
-        return true;
-    }
-
-    // Check for simple type equality
-    if (source.getId() === target.getId()) {
-        return true;
-    }
-
-    /** Don't check types when already inside them. This solves circular dependencies. */
-    if (insideTypes.has(source) || insideTypes.has(target)) {
-        return true;
-    }
-
-    // Assigning from or to any-type is always possible
-    if (source instanceof AnyType || target instanceof AnyType) {
-        return true;
-    }
-
-    // assigning to unknown type is always possible
-    if (target instanceof UnknownType) {
-        return true;
-    }
-
-    // 'null', or 'undefined' can be assigned to the void
-    if (target instanceof VoidType) {
-        return source instanceof NullType || source instanceof UndefinedType;
-    }
-
-    // Union and enum type is assignable to target when all types in the union/enum are assignable to it
-    if (source instanceof UnionType || source instanceof EnumType) {
-        return source.getTypes().every((type) => isAssignableTo(target, type, insideTypes));
-    }
-
-    // When source is an intersection type then it can be assigned to target if any of the sub types matches. Object
-    // types within the intersection must be combined first
-    if (source instanceof IntersectionType) {
-        return combineIntersectingTypes(source).some((type) => isAssignableTo(target, type, insideTypes));
-    }
-
-    // For arrays check if item types are assignable
-    if (target instanceof ArrayType) {
-        const targetItemType = target.getItem();
-        if (source instanceof ArrayType) {
-            return isAssignableTo(targetItemType, source.getItem(), insideTypes);
-        } else if (source instanceof TupleType) {
-            return source.getTypes().every((type) => isAssignableTo(targetItemType, type, insideTypes));
-        } else {
-            return false;
-        }
-    }
-
-    // When target is a union or enum type then check if source type can be assigned to any variant
-    if (target instanceof UnionType || target instanceof EnumType) {
-        return target.getTypes().some((type) => isAssignableTo(type, source, insideTypes));
-    }
-
-    // When target is an intersection type then source can be assigned to it if it matches all sub types. Object
-    // types within the intersection must be combined first
-    if (target instanceof IntersectionType) {
-        return combineIntersectingTypes(target).every((type) => isAssignableTo(type, source, insideTypes));
-    }
-
-    // Check literal types
-    if (source instanceof LiteralType) {
-        return isAssignableTo(target, getPrimitiveType(source.getValue()));
-    }
-
-    if (target instanceof ObjectType) {
-        // primitives are not assignable to `object`
-        if (
-            target.getNonPrimitive() &&
-            (source instanceof NumberType || source instanceof StringType || source instanceof BooleanType)
-        ) {
-            return false;
-        }
-
-        const targetMembers = getObjectProperties(target);
-        if (targetMembers.length === 0) {
-            // When target object is empty then anything except null and undefined can be assigned to it
-            return !isAssignableTo(new UnionType([new UndefinedType(), new NullType()]), source, insideTypes);
-        } else if (source instanceof ObjectType) {
-            const sourceMembers = getObjectProperties(source);
-
-            // Check if target has properties in common with source
-            const inCommon = targetMembers.some((targetMember) =>
-                sourceMembers.some((sourceMember) => targetMember.getName() === sourceMember.getName())
-            );
-
-            return (
-                targetMembers.every((targetMember) => {
-                    // Make sure that every required property in target type is present
-                    const sourceMember = sourceMembers.find((member) => targetMember.getName() === member.getName());
-                    return sourceMember == null ? inCommon && !targetMember.isRequired() : true;
-                }) &&
-                sourceMembers.every((sourceMember) => {
-                    const targetMember = targetMembers.find((member) => member.getName() === sourceMember.getName());
-                    if (targetMember == null) {
-                        return true;
-                    }
-                    return isAssignableTo(
-                        targetMember.getType(),
-                        sourceMember.getType(),
-                        new Set(insideTypes).add(source!).add(target!)
-                    );
-                })
-            );
-        }
-
-        const isArrayLikeType = source instanceof ArrayType || source instanceof TupleType;
-        if (isArrayLikeType) {
-            const lengthPropType = targetMembers
-                .find((prop) => prop.getName() === "length" && prop.isRequired())
-                ?.getType();
-
-            if (source instanceof ArrayType) {
-                return lengthPropType instanceof NumberType;
-            }
-
-            if (source instanceof TupleType) {
-                if (lengthPropType instanceof LiteralType) {
-                    const types = source.getTypes();
-                    const lengthPropValue = lengthPropType.getValue();
-                    return types.length === lengthPropValue;
-                }
-            }
-        }
-    }
-
-    // Check if tuple types are compatible
-    if (target instanceof TupleType) {
-        if (source instanceof TupleType) {
-            const sourceMembers = source.getTypes();
-            return target.getTypes().every((targetMember, i) => {
-                const sourceMember = sourceMembers[i];
-                if (targetMember instanceof OptionalType) {
-                    if (sourceMember) {
-                        return (
-                            isAssignableTo(targetMember, sourceMember, insideTypes) ||
-                            isAssignableTo(targetMember.getType(), sourceMember, insideTypes)
-                        );
-                    } else {
-                        return true;
-                    }
-                } else {
-                    return isAssignableTo(targetMember, sourceMember, insideTypes);
-                }
-            });
-        }
-    }
-
-    return false;
-}
-
-export function resolveInfer(
     target: BaseType | undefined,
     source: BaseType | undefined,
     insideTypes: Set<BaseType> = new Set(),
@@ -339,22 +339,22 @@ export function resolveInfer(
 
     // Union and enum type is assignable to target when all types in the union/enum are assignable to it
     if (source instanceof UnionType || source instanceof EnumType) {
-        return source.getTypes().every((type) => resolveInfer(target, type, insideTypes, inferMap));
+        return source.getTypes().every((type) => isAssignableTo(target, type, insideTypes, inferMap));
     }
 
     // When source is an intersection type then it can be assigned to target if any of the sub types matches. Object
     // types within the intersection must be combined first
     if (source instanceof IntersectionType) {
-        return combineIntersectingTypes(source).some((type) => resolveInfer(target, type, insideTypes, inferMap));
+        return combineIntersectingTypes(source).some((type) => isAssignableTo(target, type, insideTypes, inferMap));
     }
 
     // For arrays check if item types are assignable
     if (target instanceof ArrayType) {
         const targetItemType = target.getItem();
         if (source instanceof ArrayType) {
-            return resolveInfer(targetItemType, source.getItem(), insideTypes, inferMap);
+            return isAssignableTo(targetItemType, source.getItem(), insideTypes, inferMap);
         } else if (source instanceof TupleType) {
-            return resolveInfer(targetItemType, new UnionType(source.getTypes()), insideTypes, inferMap);
+            return isAssignableTo(targetItemType, new UnionType(source.getTypes()), insideTypes, inferMap);
             // return source.getTypes().every((type) => resolveInfer(targetItemType, type, insideTypes, context));
         } else {
             return false;
@@ -363,18 +363,18 @@ export function resolveInfer(
 
     // When target is a union or enum type then check if source type can be assigned to any variant
     if (target instanceof UnionType || target instanceof EnumType) {
-        return target.getTypes().some((type) => resolveInfer(type, source, insideTypes, inferMap));
+        return target.getTypes().some((type) => isAssignableTo(type, source, insideTypes, inferMap));
     }
 
     // When target is an intersection type then source can be assigned to it if it matches all sub types. Object
     // types within the intersection must be combined first
     if (target instanceof IntersectionType) {
-        return combineIntersectingTypes(target).every((type) => resolveInfer(type, source, insideTypes, inferMap));
+        return combineIntersectingTypes(target).every((type) => isAssignableTo(type, source, insideTypes, inferMap));
     }
 
     // Check literal types
     if (source instanceof LiteralType) {
-        return resolveInfer(target, getPrimitiveType(source.getValue()), undefined, inferMap);
+        return isAssignableTo(target, getPrimitiveType(source.getValue()), undefined, inferMap);
     }
 
     if (target instanceof ObjectType) {
@@ -389,7 +389,7 @@ export function resolveInfer(
         const targetMembers = getObjectProperties(target);
         if (targetMembers.length === 0) {
             // When target object is empty then anything except null and undefined can be assigned to it
-            return !resolveInfer(
+            return !isAssignableTo(
                 new UnionType([new UndefinedType(), new NullType()]).normalize(),
                 source,
                 insideTypes,
@@ -414,7 +414,7 @@ export function resolveInfer(
                     if (targetMember == null) {
                         return true;
                     }
-                    return resolveInfer(
+                    return isAssignableTo(
                         targetMember.getType(),
                         sourceMember.getType(),
                         new Set(insideTypes).add(source!).add(target!),
@@ -457,9 +457,9 @@ export function resolveInfer(
             }
 
             return targetMembers.every((targetMember, i) => {
-                if (i == targetMembers.length - 1) {
-                    // NOTE: More than one source member remaining
-                    if (sourceMembers.length - i > 0) {
+                if (targetMembers.length == i + 1) {
+                    if (sourceMembers.length > i) {
+                        // NOTE: More than one source member remaining
                         if (targetMember instanceof RestType) {
                             let remaining: Array<BaseType | undefined> = [];
                             for (let j = i; j < sourceMembers.length; j++) {
@@ -467,35 +467,38 @@ export function resolveInfer(
                             }
                             // console.log("Remaining");
                             // console.log(remaining);
-                            return resolveInfer(
+                            return isAssignableTo(
                                 targetMember.getType(),
                                 new TupleType(remaining),
                                 insideTypes,
                                 inferMap
                             );
-                        } else if (sourceMembers.length - i > 1) {
+                        } else if (sourceMembers.length > i + 1) {
                             return false;
                         }
+                    } else if (sourceMembers.length == i) {
                         // NOTE: No source members remaining
-                    } else if (sourceMembers.length - i == 0) {
                         if (targetMember instanceof RestType) {
-                            return resolveInfer(targetMember.getType(), new TupleType([]), insideTypes, inferMap);
+                            return isAssignableTo(targetMember.getType(), new TupleType([]), insideTypes, inferMap);
+                        } else if (targetMember instanceof OptionalType) {
+                            return true;
                         }
                         return false;
                     }
                 }
+
                 const sourceMember = sourceMembers[i];
                 if (targetMember instanceof OptionalType) {
                     if (sourceMember) {
                         return (
-                            resolveInfer(targetMember, sourceMember, insideTypes, inferMap) ||
-                            resolveInfer(targetMember.getType(), sourceMember, insideTypes, inferMap)
+                            isAssignableTo(targetMember, sourceMember, insideTypes, inferMap) ||
+                            isAssignableTo(targetMember.getType(), sourceMember, insideTypes, inferMap)
                         );
                     } else {
                         return true;
                     }
                 } else {
-                    return resolveInfer(targetMember, sourceMember, insideTypes, inferMap);
+                    return isAssignableTo(targetMember, sourceMember, insideTypes, inferMap);
                 }
             });
 

--- a/src/Utils/isAssignableTo.ts
+++ b/src/Utils/isAssignableTo.ts
@@ -17,6 +17,7 @@ import { StringType } from "../Type/StringType";
 import { NumberType } from "../Type/NumberType";
 import { BooleanType } from "../Type/BooleanType";
 import { InferType } from "../Type/InferType";
+import { RestType } from "../Type/RestType";
 
 /**
  * Returns the combined types from the given intersection. Currently only object types are combined. Maybe more
@@ -108,8 +109,9 @@ export function isAssignableTo(
 
     // Infer type can become anything
     if (target instanceof InferType) {
-	console.log("Reached infer")
-        target.setType(source);
+        // console.log("Reached infer");
+        // context.pushArgument(source);
+        // context.pushParameter(target.getName());
         return true;
     }
 
@@ -266,223 +268,254 @@ export function isAssignableTo(
 export function resolveInfer(
     target: BaseType | undefined,
     source: BaseType | undefined,
-    insideTypes: Set<BaseType> = new Set()
-): BaseType | undefined {
+    insideTypes: Set<BaseType> = new Set(),
+    inferMap: Map<string, BaseType> = new Map()
+): boolean {
     // Dereference source and target
-    console.log("DEREF");
+    // console.log("DEREF");
     source = derefType(source);
-    console.log(source);
+    // console.log(source);
     target = derefType(target);
-    console.log(target);
+    // console.log(target);
 
     // Type "never" can be assigned to anything
     if (source === undefined) {
-        return undefined;
+        return true;
     }
 
     // Nothing can be assigned to undefined (e.g. never-type)
     if (target === undefined) {
-        return undefined;
+        return false;
     }
 
     // Infer type can become anything
     if (target instanceof InferType) {
-        return source;
+        // console.log("Reached infer");
+        let infer = inferMap.get(target.getName());
+        const key = target.getName();
+        // console.log(key);
+        // if (key == "Rest") {
+        //     console.log(source);
+        // }
+        if (infer === undefined) {
+            inferMap.set(key, source);
+        } else {
+            inferMap.set(key, new UnionType([infer, source]));
+        }
+        // inferMap.pushArgument(source);
+        // inferMap.pushParameter(target.getName());
+        return true;
+    }
+
+    if (target instanceof RestType) {
+        console.log("RestType");
+        // console.log(source);
     }
 
     // Check for simple type equality
     if (source.getId() === target.getId()) {
-        return target;
+        return true;
     }
 
     /** Don't check types when already inside them. This solves circular dependencies. */
     if (insideTypes.has(source) || insideTypes.has(target)) {
-        return target;
+        return true;
     }
 
     // Assigning from or to any-type is always possible
     if (source instanceof AnyType || target instanceof AnyType) {
-        return target;
+        return true;
     }
 
     // assigning to unknown type is always possible
     if (target instanceof UnknownType) {
-        return target;
+        return true;
     }
 
     // 'null', or 'undefined' can be assigned to the void
-    // if (target instanceof VoidType) {
-    //     return source instanceof NullType || source instanceof UndefinedType;
-    // }
+    if (target instanceof VoidType) {
+        return source instanceof NullType || source instanceof UndefinedType;
+    }
 
     // Union and enum type is assignable to target when all types in the union/enum are assignable to it
-    // if (source instanceof UnionType || source instanceof EnumType) {
-    //     return source.getTypes().every((type) => isAssignableTo(target, type, insideTypes));
-    // }
+    if (source instanceof UnionType || source instanceof EnumType) {
+        return source.getTypes().every((type) => resolveInfer(target, type, insideTypes, inferMap));
+    }
 
     // When source is an intersection type then it can be assigned to target if any of the sub types matches. Object
     // types within the intersection must be combined first
-    // if (source instanceof IntersectionType) {
-    //     return combineIntersectingTypes(source).some((type) => isAssignableTo(target, type, insideTypes));
-    // }
+    if (source instanceof IntersectionType) {
+        return combineIntersectingTypes(source).some((type) => resolveInfer(target, type, insideTypes, inferMap));
+    }
 
     // For arrays check if item types are assignable
     if (target instanceof ArrayType) {
         const targetItemType = target.getItem();
         if (source instanceof ArrayType) {
-            return new ArrayType(resolveInfer(targetItemType, source.getItem(), insideTypes)!);
+            return resolveInfer(targetItemType, source.getItem(), insideTypes, inferMap);
         } else if (source instanceof TupleType) {
-            return new ArrayType(resolveInfer(targetItemType, new UnionType(source.getTypes()), insideTypes)!);
+            return resolveInfer(targetItemType, new UnionType(source.getTypes()), insideTypes, inferMap);
+            // return source.getTypes().every((type) => resolveInfer(targetItemType, type, insideTypes, context));
         } else {
-            throw Error("Incompatible types during infer.");
+            return false;
         }
     }
 
     // When target is a union or enum type then check if source type can be assigned to any variant
     if (target instanceof UnionType || target instanceof EnumType) {
-        const maybeInfer = target.getTypes().find((type) => type instanceof InferType);
-        if (maybeInfer !== undefined) {
-            return source;
-        }
-
-        // TODO: Check this statement again.
-        // return target.getTypes().find((type) => isAssignableTo(type, source, insideTypes));
-        return new UnionType(target.getTypes().map((type) => resolveInfer(type, source, insideTypes)));
+        return target.getTypes().some((type) => resolveInfer(type, source, insideTypes, inferMap));
     }
 
     // When target is an intersection type then source can be assigned to it if it matches all sub types. Object
     // types within the intersection must be combined first
-    // if (target instanceof IntersectionType) {
-    //     return combineIntersectingTypes(target).every((type) => isAssignableTo(type, source, insideTypes));
-    // }
+    if (target instanceof IntersectionType) {
+        return combineIntersectingTypes(target).every((type) => resolveInfer(type, source, insideTypes, inferMap));
+    }
 
     // Check literal types
-    // if (source instanceof LiteralType) {
-    //     return isAssignableTo(target, getPrimitiveType(source.getValue()));
-    // }
+    if (source instanceof LiteralType) {
+        return resolveInfer(target, getPrimitiveType(source.getValue()), undefined, inferMap);
+    }
 
     if (target instanceof ObjectType) {
         // primitives are not assignable to `object`
-        // if (
-        //     target.getNonPrimitive() &&
-        //     (source instanceof NumberType || source instanceof StringType || source instanceof BooleanType)
-        // ) {
-        //     return false;
-        // }
+        if (
+            target.getNonPrimitive() &&
+            (source instanceof NumberType || source instanceof StringType || source instanceof BooleanType)
+        ) {
+            return false;
+        }
 
         const targetMembers = getObjectProperties(target);
         if (targetMembers.length === 0) {
             // When target object is empty then anything except null and undefined can be assigned to it
-            return target;
+            return !resolveInfer(
+                new UnionType([new UndefinedType(), new NullType()]).normalize(),
+                source,
+                insideTypes,
+                inferMap
+            );
         } else if (source instanceof ObjectType) {
             const sourceMembers = getObjectProperties(source);
 
             // Check if target has properties in common with source
-            // const inCommon = targetMembers.some((targetMember) =>
-            //     sourceMembers.some((sourceMember) => targetMember.getName() === sourceMember.getName())
-            // );
-
-            // NOTE: Assume equality of member keys.
-            return new ObjectType(
-                target.getId(),
-                target.getBaseTypes(),
-                sourceMembers.map((sourceMember) => {
-                    const targetMember = targetMembers.find((member) => member.getName() === sourceMember.getName());
-
-                    if (targetMember === undefined) {
-                        throw Error("Unequal source and target objects.");
-                    }
-
-                    return new ObjectProperty(
-                        targetMember.getName(),
-                        resolveInfer(targetMember.getType(), sourceMember.getType(), insideTypes),
-                        targetMember.isRequired()
-                    );
-                }),
-                target.getAdditionalProperties()
+            const inCommon = targetMembers.some((targetMember) =>
+                sourceMembers.some((sourceMember) => targetMember.getName() === sourceMember.getName())
             );
 
-            // return (
-            //     targetMembers.every((targetMember) => {
-            //         // Make sure that every required property in target type is present
-            //         const sourceMember = sourceMembers.find((member) => targetMember.getName() === member.getName());
-            //         return sourceMember == null ? inCommon && !targetMember.isRequired() : true;
-            //     }) &&
-            //     sourceMembers.every((sourceMember) => {
-            //         const targetMember = targetMembers.find((member) => member.getName() === sourceMember.getName());
-            //         if (targetMember == null) {
-            //             return true;
-            //         }
-            //         return isAssignableTo(
-            //             targetMember.getType(),
-            //             sourceMember.getType(),
-            //             new Set(insideTypes).add(source!).add(target!)
-            //         );
-            //     })
-            // );
+            return (
+                targetMembers.every((targetMember) => {
+                    // Make sure that every required property in target type is present
+                    const sourceMember = sourceMembers.find((member) => targetMember.getName() === member.getName());
+                    return sourceMember == null ? inCommon && !targetMember.isRequired() : true;
+                }) &&
+                sourceMembers.every((sourceMember) => {
+                    const targetMember = targetMembers.find((member) => member.getName() === sourceMember.getName());
+                    if (targetMember == null) {
+                        return true;
+                    }
+                    return resolveInfer(
+                        targetMember.getType(),
+                        sourceMember.getType(),
+                        new Set(insideTypes).add(source!).add(target!),
+                        inferMap
+                    );
+                })
+            );
         }
 
-        // TODO: Handle this.
-        // const isArrayLikeType = source instanceof ArrayType || source instanceof TupleType;
-        // if (isArrayLikeType) {
-        //     const lengthPropType = targetMembers
-        //         .find((prop) => prop.getName() === "length" && prop.isRequired())
-        //         ?.getType();
+        const isArrayLikeType = source instanceof ArrayType || source instanceof TupleType;
+        if (isArrayLikeType) {
+            const lengthPropType = targetMembers
+                .find((prop) => prop.getName() === "length" && prop.isRequired())
+                ?.getType();
 
-        //     if (source instanceof ArrayType) {
-        //         return lengthPropType instanceof NumberType;
-        //     }
+            if (source instanceof ArrayType) {
+                return lengthPropType instanceof NumberType;
+            }
 
-        //     if (source instanceof TupleType) {
-        //         if (lengthPropType instanceof LiteralType) {
-        //             const types = source.getTypes();
-        //             const lengthPropValue = lengthPropType.getValue();
-        //             return types.length === lengthPropValue;
-        //         }
-        //     }
-        // }
+            if (source instanceof TupleType) {
+                if (lengthPropType instanceof LiteralType) {
+                    const types = source.getTypes();
+                    const lengthPropValue = lengthPropType.getValue();
+                    return types.length === lengthPropValue;
+                }
+            }
+        }
     }
 
     // Check if tuple types are compatible
+    // FIXME: This needs to handle RestTypes.
+    // To do so we need to compare tuple type lengths.
     if (target instanceof TupleType) {
         if (source instanceof TupleType) {
             const sourceMembers = source.getTypes();
-            return new TupleType(
-                target.getTypes().map((type, idx) => {
-                    const sourceMember = sourceMembers[idx];
-                    if (type instanceof OptionalType) {
-                        if (sourceMember) {
-                            const ret = resolveInfer(type, sourceMember, insideTypes);
-                            if (ret !== undefined) {
-                                return ret;
-                            } else {
-                                return resolveInfer(type.getType(), sourceMember, insideTypes);
+            const targetMembers = target.getTypes();
+
+            if (targetMembers.length > sourceMembers.length + 1) {
+                return false;
+            }
+
+            return targetMembers.every((targetMember, i) => {
+                if (i == targetMembers.length - 1) {
+                    // NOTE: More than one source member remaining
+                    if (sourceMembers.length - i > 0) {
+                        if (targetMember instanceof RestType) {
+                            let remaining: Array<BaseType | undefined> = [];
+                            for (let j = i; j < sourceMembers.length; j++) {
+                                remaining.push(sourceMembers[j]);
                             }
-                        } else {
-                            return resolveInfer(type, sourceMember, insideTypes);
+                            // console.log("Remaining");
+                            // console.log(remaining);
+                            return resolveInfer(
+                                targetMember.getType(),
+                                new TupleType(remaining),
+                                insideTypes,
+                                inferMap
+                            );
+                        } else if (sourceMembers.length - i > 1) {
+                            return false;
                         }
-                    } else {
-                        return resolveInfer(type, sourceMember, insideTypes);
+                        // NOTE: No source members remaining
+                    } else if (sourceMembers.length - i == 0) {
+                        if (targetMember instanceof RestType) {
+                            return resolveInfer(targetMember.getType(), new TupleType([]), insideTypes, inferMap);
+                        }
+                        return false;
                     }
-                })
-            );
+                }
+                const sourceMember = sourceMembers[i];
+                if (targetMember instanceof OptionalType) {
+                    if (sourceMember) {
+                        return (
+                            resolveInfer(targetMember, sourceMember, insideTypes, inferMap) ||
+                            resolveInfer(targetMember.getType(), sourceMember, insideTypes, inferMap)
+                        );
+                    } else {
+                        return true;
+                    }
+                } else {
+                    return resolveInfer(targetMember, sourceMember, insideTypes, inferMap);
+                }
+            });
+
             // return target.getTypes().every((targetMember, i) => {
             //     const sourceMember = sourceMembers[i];
             //     if (targetMember instanceof OptionalType) {
             //         if (sourceMember) {
             //             return (
-            //                 isAssignableTo(targetMember, sourceMember, insideTypes) ||
-            //                 isAssignableTo(targetMember.getType(), sourceMember, insideTypes)
+            //                 resolveInfer(targetMember, sourceMember, insideTypes, inferMap) ||
+            //                 resolveInfer(targetMember.getType(), sourceMember, insideTypes, inferMap)
             //             );
             //         } else {
             //             return true;
             //         }
             //     } else {
-            //         return isAssignableTo(targetMember, sourceMember, insideTypes);
+            //         return resolveInfer(targetMember, sourceMember, insideTypes, inferMap);
             //     }
             // });
         }
     }
 
-    return undefined;
+    return false;
 }

--- a/src/Utils/isAssignableTo.ts
+++ b/src/Utils/isAssignableTo.ts
@@ -16,6 +16,7 @@ import { LiteralType, LiteralValue } from "../Type/LiteralType";
 import { StringType } from "../Type/StringType";
 import { NumberType } from "../Type/NumberType";
 import { BooleanType } from "../Type/BooleanType";
+import { InferType } from "../Type/InferType";
 
 /**
  * Returns the combined types from the given intersection. Currently only object types are combined. Maybe more
@@ -89,8 +90,11 @@ export function isAssignableTo(
     insideTypes: Set<BaseType> = new Set()
 ): boolean {
     // Dereference source and target
+    // console.log("DEREF");
     source = derefType(source);
+    // console.log(source);
     target = derefType(target);
+    // console.log(target);
 
     // Type "never" can be assigned to anything
     if (source === undefined) {
@@ -100,6 +104,11 @@ export function isAssignableTo(
     // Nothing can be assigned to undefined (e.g. never-type)
     if (target === undefined) {
         return false;
+    }
+
+    // Infer type can become anything
+    if (target instanceof InferType) {
+        return true;
     }
 
     // Check for simple type equality
@@ -179,6 +188,189 @@ export function isAssignableTo(
         if (targetMembers.length === 0) {
             // When target object is empty then anything except null and undefined can be assigned to it
             return !isAssignableTo(new UnionType([new UndefinedType(), new NullType()]), source, insideTypes);
+        } else if (source instanceof ObjectType) {
+            const sourceMembers = getObjectProperties(source);
+
+            // Check if target has properties in common with source
+            const inCommon = targetMembers.some((targetMember) =>
+                sourceMembers.some((sourceMember) => targetMember.getName() === sourceMember.getName())
+            );
+
+            return (
+                targetMembers.every((targetMember) => {
+                    // Make sure that every required property in target type is present
+                    const sourceMember = sourceMembers.find((member) => targetMember.getName() === member.getName());
+                    return sourceMember == null ? inCommon && !targetMember.isRequired() : true;
+                }) &&
+                sourceMembers.every((sourceMember) => {
+                    const targetMember = targetMembers.find((member) => member.getName() === sourceMember.getName());
+                    if (targetMember == null) {
+                        return true;
+                    }
+                    return isAssignableTo(
+                        targetMember.getType(),
+                        sourceMember.getType(),
+                        new Set(insideTypes).add(source!).add(target!)
+                    );
+                })
+            );
+        }
+
+        const isArrayLikeType = source instanceof ArrayType || source instanceof TupleType;
+        if (isArrayLikeType) {
+            const lengthPropType = targetMembers
+                .find((prop) => prop.getName() === "length" && prop.isRequired())
+                ?.getType();
+
+            if (source instanceof ArrayType) {
+                return lengthPropType instanceof NumberType;
+            }
+
+            if (source instanceof TupleType) {
+                if (lengthPropType instanceof LiteralType) {
+                    const types = source.getTypes();
+                    const lengthPropValue = lengthPropType.getValue();
+                    return types.length === lengthPropValue;
+                }
+            }
+        }
+    }
+
+    // Check if tuple types are compatible
+    if (target instanceof TupleType) {
+        if (source instanceof TupleType) {
+            const sourceMembers = source.getTypes();
+            return target.getTypes().every((targetMember, i) => {
+                const sourceMember = sourceMembers[i];
+                if (targetMember instanceof OptionalType) {
+                    if (sourceMember) {
+                        return (
+                            isAssignableTo(targetMember, sourceMember, insideTypes) ||
+                            isAssignableTo(targetMember.getType(), sourceMember, insideTypes)
+                        );
+                    } else {
+                        return true;
+                    }
+                } else {
+                    return isAssignableTo(targetMember, sourceMember, insideTypes);
+                }
+            });
+        }
+    }
+
+    return false;
+}
+
+export function infer(
+    target: BaseType | undefined,
+    source: BaseType | undefined,
+    insideTypes: Set<BaseType> = new Set()
+): BaseType | undefined {
+    // Dereference source and target
+    console.log("DEREF");
+    source = derefType(source);
+    console.log(source);
+    target = derefType(target);
+    console.log(target);
+
+    // Type "never" can be assigned to anything
+    if (source === undefined) {
+        return undefined;
+    }
+
+    // Nothing can be assigned to undefined (e.g. never-type)
+    if (target === undefined) {
+        return undefined;
+    }
+
+    // Infer type can become anything
+    if (target instanceof InferType) {
+        return source;
+    }
+
+    // Check for simple type equality
+    if (source.getId() === target.getId()) {
+        return source;
+    }
+
+    /** Don't check types when already inside them. This solves circular dependencies. */
+    if (insideTypes.has(source) || insideTypes.has(target)) {
+        return source;
+    }
+
+    // Assigning from or to any-type is always possible
+    if (source instanceof AnyType || target instanceof AnyType) {
+        return source;
+    }
+
+    // assigning to unknown type is always possible
+    if (target instanceof UnknownType) {
+        return source;
+    }
+
+    // 'null', or 'undefined' can be assigned to the void
+    // if (target instanceof VoidType) {
+    //     return source instanceof NullType || source instanceof UndefinedType;
+    // }
+
+    // Union and enum type is assignable to target when all types in the union/enum are assignable to it
+    // if (source instanceof UnionType || source instanceof EnumType) {
+    //     return source.getTypes().every((type) => isAssignableTo(target, type, insideTypes));
+    // }
+
+    // When source is an intersection type then it can be assigned to target if any of the sub types matches. Object
+    // types within the intersection must be combined first
+    // if (source instanceof IntersectionType) {
+    //     return combineIntersectingTypes(source).some((type) => isAssignableTo(target, type, insideTypes));
+    // }
+
+    // For arrays check if item types are assignable
+    if (target instanceof ArrayType) {
+        const targetItemType = target.getItem();
+        if (source instanceof ArrayType) {
+            return infer(targetItemType, source.getItem(), insideTypes);
+        } else if (source instanceof TupleType) {
+            return infer(targetItemType, new UnionType(source.getTypes()), insideTypes);
+        } else {
+            throw Error("Incompatible types during infer.");
+        }
+    }
+
+    // When target is a union or enum type then check if source type can be assigned to any variant
+    if (target instanceof UnionType || target instanceof EnumType) {
+        const maybeInfer = target.getTypes().find((type) => type instanceof InferType);
+        if (maybeInfer !== undefined) {
+            return source;
+        }
+
+	// FIXME: Not sure what to do here.
+        return target.getTypes().find((type) => isAssignableTo(type, source, insideTypes));
+    }
+
+    // When target is an intersection type then source can be assigned to it if it matches all sub types. Object
+    // types within the intersection must be combined first
+    // if (target instanceof IntersectionType) {
+    //     return combineIntersectingTypes(target).every((type) => isAssignableTo(type, source, insideTypes));
+    // }
+
+    // Check literal types
+    // if (source instanceof LiteralType) {
+    //     return isAssignableTo(target, getPrimitiveType(source.getValue()));
+    // }
+
+    if (target instanceof ObjectType) {
+        // primitives are not assignable to `object`
+        if (
+            target.getNonPrimitive() &&
+            (source instanceof NumberType || source instanceof StringType || source instanceof BooleanType)
+        ) {
+            return false;
+        }
+
+        const targetMembers = getObjectProperties(target);
+        if (targetMembers.length === 0) {
+            // When target object is empty then anything except null and undefined can be assigned to it
+            return undefined;
         } else if (source instanceof ObjectType) {
             const sourceMembers = getObjectProperties(source);
 

--- a/src/Utils/isAssignableTo.ts
+++ b/src/Utils/isAssignableTo.ts
@@ -162,7 +162,7 @@ export function isAssignableTo(
         if (source instanceof ArrayType) {
             return isAssignableTo(targetItemType, source.getItem(), inferMap, insideTypes);
         } else if (source instanceof TupleType) {
-            return isAssignableTo(targetItemType, new UnionType(source.getNormalizedTypes()), inferMap, insideTypes);
+            return isAssignableTo(targetItemType, new UnionType(source.getTypes()), inferMap, insideTypes);
         } else {
             return false;
         }

--- a/src/Utils/isAssignableTo.ts
+++ b/src/Utils/isAssignableTo.ts
@@ -297,6 +297,7 @@ export function isAssignableTo(
                         return true;
                     }
                 } else {
+                    // TODO: Should this situation always result in false? If so, move it to the InferType clause at the start of this function.
                     if (!sourceMember && targetMember instanceof InferType) {
                         return false;
                     }

--- a/src/Utils/isAssignableTo.ts
+++ b/src/Utils/isAssignableTo.ts
@@ -85,186 +85,6 @@ function getPrimitiveType(value: LiteralValue) {
  * @param insideTypes - Optional parameter used internally to solve circular dependencies.
  * @return True if source type is assignable to target type.
  */
-// export function isAssignableTo(
-//     target: BaseType | undefined,
-//     source: BaseType | undefined,
-//     insideTypes: Set<BaseType> = new Set()
-// ): boolean {
-//     // Dereference source and target
-//     // console.log("DEREF");
-//     source = derefType(source);
-//     // console.log(source);
-//     target = derefType(target);
-//     // console.log(target);
-
-//     // Type "never" can be assigned to anything
-//     if (source === undefined) {
-//         return true;
-//     }
-
-//     // Nothing can be assigned to undefined (e.g. never-type)
-//     if (target === undefined) {
-//         return false;
-//     }
-
-//     // Infer type can become anything
-//     if (target instanceof InferType) {
-//         // console.log("Reached infer");
-//         // context.pushArgument(source);
-//         // context.pushParameter(target.getName());
-//         return true;
-//     }
-
-//     // Check for simple type equality
-//     if (source.getId() === target.getId()) {
-//         return true;
-//     }
-
-//     /** Don't check types when already inside them. This solves circular dependencies. */
-//     if (insideTypes.has(source) || insideTypes.has(target)) {
-//         return true;
-//     }
-
-//     // Assigning from or to any-type is always possible
-//     if (source instanceof AnyType || target instanceof AnyType) {
-//         return true;
-//     }
-
-//     // assigning to unknown type is always possible
-//     if (target instanceof UnknownType) {
-//         return true;
-//     }
-
-//     // 'null', or 'undefined' can be assigned to the void
-//     if (target instanceof VoidType) {
-//         return source instanceof NullType || source instanceof UndefinedType;
-//     }
-
-//     // Union and enum type is assignable to target when all types in the union/enum are assignable to it
-//     if (source instanceof UnionType || source instanceof EnumType) {
-//         return source.getTypes().every((type) => isAssignableTo(target, type, insideTypes));
-//     }
-
-//     // When source is an intersection type then it can be assigned to target if any of the sub types matches. Object
-//     // types within the intersection must be combined first
-//     if (source instanceof IntersectionType) {
-//         return combineIntersectingTypes(source).some((type) => isAssignableTo(target, type, insideTypes));
-//     }
-
-//     // For arrays check if item types are assignable
-//     if (target instanceof ArrayType) {
-//         const targetItemType = target.getItem();
-//         if (source instanceof ArrayType) {
-//             return isAssignableTo(targetItemType, source.getItem(), insideTypes);
-//         } else if (source instanceof TupleType) {
-//             return source.getTypes().every((type) => isAssignableTo(targetItemType, type, insideTypes));
-//         } else {
-//             return false;
-//         }
-//     }
-
-//     // When target is a union or enum type then check if source type can be assigned to any variant
-//     if (target instanceof UnionType || target instanceof EnumType) {
-//         return target.getTypes().some((type) => isAssignableTo(type, source, insideTypes));
-//     }
-
-//     // When target is an intersection type then source can be assigned to it if it matches all sub types. Object
-//     // types within the intersection must be combined first
-//     if (target instanceof IntersectionType) {
-//         return combineIntersectingTypes(target).every((type) => isAssignableTo(type, source, insideTypes));
-//     }
-
-//     // Check literal types
-//     if (source instanceof LiteralType) {
-//         return isAssignableTo(target, getPrimitiveType(source.getValue()));
-//     }
-
-//     if (target instanceof ObjectType) {
-//         // primitives are not assignable to `object`
-//         if (
-//             target.getNonPrimitive() &&
-//             (source instanceof NumberType || source instanceof StringType || source instanceof BooleanType)
-//         ) {
-//             return false;
-//         }
-
-//         const targetMembers = getObjectProperties(target);
-//         if (targetMembers.length === 0) {
-//             // When target object is empty then anything except null and undefined can be assigned to it
-//             return !isAssignableTo(new UnionType([new UndefinedType(), new NullType()]), source, insideTypes);
-//         } else if (source instanceof ObjectType) {
-//             const sourceMembers = getObjectProperties(source);
-
-//             // Check if target has properties in common with source
-//             const inCommon = targetMembers.some((targetMember) =>
-//                 sourceMembers.some((sourceMember) => targetMember.getName() === sourceMember.getName())
-//             );
-
-//             return (
-//                 targetMembers.every((targetMember) => {
-//                     // Make sure that every required property in target type is present
-//                     const sourceMember = sourceMembers.find((member) => targetMember.getName() === member.getName());
-//                     return sourceMember == null ? inCommon && !targetMember.isRequired() : true;
-//                 }) &&
-//                 sourceMembers.every((sourceMember) => {
-//                     const targetMember = targetMembers.find((member) => member.getName() === sourceMember.getName());
-//                     if (targetMember == null) {
-//                         return true;
-//                     }
-//                     return isAssignableTo(
-//                         targetMember.getType(),
-//                         sourceMember.getType(),
-//                         new Set(insideTypes).add(source!).add(target!)
-//                     );
-//                 })
-//             );
-//         }
-
-//         const isArrayLikeType = source instanceof ArrayType || source instanceof TupleType;
-//         if (isArrayLikeType) {
-//             const lengthPropType = targetMembers
-//                 .find((prop) => prop.getName() === "length" && prop.isRequired())
-//                 ?.getType();
-
-//             if (source instanceof ArrayType) {
-//                 return lengthPropType instanceof NumberType;
-//             }
-
-//             if (source instanceof TupleType) {
-//                 if (lengthPropType instanceof LiteralType) {
-//                     const types = source.getTypes();
-//                     const lengthPropValue = lengthPropType.getValue();
-//                     return types.length === lengthPropValue;
-//                 }
-//             }
-//         }
-//     }
-
-//     // Check if tuple types are compatible
-//     if (target instanceof TupleType) {
-//         if (source instanceof TupleType) {
-//             const sourceMembers = source.getTypes();
-//             return target.getTypes().every((targetMember, i) => {
-//                 const sourceMember = sourceMembers[i];
-//                 if (targetMember instanceof OptionalType) {
-//                     if (sourceMember) {
-//                         return (
-//                             isAssignableTo(targetMember, sourceMember, insideTypes) ||
-//                             isAssignableTo(targetMember.getType(), sourceMember, insideTypes)
-//                         );
-//                     } else {
-//                         return true;
-//                     }
-//                 } else {
-//                     return isAssignableTo(targetMember, sourceMember, insideTypes);
-//                 }
-//             });
-//         }
-//     }
-
-//     return false;
-// }
-
 export function isAssignableTo(
     target: BaseType | undefined,
     source: BaseType | undefined,
@@ -272,11 +92,8 @@ export function isAssignableTo(
     inferMap: Map<string, BaseType> = new Map()
 ): boolean {
     // Dereference source and target
-    // console.log("DEREF");
     source = derefType(source);
-    // console.log(source);
     target = derefType(target);
-    // console.log(target);
 
     // Type "never" can be assigned to anything
     if (source === undefined) {
@@ -290,26 +107,16 @@ export function isAssignableTo(
 
     // Infer type can become anything
     if (target instanceof InferType) {
-        // console.log("Reached infer");
         let infer = inferMap.get(target.getName());
         const key = target.getName();
-        // console.log(key);
-        // if (key == "Rest") {
-        //     console.log(source);
-        // }
+
         if (infer === undefined) {
             inferMap.set(key, source);
         } else {
             inferMap.set(key, new UnionType([infer, source]));
         }
-        // inferMap.pushArgument(source);
-        // inferMap.pushParameter(target.getName());
-        return true;
-    }
 
-    if (target instanceof RestType) {
-        console.log("RestType");
-        // console.log(source);
+        return true;
     }
 
     // Check for simple type equality
@@ -445,8 +252,6 @@ export function isAssignableTo(
     }
 
     // Check if tuple types are compatible
-    // FIXME: This needs to handle RestTypes.
-    // To do so we need to compare tuple type lengths.
     if (target instanceof TupleType) {
         if (source instanceof TupleType) {
             const sourceMembers = source.getTypes();
@@ -465,8 +270,6 @@ export function isAssignableTo(
                             for (let j = i; j < sourceMembers.length; j++) {
                                 remaining.push(sourceMembers[j]);
                             }
-                            // console.log("Remaining");
-                            // console.log(remaining);
                             return isAssignableTo(
                                 targetMember.getType(),
                                 new TupleType(remaining),
@@ -501,22 +304,6 @@ export function isAssignableTo(
                     return isAssignableTo(targetMember, sourceMember, insideTypes, inferMap);
                 }
             });
-
-            // return target.getTypes().every((targetMember, i) => {
-            //     const sourceMember = sourceMembers[i];
-            //     if (targetMember instanceof OptionalType) {
-            //         if (sourceMember) {
-            //             return (
-            //                 resolveInfer(targetMember, sourceMember, insideTypes, inferMap) ||
-            //                 resolveInfer(targetMember.getType(), sourceMember, insideTypes, inferMap)
-            //             );
-            //         } else {
-            //             return true;
-            //         }
-            //     } else {
-            //         return resolveInfer(targetMember, sourceMember, insideTypes, inferMap);
-            //     }
-            // });
         }
     }
 

--- a/test/unit/isAssignableTo.test.ts
+++ b/test/unit/isAssignableTo.test.ts
@@ -319,10 +319,7 @@ describe("isAssignableTo", () => {
             )
         ).toBe(true);
         expect(
-            isAssignableTo(
-                new TupleType([new StringType(), new InferType("T")]),
-                new TupleType([new StringType()])
-            )
+            isAssignableTo(new TupleType([new StringType(), new InferType("T")]), new TupleType([new StringType()]))
         ).toBe(false);
         expect(
             isAssignableTo(

--- a/test/unit/isAssignableTo.test.ts
+++ b/test/unit/isAssignableTo.test.ts
@@ -4,6 +4,7 @@ import { AnyType } from "../../src/Type/AnyType";
 import { ArrayType } from "../../src/Type/ArrayType";
 import { BooleanType } from "../../src/Type/BooleanType";
 import { DefinitionType } from "../../src/Type/DefinitionType";
+import { InferType } from "../../src/Type/InferType";
 import { IntersectionType } from "../../src/Type/IntersectionType";
 import { LiteralType } from "../../src/Type/LiteralType";
 import { NullType } from "../../src/Type/NullType";
@@ -11,6 +12,7 @@ import { NumberType } from "../../src/Type/NumberType";
 import { ObjectProperty, ObjectType } from "../../src/Type/ObjectType";
 import { OptionalType } from "../../src/Type/OptionalType";
 import { ReferenceType } from "../../src/Type/ReferenceType";
+import { RestType } from "../../src/Type/RestType";
 import { StringType } from "../../src/Type/StringType";
 import { TupleType } from "../../src/Type/TupleType";
 import { UndefinedType } from "../../src/Type/UndefinedType";
@@ -302,6 +304,36 @@ describe("isAssignableTo", () => {
             isAssignableTo(
                 new TupleType([new StringType(), new OptionalType(new StringType())]),
                 new TupleType([new StringType(), new StringType()])
+            )
+        ).toBe(true);
+        expect(
+            isAssignableTo(
+                new TupleType([new StringType(), new InferType("T")]),
+                new TupleType([new StringType(), new NumberType(), new StringType()])
+            )
+        ).toBe(false);
+        expect(
+            isAssignableTo(
+                new TupleType([new StringType(), new InferType("T")]),
+                new TupleType([new StringType(), new NumberType()])
+            )
+        ).toBe(true);
+        expect(
+            isAssignableTo(
+                new TupleType([new StringType(), new InferType("T")]),
+                new TupleType([new StringType()])
+            )
+        ).toBe(false);
+        expect(
+            isAssignableTo(
+                new TupleType([new StringType(), new RestType(new InferType("T"))]),
+                new TupleType([new StringType()])
+            )
+        ).toBe(true);
+        expect(
+            isAssignableTo(
+                new TupleType([new StringType(), new RestType(new InferType("T"))]),
+                new TupleType([new StringType(), new NumberType(), new StringType()])
             )
         ).toBe(true);
     });

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -112,6 +112,17 @@ describe("valid-data-type", () => {
     it("type-conditional-omit", assertValidSchema("type-conditional-omit", "MyObject"));
     it("type-conditional-jsdoc", assertValidSchema("type-conditional-jsdoc", "MyObject", "extended"));
 
+    it("type-conditional-infer", assertValidSchema("type-conditional-infer", "MyType"));
+    it("type-conditional-infer-nested", assertValidSchema("type-conditional-infer-nested", "MyType"));
+    it("type-conditional-infer-recursive", assertValidSchema("type-conditional-infer-recursive", "MyType"));
+    it("type-conditional-infer-rest", assertValidSchema("type-conditional-infer-rest", "MyType"));
+    it("type-conditional-infer-tail-recursion", assertValidSchema("type-conditional-infer-tail-recursion", "MyType"));
+    it("type-conditional-infer-tuple-xor", assertValidSchema("type-conditional-infer-tuple-xor", "MyType"));
+
+    it("type-tuple-nested-rest", assertValidSchema("type-tuple-nested-rest", "MyType"));
+    it("type-tuple-nested-rest-to-union", assertValidSchema("type-tuple-nested-rest-to-union", "MyType"));
+    it("type-tuple-nested-rest-uniform", assertValidSchema("type-tuple-nested-rest-uniform", "MyType"));
+
     it("type-recursive-deep-exclude", assertValidSchema("type-recursive-deep-exclude", "MyType"));
     it("ignore-export", assertValidSchema("ignore-export", "*"));
 });

--- a/test/valid-data/type-conditional-infer-nested/main.ts
+++ b/test/valid-data/type-conditional-infer-nested/main.ts
@@ -1,0 +1,3 @@
+type Nested<T extends Array<Array<any>>> = T extends Array<infer A> ? (A extends Array<infer B> ? B : never) : never;
+
+export type MyType = Nested<[[string, number], [boolean]]>;

--- a/test/valid-data/type-conditional-infer-nested/schema.json
+++ b/test/valid-data/type-conditional-infer-nested/schema.json
@@ -1,0 +1,13 @@
+{
+  "$ref": "#/definitions/MyType",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyType": {
+      "type": [
+        "string",
+        "number",
+        "boolean"
+      ]
+    }
+  }
+}

--- a/test/valid-data/type-conditional-infer-recursive/main.ts
+++ b/test/valid-data/type-conditional-infer-recursive/main.ts
@@ -1,0 +1,3 @@
+type Recursive<T> = T extends Array<infer A> ? Recursive<A> : T;
+
+export type MyType = Recursive<[[[string], [number, { a: string }]], [[boolean]]]>;

--- a/test/valid-data/type-conditional-infer-recursive/schema.json
+++ b/test/valid-data/type-conditional-infer-recursive/schema.json
@@ -1,0 +1,31 @@
+{
+  "$ref": "#/definitions/MyType",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyType": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "a": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "a"
+          ],
+          "type": "object"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    }
+  }
+}

--- a/test/valid-data/type-conditional-infer-rest/main.ts
+++ b/test/valid-data/type-conditional-infer-rest/main.ts
@@ -1,0 +1,3 @@
+type GetRest<T extends any[]> = T extends [any, ...infer T] ? T : never;
+
+export type MyType = GetRest<[string, string, number, boolean]>;

--- a/test/valid-data/type-conditional-infer-rest/schema.json
+++ b/test/valid-data/type-conditional-infer-rest/schema.json
@@ -1,0 +1,22 @@
+{
+  "$ref": "#/definitions/MyType",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyType": {
+      "items": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        }
+      ],
+      "maxItems": 3,
+      "minItems": 3,
+      "type": "array"
+    }
+  }
+}

--- a/test/valid-data/type-conditional-infer-tail-recursion/main.ts
+++ b/test/valid-data/type-conditional-infer-tail-recursion/main.ts
@@ -1,0 +1,12 @@
+type GetFirst<T> = T extends [infer A, any] ? A : never;
+type GetSecond<T> = T extends [any, infer A] ? A : never;
+
+type Augment<T extends [string, any]> = { [K in GetFirst<T>]: GetSecond<T> };
+
+type TailRecursion<T extends any[]> = T extends [infer Head, ...infer Tail]
+    ? Head extends [string, any]
+        ? [Augment<Head>, ...TailRecursion<Tail>]
+        : never
+    : [];
+
+export type MyType = TailRecursion<[["a", string], ["b", number], ["c", boolean]]>;

--- a/test/valid-data/type-conditional-infer-tail-recursion/schema.json
+++ b/test/valid-data/type-conditional-infer-tail-recursion/schema.json
@@ -1,0 +1,49 @@
+{
+  "$ref": "#/definitions/MyType",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyType": {
+      "items": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "a": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "a"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "b": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "b"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "c": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "c"
+          ],
+          "type": "object"
+        }
+      ],
+      "maxItems": 3,
+      "minItems": 3,
+      "type": "array"
+    }
+  }
+}

--- a/test/valid-data/type-conditional-infer-tuple-xor/main.ts
+++ b/test/valid-data/type-conditional-infer-tuple-xor/main.ts
@@ -1,0 +1,13 @@
+type Without<T, U> = {
+    [P in Exclude<keyof T, keyof U>]?: never;
+};
+
+type XOR<T, U> = T | U extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U;
+
+type TupleXOR<T extends any[]> = T extends [infer Only]
+    ? Only
+    : T extends [infer A, infer B, ...infer Rest]
+    ? TupleXOR<[XOR<A, B>, ...Rest]>
+    : never;
+
+export type MyType = TupleXOR<[{ a: string }, { b: number }, { c: boolean }]>;

--- a/test/valid-data/type-conditional-infer-tuple-xor/schema.json
+++ b/test/valid-data/type-conditional-infer-tuple-xor/schema.json
@@ -1,0 +1,64 @@
+{
+  "$ref": "#/definitions/MyType",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyType": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "a": {
+              "not": {}
+            },
+            "b": {
+              "not": {}
+            },
+            "c": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "c"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "a": {
+              "not": {}
+            },
+            "b": {
+              "type": "number"
+            },
+            "c": {
+              "not": {}
+            }
+          },
+          "required": [
+            "b"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "a": {
+              "type": "string"
+            },
+            "b": {
+              "not": {}
+            },
+            "c": {
+              "not": {}
+            }
+          },
+          "required": [
+            "a"
+          ],
+          "type": "object"
+        }
+      ]
+    }
+  }
+}

--- a/test/valid-data/type-conditional-infer/main.ts
+++ b/test/valid-data/type-conditional-infer/main.ts
@@ -1,0 +1,3 @@
+type InferObject<T extends { a: any }> = T extends { a: infer A } ? A : never;
+
+export type MyType = InferObject<{ a: string }>;

--- a/test/valid-data/type-conditional-infer/schema.json
+++ b/test/valid-data/type-conditional-infer/schema.json
@@ -1,0 +1,9 @@
+{
+  "$ref": "#/definitions/MyType",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyType": {
+      "type": "string"
+    }
+  }
+}

--- a/test/valid-data/type-tuple-nested-rest-to-union/main.ts
+++ b/test/valid-data/type-tuple-nested-rest-to-union/main.ts
@@ -1,0 +1,5 @@
+type NestedTuple = [{ a: number }, ...[{ b: string }, { c: number }, ...[{ d: boolean }, ...[]]]];
+
+type ToUnion<T extends any[]> = T extends Array<infer A> ? A : never;
+
+export type MyType = ToUnion<NestedTuple>;

--- a/test/valid-data/type-tuple-nested-rest-to-union/schema.json
+++ b/test/valid-data/type-tuple-nested-rest-to-union/schema.json
@@ -1,0 +1,58 @@
+{
+  "$ref": "#/definitions/MyType",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyType": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "a": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "a"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "b": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "b"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "c": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "c"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "d": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "d"
+          ],
+          "type": "object"
+        }
+      ]
+    }
+  }
+}

--- a/test/valid-data/type-tuple-nested-rest-uniform/main.ts
+++ b/test/valid-data/type-tuple-nested-rest-uniform/main.ts
@@ -1,0 +1,1 @@
+export type MyType = [number, ...[number, number, ...[number, ...[]]]];

--- a/test/valid-data/type-tuple-nested-rest-uniform/schema.json
+++ b/test/valid-data/type-tuple-nested-rest-uniform/schema.json
@@ -1,0 +1,14 @@
+{
+  "$ref": "#/definitions/MyType",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyType": {
+      "items": {
+        "type": "number"
+      },
+      "maxItems": 4,
+      "minItems": 4,
+      "type": "array"
+    }
+  }
+}

--- a/test/valid-data/type-tuple-nested-rest/main.ts
+++ b/test/valid-data/type-tuple-nested-rest/main.ts
@@ -1,0 +1,1 @@
+export type MyType = [{ a: number }, ...[{ b: string }, { c: number }, ...[{ d: boolean }, ...[]]]];

--- a/test/valid-data/type-tuple-nested-rest/schema.json
+++ b/test/valid-data/type-tuple-nested-rest/schema.json
@@ -1,0 +1,61 @@
+{
+  "$ref": "#/definitions/MyType",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyType": {
+      "items": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "a": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "a"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "b": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "b"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "c": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "c"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "d": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "d"
+          ],
+          "type": "object"
+        }
+      ],
+      "maxItems": 4,
+      "minItems": 4,
+      "type": "array"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #513, #1075

The `infer` keyword is used in conditional expressions to infer types of type parameters. It is the basis of many useful type constructs. This pull request implements support for inferred types, including inferred rest types. 

The newly added `InferType` is a simple type that stores the name of the inferred parameter. Evaluation of inferred types happens in `ConditionalTypeNodeParser`, as type inference can only occur in conditional expressions. The heavy lifting is done by the `isAssignableTo` function. It has been updated to build a map of all inferred types. These inferred types are then passed to the sub-context when evaluating the true branch. Additionally, the `RestType` has been updated to not only support the `ArrayType`, but also `TupleType` and `InferType`.

See the added tests for examples. 