### PR TITLE
feat: export some useful func for custom parser

### DIFF
--- a/factory/parser.ts
+++ b/factory/parser.ts
@@ -58,7 +58,15 @@ import { VoidTypeNodeParser } from "../src/NodeParser/VoidTypeNodeParser";
 import { SubNodeParser } from "../src/SubNodeParser";
 import { TopRefNodeParser } from "../src/TopRefNodeParser";
 
-export type ParserAugmentor = (parser: MutableParser) => void;
+
+export interface IParserAugmentorContext {
+    withExpose(nodeParser: SubNodeParser): SubNodeParser;
+    withTopRef(nodeParser: NodeParser): NodeParser;
+    withJsDoc(nodeParser: SubNodeParser): SubNodeParser;
+    withCircular(nodeParser: SubNodeParser): SubNodeParser
+}
+
+export type ParserAugmentor = (parser: MutableParser, context: IParserAugmentorContext) => void;
 
 export function createParser(program: ts.Program, config: Config, augmentor?: ParserAugmentor): NodeParser {
     const typeChecker = program.getTypeChecker();
@@ -87,7 +95,12 @@ export function createParser(program: ts.Program, config: Config, augmentor?: Pa
     }
 
     if (augmentor) {
-        augmentor(chainNodeParser);
+        augmentor(chainNodeParser, {
+            withExpose,
+            withTopRef,
+            withJsDoc,
+            withCircular,
+        });
     }
 
     chainNodeParser

--- a/factory/parser.ts
+++ b/factory/parser.ts
@@ -58,12 +58,13 @@ import { VoidTypeNodeParser } from "../src/NodeParser/VoidTypeNodeParser";
 import { SubNodeParser } from "../src/SubNodeParser";
 import { TopRefNodeParser } from "../src/TopRefNodeParser";
 
-
 export interface IParserAugmentorContext {
     withExpose(nodeParser: SubNodeParser): SubNodeParser;
     withTopRef(nodeParser: NodeParser): NodeParser;
     withJsDoc(nodeParser: SubNodeParser): SubNodeParser;
-    withCircular(nodeParser: SubNodeParser): SubNodeParser
+    withCircular(nodeParser: SubNodeParser): SubNodeParser;
+    mergedConfig: Config;
+    typeChecker: ts.TypeChecker;
 }
 
 export type ParserAugmentor = (parser: MutableParser, context: IParserAugmentorContext) => void;
@@ -100,6 +101,8 @@ export function createParser(program: ts.Program, config: Config, augmentor?: Pa
             withTopRef,
             withJsDoc,
             withCircular,
+            mergedConfig,
+            typeChecker,
         });
     }
 


### PR DESCRIPTION
I want to support some custom jsDoc and generate different definition for these jsDoc, So I need to write a custom parser:

the easiest way is extends the `InterfaceAndClassNodeParser` class:
```ts
export class CustomInterfaceAndClassNodeParser extends InterfaceAndClassNodeParser {
}
```


and when I  have wrote the custom parser, I found that I also need some helper function：

![CleanShot 2022-11-23 at 23 49 31@2x](https://user-images.githubusercontent.com/13938334/203590278-fd46f158-9d1a-4baf-a781-881d4903db18.png)

