### PR TITLE
feat: export typescript dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ Similar to custom formatting, extending the built-in parsing works practically t
 ```ts
 // my-constructor-parser.ts
 import { Context, StringType, ReferenceType, BaseType, SubNodeParser } from "ts-json-schema-generator";
-import ts from "typescript";
+// use typescript exported by TJS to avoid version conflict
+import ts from "ts-json-schema-generator";
 
 export class MyConstructorParser implements SubNodeParser {
     supportsNode(node: ts.Node): boolean {

--- a/index.ts
+++ b/index.ts
@@ -158,3 +158,6 @@ export * from "./src/NodeParser/VoidTypeNodeParser";
 export * from "./src/SchemaGenerator";
 
 export * from "./factory";
+
+import ts from "typescript";
+export { ts };


### PR DESCRIPTION
fixes #1328.

Exports bundled typescript module to be used when defining custom
parser/formatter. This will prevent version conflict between bundled and
user versions of typescript.