### PR TITLE
feat: support conditionals in mapped types

### DIFF
--- a/src/NodeParser/MappedTypeNodeParser.ts
+++ b/src/NodeParser/MappedTypeNodeParser.ts
@@ -13,7 +13,6 @@ import { ObjectProperty, ObjectType } from "../Type/ObjectType";
 import { StringType } from "../Type/StringType";
 import { SymbolType } from "../Type/SymbolType";
 import { UnionType } from "../Type/UnionType";
-import assert from "../Utils/assert";
 import { derefAnnotatedType, derefType } from "../Utils/derefType";
 import { getKey } from "../Utils/nodeKey";
 import { preserveAnnotation } from "../Utils/preserveAnnotation";

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -83,6 +83,7 @@ describe("valid-data-type", () => {
     it("type-mapped-index", assertValidSchema("type-mapped-index", "MyObject"));
     it("type-mapped-index-as", assertValidSchema("type-mapped-index-as", "MyObject"));
     it("type-mapped-index-as-template", assertValidSchema("type-mapped-index-as-template", "MyObject"));
+    it("type-mapped-index-as-with-conditional", assertValidSchema("type-mapped-index-as-with-conditional", "MyObject"));
     it("type-mapped-literal", assertValidSchema("type-mapped-literal", "MyObject"));
     it("type-mapped-generic", assertValidSchema("type-mapped-generic", "MyObject"));
     it("type-mapped-native", assertValidSchema("type-mapped-native", "MyObject"));

--- a/test/valid-data/type-mapped-index-as-with-conditional/main.ts
+++ b/test/valid-data/type-mapped-index-as-with-conditional/main.ts
@@ -1,0 +1,9 @@
+interface Message {
+    id: number;
+    name: string;
+    title: string;
+}
+
+export type MyObject = {
+    [K in keyof Message as Exclude<K, "title">]: Message[K];
+};

--- a/test/valid-data/type-mapped-index-as-with-conditional/schema.json
+++ b/test/valid-data/type-mapped-index-as-with-conditional/schema.json
@@ -1,0 +1,22 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "number"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name"
+      ],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
This fixes https://github.com/vega/ts-json-schema-generator/issues/1502.

Instead of just returning `null` or `undefined`, we instead want to filter out `NeverType` from the list of keys after we parse them. This way we will actually get the correct union of keys, even after the conditional. See the test for more information.