### PR TITLE
feat: bump `typescript` to 4.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "json5": "^2.2.1",
     "normalize-path": "^3.0.0",
     "safe-stable-stringify": "^2.3.1",
-    "typescript": "~4.7.4"
+    "typescript": "~4.8.2"
   },
   "devDependencies": {
     "@auto-it/conventional-commits": "^10.37.4",

--- a/src/TypeFormatter/UnionTypeFormatter.ts
+++ b/src/TypeFormatter/UnionTypeFormatter.ts
@@ -56,7 +56,9 @@ export class UnionTypeFormatter implements SubTypeFormatter {
 
         // Flatten anyOf inside anyOf unless the anyOf has an annotation
         for (const def of definitions) {
-            if (Object.keys(def) === ["anyOf"]) {
+            const definition = Object.keys(def);
+
+            if (definition.length === 1 && definition[0] === "anyOf") {
                 flattenedDefinitions.push(...(def.anyOf as any));
             } else {
                 flattenedDefinitions.push(def);

--- a/src/TypeFormatter/UnionTypeFormatter.ts
+++ b/src/TypeFormatter/UnionTypeFormatter.ts
@@ -56,9 +56,9 @@ export class UnionTypeFormatter implements SubTypeFormatter {
 
         // Flatten anyOf inside anyOf unless the anyOf has an annotation
         for (const def of definitions) {
-            const definition = Object.keys(def);
+            const keys = Object.keys(def);
 
-            if (definition.length === 1 && definition[0] === "anyOf") {
+            if (keys.length === 1 && keys[0] === "anyOf") {
                 flattenedDefinitions.push(...(def.anyOf as any));
             } else {
                 flattenedDefinitions.push(def);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5614,10 +5614,10 @@ typescript-memoize@^1.0.0-alpha.3:
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.1.0.tgz#4a8f512d06fc995167c703a3592219901db8bc79"
   integrity sha512-LQPKVXK8QrBBkL/zclE6YgSWn0I8ew5m0Lf+XL00IwMhlotqRLlzHV+BRrljVQIc+NohUAuQP7mg4HQwrx5Xbg==
 
-typescript@~4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+typescript@~4.8.2:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
+  integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Closes #1387

Upgrade `typescript` to 4.8.2. Dependabot’s upgrade failed in #1379. Had to fix one line.