### PR TITLE
feat: add `discriminator` tag to generate `if-then` schemas

### DIFF
--- a/src/AnnotationsReader/BasicAnnotationsReader.ts
+++ b/src/AnnotationsReader/BasicAnnotationsReader.ts
@@ -19,6 +19,9 @@ export class BasicAnnotationsReader implements AnnotationsReader {
         "comment",
         "contentMediaType",
         "contentEncoding",
+
+        // Custom tag for if-then-else support.
+        "discriminator",
     ]);
     private static jsonTags = new Set<string>([
         "minimum",

--- a/src/Type/UnionType.ts
+++ b/src/Type/UnionType.ts
@@ -5,6 +5,7 @@ import { derefType } from "../Utils/derefType";
 
 export class UnionType extends BaseType {
     private readonly types: BaseType[];
+    private discriminator?: string = undefined;
 
     public constructor(types: readonly BaseType[]) {
         super();
@@ -18,6 +19,14 @@ export class UnionType extends BaseType {
                 return flatTypes;
             }, [] as BaseType[])
         );
+    }
+
+    public setDiscriminator(discriminator: string) {
+        this.discriminator = discriminator;
+    }
+
+    public getDiscriminator() {
+        return this.discriminator;
     }
 
     public getId(): string {

--- a/src/TypeFormatter/AnnotatedTypeFormatter.ts
+++ b/src/TypeFormatter/AnnotatedTypeFormatter.ts
@@ -52,7 +52,7 @@ export class AnnotatedTypeFormatter implements SubTypeFormatter {
         return type instanceof AnnotatedType;
     }
     public getDefinition(type: AnnotatedType): Definition {
-        let annotations = type.getAnnotations();
+        const annotations = type.getAnnotations();
 
         if ("discriminator" in annotations) {
             const derefed = derefType(type.getType());

--- a/src/TypeFormatter/AnnotatedTypeFormatter.ts
+++ b/src/TypeFormatter/AnnotatedTypeFormatter.ts
@@ -60,7 +60,11 @@ export class AnnotatedTypeFormatter implements SubTypeFormatter {
                 derefed.setDiscriminator(annotations.discriminator);
                 delete annotations.discriminator;
             } else {
-                throw new Error(`Cannot assign discriminator tag to type: ${derefed.constructor.name}.`);
+                throw new Error(
+                    `Cannot assign discriminator tag to type: ${JSON.stringify(
+                        derefed
+                    )}. This tag can only be assigned to union types.`
+                );
             }
         }
 

--- a/src/TypeFormatter/UnionTypeFormatter.ts
+++ b/src/TypeFormatter/UnionTypeFormatter.ts
@@ -31,12 +31,12 @@ export class UnionTypeFormatter implements SubTypeFormatter {
                 return definitions[0];
             }
 
-            let kindTypes = type
+            const kindTypes = type
                 .getTypes()
                 .filter((item) => !(derefType(item) instanceof NeverType))
-                .map((type) => getTypeByKey(type, new LiteralType(discriminator)));
+                .map((item) => getTypeByKey(item, new LiteralType(discriminator)));
 
-            const undefinedIndex = kindTypes.findIndex((type) => type === undefined);
+            const undefinedIndex = kindTypes.findIndex((item) => item === undefined);
 
             if (undefinedIndex != -1) {
                 throw new Error(
@@ -46,9 +46,9 @@ export class UnionTypeFormatter implements SubTypeFormatter {
                 );
             }
 
-            const kindDefinitions = kindTypes.map((type) => this.childTypeFormatter.getDefinition(type as BaseType));
+            const kindDefinitions = kindTypes.map((item) => this.childTypeFormatter.getDefinition(item as BaseType));
 
-            let allOf = [];
+            const allOf = [];
 
             for (let i = 0; i < definitions.length; i++) {
                 allOf.push({

--- a/src/TypeFormatter/UnionTypeFormatter.ts
+++ b/src/TypeFormatter/UnionTypeFormatter.ts
@@ -17,9 +17,6 @@ export class UnionTypeFormatter implements SubTypeFormatter {
         return type instanceof UnionType;
     }
     public getDefinition(type: UnionType): Definition {
-        // FIXME: Filtering never types from union types is wrong. However,
-        // disabling this line will result in regressions of tests using the
-        // `hidden` tag.
         const definitions = type
             .getTypes()
             .filter((item) => !(derefType(item) instanceof NeverType))
@@ -27,10 +24,6 @@ export class UnionTypeFormatter implements SubTypeFormatter {
 
         const discriminator = type.getDiscriminator();
         if (discriminator !== undefined) {
-            if (definitions.length === 1) {
-                return definitions[0];
-            }
-
             const kindTypes = type
                 .getTypes()
                 .filter((item) => !(derefType(item) instanceof NeverType))

--- a/src/Utils/removeUnreachable.ts
+++ b/src/Utils/removeUnreachable.ts
@@ -58,6 +58,8 @@ function addReachable(
         } else if (items) {
             addReachable(items, definitions, reachable);
         }
+    } else if (definition.then) {
+        addReachable(definition.then, definitions, reachable);
     }
 }
 

--- a/test/invalid-data.test.ts
+++ b/test/invalid-data.test.ts
@@ -13,7 +13,7 @@ function assertSchema(name: string, type: string, message: string) {
             type: type,
             expose: "export",
             topRef: true,
-            jsDoc: "none",
+            jsDoc: "basic",
             skipTypeCheck: !!process.env.FAST_TEST,
         };
 
@@ -33,6 +33,22 @@ describe("invalid-data", () => {
 
     it("script-empty", assertSchema("script-empty", "MyType", `No root type "MyType" found`));
     it("duplicates", assertSchema("duplicates", "MyType", `Type "A" has multiple definitions.`));
+    it(
+        "missing-discriminator",
+        assertSchema(
+            "missing-discriminator",
+            "MyType",
+            `Cannot find discriminator keyword "type" in type {"name":"B","type":{"id":"interface-1119825560-40-63-1119825560-0-124","baseTypes":[],"properties":[],"additionalProperties":false,"nonPrimitive":false}}.`
+        )
+    );
+    it(
+        "non-union-discriminator",
+        assertSchema(
+            "non-union-discriminator",
+            "MyType",
+            `Cannot assign discriminator tag to type: {"id":"interface-2103469249-0-76-2103469249-0-77","baseTypes":[],"properties":[{"name":"name","type":{},"required":true}],"additionalProperties":false,"nonPrimitive":false}. This tag can only be assigned to union types.`
+        )
+    );
     it(
         "no-function-name",
         assertSchema(

--- a/test/invalid-data.test.ts
+++ b/test/invalid-data.test.ts
@@ -38,7 +38,9 @@ describe("invalid-data", () => {
         assertSchema(
             "missing-discriminator",
             "MyType",
-            `Cannot find discriminator keyword "type" in type {"name":"B","type":{"id":"interface-1119825560-40-63-1119825560-0-124","baseTypes":[],"properties":[],"additionalProperties":false,"nonPrimitive":false}}.`
+            'Cannot find discriminator keyword "type" in type ' +
+                '{"name":"B","type":{"id":"interface-1119825560-40-63-1119825560-0-124",' +
+                '"baseTypes":[],"properties":[],"additionalProperties":false,"nonPrimitive":false}}.'
         )
     );
     it(
@@ -46,7 +48,11 @@ describe("invalid-data", () => {
         assertSchema(
             "non-union-discriminator",
             "MyType",
-            `Cannot assign discriminator tag to type: {"id":"interface-2103469249-0-76-2103469249-0-77","baseTypes":[],"properties":[{"name":"name","type":{},"required":true}],"additionalProperties":false,"nonPrimitive":false}. This tag can only be assigned to union types.`
+            "Cannot assign discriminator tag to type: " +
+                '{"id":"interface-2103469249-0-76-2103469249-0-77","baseTypes":[],' +
+                '"properties":[{"name":"name","type":{},"required":true}],' +
+                '"additionalProperties":false,"nonPrimitive":false}. ' +
+                "This tag can only be assigned to union types."
         )
     );
     it(

--- a/test/invalid-data/missing-discriminator/main.ts
+++ b/test/invalid-data/missing-discriminator/main.ts
@@ -1,0 +1,10 @@
+export interface A {
+    type: string;
+}
+
+export interface B {}
+
+/**
+ * @discriminator type
+ */
+export type MyType = A | B;

--- a/test/invalid-data/non-union-discriminator/main.ts
+++ b/test/invalid-data/non-union-discriminator/main.ts
@@ -1,0 +1,6 @@
+/**
+ * @discriminator name
+ */
+export interface MyType {
+    name: string;
+}

--- a/test/valid-data-annotations.test.ts
+++ b/test/valid-data-annotations.test.ts
@@ -42,4 +42,6 @@ describe("valid-data-annotations", () => {
     it("annotation-ref", assertValidSchema("annotation-ref", "MyObject", "extended"));
 
     it("annotation-writeOnly", assertValidSchema("annotation-writeOnly", "MyObject", "basic"));
+
+    it("annotation-union-if-then", assertValidSchema("annotation-union-if-then", "Animal", "basic"));
 });

--- a/test/valid-data/annotation-union-if-then/main.ts
+++ b/test/valid-data/annotation-union-if-then/main.ts
@@ -1,0 +1,14 @@
+export type Fish = {
+    animal_type: "fish";
+    found_in: "ocean" | "river";
+};
+
+export type Bird = {
+    animal_type: "bird";
+    can_fly: boolean;
+};
+
+/**
+ * @discriminator animal_type
+ */
+export type Animal = Bird | Fish;

--- a/test/valid-data/annotation-union-if-then/schema.json
+++ b/test/valid-data/annotation-union-if-then/schema.json
@@ -1,0 +1,65 @@
+{
+  "$ref": "#/definitions/Animal",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Animal": {
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "animal_type": {
+                "const": "bird",
+                "type": "string"
+              }
+            }
+          },
+          "then": {
+            "$ref": "#/definitions/Bird"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "animal_type": {
+                "const": "fish",
+                "type": "string"
+              }
+            }
+          },
+          "then": {
+            "$ref": "#/definitions/Fish"
+          }
+        }
+      ]
+    },
+    "Bird": {
+      "additionalProperties": false,
+      "properties": {
+        "animal_type": {
+          "const": "bird",
+          "type": "string"
+        },
+        "can_fly": {
+          "type": "boolean"
+        }
+      },
+      "required": ["animal_type", "can_fly"],
+      "type": "object"
+    },
+    "Fish": {
+      "additionalProperties": false,
+      "properties": {
+        "animal_type": {
+          "const": "fish",
+          "type": "string"
+        },
+        "found_in": {
+          "enum": ["ocean", "river"],
+          "type": "string"
+        }
+      },
+      "required": ["animal_type", "found_in"],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1209

This pr adds the ability to select a common property in a union type to act as a discriminator. This is done by specifying the desired property key using the `discriminator` tag. For an example, see the tagged issue or a supplied test case. Note that each of the constituent types should contain this key. A possible next step would be to allow each of the constituent types to define a separate discriminator. The `discriminator` tag would then not be applied to the union definition, but to the separate object definitions.