### PR TITLE
feat: Add support for computed types on literals

### DIFF
--- a/factory/parser.ts
+++ b/factory/parser.ts
@@ -157,7 +157,13 @@ export function createParser(program: ts.Program, config: Config, augmentor?: Pa
         .addNodeParser(
             withCircular(
                 withExpose(
-                    withJsDoc(new TypeLiteralNodeParser(withJsDoc(chainNodeParser), mergedConfig.additionalProperties))
+                    withJsDoc(
+                        new TypeLiteralNodeParser(
+                            typeChecker,
+                            withJsDoc(chainNodeParser),
+                            mergedConfig.additionalProperties
+                        )
+                    )
                 )
             )
         )

--- a/test/valid-data-struct.test.ts
+++ b/test/valid-data-struct.test.ts
@@ -8,6 +8,10 @@ describe("valid-data-struct", () => {
     it("object-literal-expression", assertValidSchema("object-literal-expression", "MyType"));
 
     it("literal-object-type", assertValidSchema("literal-object-type", "MyType"));
+    it(
+        "literal-object-type-with-computed-props",
+        assertValidSchema("literal-object-type-with-computed-props", "MyType")
+    );
     it("literal-array-type", assertValidSchema("literal-array-type", "MyType"));
     it("literal-index-type", assertValidSchema("literal-index-type", "MyType"));
 

--- a/test/valid-data/literal-object-type-with-computed-props/main.ts
+++ b/test/valid-data/literal-object-type-with-computed-props/main.ts
@@ -1,0 +1,13 @@
+import { key as importedKey, Keys } from "./module";
+const key = "localKey";
+
+enum LocalKeys {
+    Key = "localEnumKey",
+}
+
+export type MyType = {
+    [key]: string;
+    [LocalKeys.Key]: string;
+    [importedKey]: string;
+    [Keys.Key]: string;
+};

--- a/test/valid-data/literal-object-type-with-computed-props/module.ts
+++ b/test/valid-data/literal-object-type-with-computed-props/module.ts
@@ -1,0 +1,5 @@
+export const key = "exportedKey";
+
+export enum Keys {
+    Key = "exportedEnumKey",
+}

--- a/test/valid-data/literal-object-type-with-computed-props/schema.json
+++ b/test/valid-data/literal-object-type-with-computed-props/schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/MyType",
+  "definitions": {
+    "MyType": {
+      "type": "object",
+      "properties": {
+        "localKey": {
+          "type": "string"
+        },
+        "localEnumKey": {
+          "type": "string"
+        },
+        "exportedKey": {
+          "type": "string"
+        },
+        "exportedEnumKey": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "localKey",
+        "localEnumKey",
+        "exportedKey",
+        "exportedEnumKey"
+      ],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
This mirrors https://github.com/vega/ts-json-schema-generator/pull/746 in that it also adds support for computed types, however in this case it adds support for typescript types defined with the `Type` keyword vs `Interface`.

Before this change the newly added tests would fail because all of the keys would evaluate to `__computed` which is an internal Typescript value.

Since `Type` types use the `TypeLiteralNodeParser` parser under-the-hood, this updates that parser.

(This also eliminates an any cast)