### PR TITLE
fix: incorrect output of Record with numeric key

### DIFF
--- a/test/valid-data/type-mapped-number/main.ts
+++ b/test/valid-data/type-mapped-number/main.ts
@@ -1,0 +1,1 @@
+export type MyObject = Record<number, string>;

--- a/test/valid-data/type-mapped-number/schema.json
+++ b/test/valid-data/type-mapped-number/schema.json
@@ -1,0 +1,12 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
As highlighted in the following issue: https://github.com/vega/ts-json-schema-generator/issues/1262

A `Record` with a numeric key is incorrectly outputted as an `array` instead of an `object`.

To fix this, I'm proposing we check the `id` of the `constraintType`. If that is a `number`, then we can safely assume it's an `array`. When it is an `object`, the `id` contains an `alias`.

