### PR TITLE
fix: return an any-type if a given node is missing type declarations

### DIFF
--- a/src/NodeParser/TypeReferenceNodeParser.ts
+++ b/src/NodeParser/TypeReferenceNodeParser.ts
@@ -33,6 +33,10 @@ export class TypeReferenceNodeParser implements SubNodeParser {
             return this.childNodeParser.createType(node.typeArguments![0]!, this.createSubContext(node, context));
         }
 
+        if (!typeSymbol.declarations) {
+            return new AnyType();
+        }
+
         if (typeSymbol.flags & ts.SymbolFlags.Alias) {
             const aliasedSymbol = this.typeChecker.getAliasedSymbol(typeSymbol);
 

--- a/src/NodeParser/TypeReferenceNodeParser.ts
+++ b/src/NodeParser/TypeReferenceNodeParser.ts
@@ -69,7 +69,7 @@ export class TypeReferenceNodeParser implements SubNodeParser {
         }
 
         return this.childNodeParser.createType(
-            typeSymbol.declarations!.filter((n: ts.Declaration) => !invalidTypes[n.kind])[0],
+            typeSymbol.declarations.filter((n: ts.Declaration) => !invalidTypes[n.kind])[0],
             this.createSubContext(node, context)
         );
     }


### PR DESCRIPTION
We encountered a problem where the `TypeReferenceNodeParser` class would crash if a type is missing definitions. We're using the [react-input-mask-library](https://www.npmjs.com/package/react-input-mask) package which is missing type declarations, so we are using the [@types/react-input-mask](https://www.npmjs.com/package/@types/react-input-mask) for types. It seems when an external `@types` package is used the generator is unable to find any type of information about the given node. 

This is more a suggestion, but I personally think returning an `AnyType` when this is the case is better than the generator failing entirely. 