### PR TITLE
fix: Definition Not Created When Properties Are Nullable

### DIFF
--- a/src/Utils/removeUnreachable.ts
+++ b/src/Utils/removeUnreachable.ts
@@ -39,7 +39,7 @@ function addReachable(
         }
     } else if (definition.not) {
         addReachable(definition.not, definitions, reachable);
-    } else if (definition.type === "object") {
+    } else if (definition.type?.includes("object")) {
         for (const prop in definition.properties || {}) {
             const propDefinition = definition.properties![prop];
             addReachable(propDefinition, definitions, reachable);
@@ -49,7 +49,7 @@ function addReachable(
         if (additionalProperties) {
             addReachable(additionalProperties, definitions, reachable);
         }
-    } else if (definition.type === "array") {
+    } else if (definition.type?.includes("array")) {
         const items = definition.items;
         if (Array.isArray(items)) {
             for (const item of items) {

--- a/test/valid-data-annotations.test.ts
+++ b/test/valid-data-annotations.test.ts
@@ -73,4 +73,6 @@ describe("valid-data-annotations", () => {
     it("annotation-writeOnly", assertValidSchema("annotation-writeOnly", "MyObject", "basic"));
 
     it("annotation-union-if-then", assertValidSchema("annotation-union-if-then", "Animal", "basic"));
+
+    it("annotation-nullable-definition", assertValidSchema("annotation-nullable-definition", "MyObject", "extended"));
 });

--- a/test/valid-data/annotation-nullable-definition/main.ts
+++ b/test/valid-data/annotation-nullable-definition/main.ts
@@ -1,0 +1,10 @@
+export class Definition {
+     name: string
+}
+
+export class MyObject  {
+    /**
+     * @nullable
+     */
+    optional?: Definition[]
+}

--- a/test/valid-data/annotation-nullable-definition/schema.json
+++ b/test/valid-data/annotation-nullable-definition/schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema":"http://json-schema.org/draft-07/schema#",
+  "$ref":"#/definitions/MyObject",
+  "definitions":{
+     "MyObject":{
+        "type":"object",
+        "properties":{
+           "optional":{
+              "type":[
+                 "array",
+                 "null"
+              ],
+              "items":{
+                 "$ref":"#/definitions/Definition"
+              }
+           }
+        },
+        "additionalProperties":false
+     },
+     "Definition":{
+        "type":"object",
+        "properties":{
+           "name":{
+              "type":"string"
+           }
+        },
+        "required":[
+           "name"
+        ],
+        "additionalProperties":false
+     }
+  }
+}


### PR DESCRIPTION
fixes issue #1419

When using the @nullable annotation, the type of a definition may go from:

```
type: "string"
```
to:
```
type: ["string", "null"]
```

The check for removing unreachable definitions only assumed the attribute type was a string and not an array of strings.

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v1.1.2-next.0`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Moyo George ([@ThatOneAwkwardGuy](https://github.com/ThatOneAwkwardGuy)), for all your work!
  
  #### 🐛 Bug Fix
  
  - fix: Definition Not Created When Properties Are Nullable [#1420](https://github.com/vega/ts-json-schema-generator/pull/1420) ([@ThatOneAwkwardGuy](https://github.com/ThatOneAwkwardGuy))
  
  #### Authors: 1
  
  - Moyo George ([@ThatOneAwkwardGuy](https://github.com/ThatOneAwkwardGuy))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
