### PR TITLE
ci: don't add message to released prs

### DIFF
--- a/.autorc.json
+++ b/.autorc.json
@@ -2,8 +2,7 @@
     "plugins": [
         "npm",
         "conventional-commits",
-        "first-time-contributor",
-        "released"
+        "first-time-contributor"
     ],
     "baseBranch": "stable",
     "prereleaseBranches": [


### PR DESCRIPTION
I think GitHub already adds the annotations so we don't need it, do we?

<img width="927" alt="Screenshot 2022-09-20 at 22 58 49" src="https://user-images.githubusercontent.com/589034/191404639-fafa0ad9-4f5e-4d82-b27b-e7d3839ea3a1.png">
