### PR TITLE
fix: support non-literal types in template literal strings

### DIFF
--- a/src/NodeParser/StringTemplateLiteralNodeParser.ts
+++ b/src/NodeParser/StringTemplateLiteralNodeParser.ts
@@ -3,7 +3,6 @@ import { Context, NodeParser } from "../NodeParser";
 import { SubNodeParser } from "../SubNodeParser";
 import { BaseType } from "../Type/BaseType";
 import { LiteralType } from "../Type/LiteralType";
-import { NumberType } from "../Type/NumberType";
 import { StringType } from "../Type/StringType";
 import { UnionType } from "../Type/UnionType";
 import { extractLiterals } from "../Utils/extractLiterals";
@@ -23,7 +22,7 @@ export class StringTemplateLiteralNodeParser implements SubNodeParser {
         if (
             node.templateSpans
                 .map((span) => this.childNodeParser.createType(span.type, context))
-                .some((type) => type instanceof NumberType)
+                .some((type) => !(type instanceof LiteralType))
         ) {
             return new StringType();
         }

--- a/src/NodeParser/StringTemplateLiteralNodeParser.ts
+++ b/src/NodeParser/StringTemplateLiteralNodeParser.ts
@@ -1,6 +1,7 @@
 import ts from "typescript";
 import { Context, NodeParser } from "../NodeParser";
 import { SubNodeParser } from "../SubNodeParser";
+import { AliasType } from "../Type/AliasType";
 import { BaseType } from "../Type/BaseType";
 import { LiteralType } from "../Type/LiteralType";
 import { StringType } from "../Type/StringType";
@@ -22,7 +23,10 @@ export class StringTemplateLiteralNodeParser implements SubNodeParser {
         if (
             node.templateSpans
                 .map((span) => this.childNodeParser.createType(span.type, context))
-                .some((type) => !(type instanceof LiteralType))
+                .some(
+                    (type) =>
+                        !(type instanceof LiteralType) && !(type instanceof UnionType) && !(type instanceof AliasType)
+                )
         ) {
             return new StringType();
         }

--- a/src/NodeParser/StringTemplateLiteralNodeParser.ts
+++ b/src/NodeParser/StringTemplateLiteralNodeParser.ts
@@ -3,6 +3,8 @@ import { Context, NodeParser } from "../NodeParser";
 import { SubNodeParser } from "../SubNodeParser";
 import { BaseType } from "../Type/BaseType";
 import { LiteralType } from "../Type/LiteralType";
+import { NumberType } from "../Type/NumberType";
+import { StringType } from "../Type/StringType";
 import { UnionType } from "../Type/UnionType";
 import { extractLiterals } from "../Utils/extractLiterals";
 
@@ -18,6 +20,14 @@ export class StringTemplateLiteralNodeParser implements SubNodeParser {
         if (node.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral) {
             return new LiteralType(node.text);
         }
+        if (
+            node.templateSpans
+                .map((span) => this.childNodeParser.createType(span.type, context))
+                .some((type) => type instanceof NumberType)
+        ) {
+            return new StringType();
+        }
+
         const prefix = node.head.text;
         const matrix: string[][] = [[prefix]].concat(
             node.templateSpans.map((span) => {

--- a/src/Utils/extractLiterals.ts
+++ b/src/Utils/extractLiterals.ts
@@ -1,6 +1,7 @@
 import { UnknownTypeError } from "../Error/UnknownTypeError";
 import { AliasType } from "../Type/AliasType";
 import { BaseType } from "../Type/BaseType";
+import { BooleanType } from "../Type/BooleanType";
 import { LiteralType } from "../Type/LiteralType";
 import { UnionType } from "../Type/UnionType";
 
@@ -20,6 +21,10 @@ function* _extractLiterals(type: BaseType): Iterable<string> {
     }
     if (type instanceof AliasType) {
         yield* _extractLiterals(type.getType());
+        return;
+    }
+    if (type instanceof BooleanType) {
+        yield* _extractLiterals(new UnionType([new LiteralType("true"), new LiteralType("false")]));
         return;
     }
 

--- a/test/valid-data/string-template-expression-literals/main.ts
+++ b/test/valid-data/string-template-expression-literals/main.ts
@@ -3,10 +3,12 @@ type Result = OK | "fail" | `abort`;
 type PrivateResultId = `__${Result}_id`;
 type OK_ID = `id_${OK}`;
 type Num = `${number}`;
+type Bool = `${boolean}`;
 
 export interface MyObject {
     foo: Result;
     _foo: PrivateResultId;
     ok: OK_ID;
     num: Num;
+    bool: Bool;
 }

--- a/test/valid-data/string-template-expression-literals/main.ts
+++ b/test/valid-data/string-template-expression-literals/main.ts
@@ -2,8 +2,8 @@ type OK = "ok";
 type Result = OK | "fail" | `abort`;
 type PrivateResultId = `__${Result}_id`;
 type OK_ID = `id_${OK}`;
-type Num = `${number}`;
-type Bool = `${boolean}`;
+type Num = `${number}%`;
+type Bool = `${boolean}!`;
 
 export interface MyObject {
     foo: Result;

--- a/test/valid-data/string-template-expression-literals/main.ts
+++ b/test/valid-data/string-template-expression-literals/main.ts
@@ -2,9 +2,11 @@ type OK = "ok";
 type Result = OK | "fail" | `abort`;
 type PrivateResultId = `__${Result}_id`;
 type OK_ID = `id_${OK}`;
+type Num = `${number}`;
 
 export interface MyObject {
     foo: Result;
     _foo: PrivateResultId;
     ok: OK_ID;
+    num: Num;
 }

--- a/test/valid-data/string-template-expression-literals/schema.json
+++ b/test/valid-data/string-template-expression-literals/schema.json
@@ -24,6 +24,9 @@
         "ok": {
           "const": "id_ok",
           "type": "string"
+        },
+        "num": {
+          "type": "string"
         }
       },
       "required": [

--- a/test/valid-data/string-template-expression-literals/schema.json
+++ b/test/valid-data/string-template-expression-literals/schema.json
@@ -29,7 +29,7 @@
           "type": "string"
         },
         "bool": {
-          "enum": ["true", "false"],
+          "enum": ["true!", "false!"],
           "type": "string"
         }
       },

--- a/test/valid-data/string-template-expression-literals/schema.json
+++ b/test/valid-data/string-template-expression-literals/schema.json
@@ -29,6 +29,7 @@
           "type": "string"
         },
         "bool": {
+          "enum": ["true", "false"],
           "type": "string"
         }
       },

--- a/test/valid-data/string-template-expression-literals/schema.json
+++ b/test/valid-data/string-template-expression-literals/schema.json
@@ -27,6 +27,9 @@
         },
         "num": {
           "type": "string"
+        },
+        "bool": {
+          "type": "boolean"
         }
       },
       "required": [

--- a/test/valid-data/string-template-expression-literals/schema.json
+++ b/test/valid-data/string-template-expression-literals/schema.json
@@ -29,13 +29,15 @@
           "type": "string"
         },
         "bool": {
-          "type": "boolean"
+          "type": "string"
         }
       },
       "required": [
         "foo",
         "_foo",
-        "ok"
+        "ok",
+        "num",
+        "bool"
       ],
       "type": "object"
     }


### PR DESCRIPTION
When given a template literal type which contains a `number` type, for instance:

```ts
type Foo = `${number}`;
```

The generator fails with `Unknown type "number"`.

This PR solves this by simply returning a `StringType` when a template literal string contains a `number` type, which makes sense, because JSON Schema can't really represent these types easily. I feel like making a regex-converter for these types is a bit overkill.