### PR TITLE
docs: clarify escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,22 @@ This project is made possible by a [community of contributors](https://github.co
 
 ## CLI Usage
 
+Run the schema generator with npx:
+
+```bash
+npx ts-json-schema-generator --path 'my/project/**/*.ts' --type 'My.Type.Name'
+```
+
+Or install the package and then run it
+
 ```bash
 npm install --save ts-json-schema-generator
 ./node_modules/.bin/ts-json-schema-generator --path 'my/project/**/*.ts' --type 'My.Type.Name'
 ```
 
 Note that different platforms (e.g. Windows) may use different path separators so you may have to adjust the command above.
+
+Also note that you need to quote paths with `*` as otherwise the shell will expand the paths and therefore only pass the first path to the generator.
 
 ## Programmatic Usage
 


### PR DESCRIPTION
Fixes #1472. Fixes #1488

Thanks to [grimmer0125](https://github.com/grimmer0125) for motivating this change. 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.1.3--canary.1489.d176f88.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install ts-json-schema-generator@1.1.3--canary.1489.d176f88.0
  # or 
  yarn add ts-json-schema-generator@1.1.3--canary.1489.d176f88.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
