### PR TITLE
fix: add enum to discriminator to avoid schema accepting too much (#1492)

### DIFF
--- a/src/TypeFormatter/UnionTypeFormatter.ts
+++ b/src/TypeFormatter/UnionTypeFormatter.ts
@@ -56,6 +56,15 @@ export class UnionTypeFormatter implements SubTypeFormatter {
                 .map((item) => item.const)
                 .filter((item): item is string | number | boolean | null => item !== undefined);
 
+            const duplicates = kindValues.filter((item, index) => kindValues.indexOf(item) !== index);
+            if (duplicates.length > 0) {
+                throw new Error(
+                    `Duplicate discriminator values: ${duplicates.join(", ")} in type ${JSON.stringify(
+                        type.getName()
+                    )}.`
+                );
+            }
+
             const properties = {
                 [discriminator]: {
                     enum: kindValues,

--- a/src/TypeFormatter/UnionTypeFormatter.ts
+++ b/src/TypeFormatter/UnionTypeFormatter.ts
@@ -52,7 +52,17 @@ export class UnionTypeFormatter implements SubTypeFormatter {
                 });
             }
 
-            return { allOf };
+            const kindValues = kindDefinitions
+                .map((item) => item.const)
+                .filter((item): item is string => typeof item === "string");
+
+            const properties = {
+                [discriminator]: {
+                    enum: kindValues,
+                },
+            };
+
+            return { type: "object", properties, required: [discriminator], allOf };
         }
 
         // TODO: why is this not covered by LiteralUnionTypeFormatter?

--- a/src/TypeFormatter/UnionTypeFormatter.ts
+++ b/src/TypeFormatter/UnionTypeFormatter.ts
@@ -1,4 +1,4 @@
-import { JSONSchema7 } from "json-schema";
+import {JSONSchema7, JSONSchema7Array, JSONSchema7Object} from "json-schema";
 import { Definition } from "../Schema/Definition";
 import { SubTypeFormatter } from "../SubTypeFormatter";
 import { BaseType } from "../Type/BaseType";
@@ -54,7 +54,7 @@ export class UnionTypeFormatter implements SubTypeFormatter {
 
             const kindValues = kindDefinitions
                 .map((item) => item.const)
-                .filter((item): item is string => typeof item === "string");
+                .filter((item): item is string | number | boolean | null => item !== undefined);
 
             const properties = {
                 [discriminator]: {

--- a/src/TypeFormatter/UnionTypeFormatter.ts
+++ b/src/TypeFormatter/UnionTypeFormatter.ts
@@ -1,4 +1,4 @@
-import {JSONSchema7, JSONSchema7Array, JSONSchema7Object} from "json-schema";
+import { JSONSchema7 } from "json-schema";
 import { Definition } from "../Schema/Definition";
 import { SubTypeFormatter } from "../SubTypeFormatter";
 import { BaseType } from "../Type/BaseType";

--- a/test/invalid-data.test.ts
+++ b/test/invalid-data.test.ts
@@ -56,6 +56,10 @@ describe("invalid-data", () => {
         )
     );
     it(
+        "duplicate-discriminator",
+        assertSchema("duplicate-discriminator", "MyType", 'Duplicate discriminator values: A in type "(A|B)".')
+    );
+    it(
         "no-function-name",
         assertSchema(
             "function-parameters-declaration-missing-name",

--- a/test/invalid-data/duplicate-discriminator/main.ts
+++ b/test/invalid-data/duplicate-discriminator/main.ts
@@ -1,0 +1,14 @@
+export type A = {
+    type: "A",
+    a: string,
+}
+
+export type B = {
+    type: "A",
+    b: string,
+}
+
+/**
+ * @discriminator type
+ */
+export type MyType = A | B;

--- a/test/valid-data/annotation-union-if-then/schema.json
+++ b/test/valid-data/annotation-union-if-then/schema.json
@@ -30,7 +30,19 @@
             "$ref": "#/definitions/Fish"
           }
         }
-      ]
+      ],
+      "properties": {
+        "animal_type": {
+          "enum": [
+            "bird",
+            "fish"
+          ]
+        }
+      },
+      "required": [
+        "animal_type"
+      ],
+      "type": "object"
     },
     "Bird": {
       "additionalProperties": false,


### PR DESCRIPTION
Fixes #1492 and fixes #1494

Since this is the first time I'm looking into the source code of this repository, I'm not sure if I've taken the right approach to solve this. My changes do seem to fix the issue, but there may be some edge cases I have overlooked. 
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v1.2.0-next.4`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: null[@mvanniekerkSQ](https://github.com/mvanniekerkSQ)
  
  :heart: null[@swnf](https://github.com/swnf)
  
  :heart: Thomas ([@thomaswr](https://github.com/thomaswr))
  
  :heart: Arthur Fiorette ([@arthurfiorette](https://github.com/arthurfiorette))
  
  :heart: Sean Keenan ([@sean9keenan](https://github.com/sean9keenan))
  
  #### 🚀 Enhancement
  
  - feat: basic support for inferrable types [#1407](https://github.com/vega/ts-json-schema-generator/pull/1407) ([@swnf](https://github.com/swnf))
  - feat: add support for type URL (string with format "uri") [#1480](https://github.com/vega/ts-json-schema-generator/pull/1480) (thomas.riener@derstandard.at [@thomaswr](https://github.com/thomaswr))
  - feat: support for sourceless nodes. [#1386](https://github.com/vega/ts-json-schema-generator/pull/1386) ([@arthurfiorette](https://github.com/arthurfiorette))
  - feat: Add support for computed types on literals [#1438](https://github.com/vega/ts-json-schema-generator/pull/1438) ([@sean9keenan](https://github.com/sean9keenan))
  
  #### 🐛 Bug Fix
  
  - fix: add enum to discriminator to avoid schema accepting too much (#1492) [#1493](https://github.com/vega/ts-json-schema-generator/pull/1493) ([@mvanniekerkSQ](https://github.com/mvanniekerkSQ))
  - chore: upgrade deps [#1490](https://github.com/vega/ts-json-schema-generator/pull/1490) ([@domoritz](https://github.com/domoritz))
  - docs: clarify escaping [#1489](https://github.com/vega/ts-json-schema-generator/pull/1489) ([@domoritz](https://github.com/domoritz))
  - chore: upgrade deps [#1487](https://github.com/vega/ts-json-schema-generator/pull/1487) ([@domoritz](https://github.com/domoritz))
  - fix: Export HiddenType and HiddenTypeFormatter [#1437](https://github.com/vega/ts-json-schema-generator/pull/1437) ([@sean9keenan](https://github.com/sean9keenan))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump @typescript-eslint/parser from 5.43.0 to 5.44.0 [#1483](https://github.com/vega/ts-json-schema-generator/pull/1483) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.7.1 to 2.8.0 [#1482](https://github.com/vega/ts-json-schema-generator/pull/1482) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.43.0 to 5.44.0 [#1484](https://github.com/vega/ts-json-schema-generator/pull/1484) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest-junit from 14.0.1 to 15.0.0 [#1479](https://github.com/vega/ts-json-schema-generator/pull/1479) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.42.1 to 5.43.0 [#1473](https://github.com/vega/ts-json-schema-generator/pull/1473) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 29.2.2 to 29.2.3 [#1474](https://github.com/vega/ts-json-schema-generator/pull/1474) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.42.1 to 5.43.0 [#1475](https://github.com/vega/ts-json-schema-generator/pull/1475) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.27.0 to 8.28.0 [#1476](https://github.com/vega/ts-json-schema-generator/pull/1476) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv from 8.11.0 to 8.11.2 [#1478](https://github.com/vega/ts-json-schema-generator/pull/1478) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.42.0 to 5.42.1 [#1468](https://github.com/vega/ts-json-schema-generator/pull/1468) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump chai from 4.3.6 to 4.3.7 [#1469](https://github.com/vega/ts-json-schema-generator/pull/1469) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.42.0 to 5.42.1 [#1470](https://github.com/vega/ts-json-schema-generator/pull/1470) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 29.2.2 to 29.3.1 [#1471](https://github.com/vega/ts-json-schema-generator/pull/1471) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.41.0 to 5.42.0 [#1461](https://github.com/vega/ts-json-schema-generator/pull/1461) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.19.4 to 7.20.2 [#1464](https://github.com/vega/ts-json-schema-generator/pull/1464) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 29.0.3 to 29.2.2 [#1462](https://github.com/vega/ts-json-schema-generator/pull/1462) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.26.0 to 8.27.0 [#1463](https://github.com/vega/ts-json-schema-generator/pull/1463) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.41.0 to 5.42.0 [#1465](https://github.com/vega/ts-json-schema-generator/pull/1465) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 18.11.7 to 18.11.9 [#1466](https://github.com/vega/ts-json-schema-generator/pull/1466) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.19.6 to 7.20.2 [#1467](https://github.com/vega/ts-json-schema-generator/pull/1467) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.40.1 to 5.41.0 [#1458](https://github.com/vega/ts-json-schema-generator/pull/1458) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 29.2.1 to 29.2.2 [#1457](https://github.com/vega/ts-json-schema-generator/pull/1457) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.40.1 to 5.41.0 [#1459](https://github.com/vega/ts-json-schema-generator/pull/1459) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 18.11.3 to 18.11.7 [#1460](https://github.com/vega/ts-json-schema-generator/pull/1460) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump safe-stable-stringify from 2.4.0 to 2.4.1 [#1448](https://github.com/vega/ts-json-schema-generator/pull/1448) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@domoritz](https://github.com/domoritz))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.40.0 to 5.40.1 [#1449](https://github.com/vega/ts-json-schema-generator/pull/1449) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.25.0 to 8.26.0 [#1447](https://github.com/vega/ts-json-schema-generator/pull/1447) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 18.11.0 to 18.11.3 [#1450](https://github.com/vega/ts-json-schema-generator/pull/1450) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.19.3 to 7.19.6 [#1451](https://github.com/vega/ts-json-schema-generator/pull/1451) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 29.2.0 to 29.2.1 [#1452](https://github.com/vega/ts-json-schema-generator/pull/1452) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.40.0 to 5.40.1 [#1453](https://github.com/vega/ts-json-schema-generator/pull/1453) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega-lite from 5.5.0 to 5.6.0 [#1444](https://github.com/vega/ts-json-schema-generator/pull/1444) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@domoritz](https://github.com/domoritz))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.39.0 to 5.40.0 [#1441](https://github.com/vega/ts-json-schema-generator/pull/1441) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 18.8.3 to 18.11.0 [#1440](https://github.com/vega/ts-json-schema-generator/pull/1440) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 29.1.2 to 29.2.0 [#1442](https://github.com/vega/ts-json-schema-generator/pull/1442) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.39.0 to 5.40.0 [#1443](https://github.com/vega/ts-json-schema-generator/pull/1443) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.19.3 to 7.19.4 [#1445](https://github.com/vega/ts-json-schema-generator/pull/1445) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.38.1 to 5.39.0 [#1435](https://github.com/vega/ts-json-schema-generator/pull/1435) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.24.0 to 8.25.0 [#1432](https://github.com/vega/ts-json-schema-generator/pull/1432) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 29.0.3 to 29.1.2 [#1433](https://github.com/vega/ts-json-schema-generator/pull/1433) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 18.7.23 to 18.8.3 [#1434](https://github.com/vega/ts-json-schema-generator/pull/1434) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.38.1 to 5.39.0 [#1436](https://github.com/vega/ts-json-schema-generator/pull/1436) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.38.0 to 5.38.1 [#1426](https://github.com/vega/ts-json-schema-generator/pull/1426) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 18.7.20 to 18.7.23 [#1424](https://github.com/vega/ts-json-schema-generator/pull/1424) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.19.1 to 7.19.3 [#1425](https://github.com/vega/ts-json-schema-generator/pull/1425) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.19.1 to 7.19.3 [#1427](https://github.com/vega/ts-json-schema-generator/pull/1427) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.38.0 to 5.38.1 [#1428](https://github.com/vega/ts-json-schema-generator/pull/1428) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 9.4.0 to 9.4.1 [#1429](https://github.com/vega/ts-json-schema-generator/pull/1429) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.8.3 to 4.8.4 [#1430](https://github.com/vega/ts-json-schema-generator/pull/1430) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 8
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - [@mvanniekerkSQ](https://github.com/mvanniekerkSQ)
  - [@swnf](https://github.com/swnf)
  - Arthur Fiorette ([@arthurfiorette](https://github.com/arthurfiorette))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
  - Sean Keenan ([@sean9keenan](https://github.com/sean9keenan))
  - Thomas ([@thomaswr](https://github.com/thomaswr))
  - Thomas Riener (thomas.riener@derstandard.at)
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
