### PR TITLE
feat: support constructor node types

### DIFF
--- a/factory/parser.ts
+++ b/factory/parser.ts
@@ -16,6 +16,7 @@ import { BooleanLiteralNodeParser } from "../src/NodeParser/BooleanLiteralNodePa
 import { BooleanTypeNodeParser } from "../src/NodeParser/BooleanTypeNodeParser";
 import { CallExpressionParser } from "../src/NodeParser/CallExpressionParser";
 import { ConditionalTypeNodeParser } from "../src/NodeParser/ConditionalTypeNodeParser";
+import { ConstructorNodeParser } from "../src/NodeParser/ConstructorNodeParser";
 import { EnumNodeParser } from "../src/NodeParser/EnumNodeParser";
 import { ExpressionWithTypeArgumentsNodeParser } from "../src/NodeParser/ExpressionWithTypeArgumentsNodeParser";
 import { FunctionNodeParser } from "../src/NodeParser/FunctionNodeParser";
@@ -112,6 +113,7 @@ export function createParser(program: ts.Program, config: Config, augmentor?: Pa
         .addNodeParser(new BooleanLiteralNodeParser())
         .addNodeParser(new NullLiteralNodeParser())
         .addNodeParser(new FunctionNodeParser())
+        .addNodeParser(new ConstructorNodeParser())
         .addNodeParser(new ObjectLiteralExpressionNodeParser(chainNodeParser))
         .addNodeParser(new ArrayLiteralExpressionNodeParser(chainNodeParser))
 

--- a/src/NodeParser/ConstructorNodeParser.ts
+++ b/src/NodeParser/ConstructorNodeParser.ts
@@ -1,0 +1,18 @@
+import ts from "typescript";
+import { SubNodeParser } from "../SubNodeParser";
+import { BaseType } from "../Type/BaseType";
+import { ConstructorType } from "../Type/ConstructorType";
+
+/**
+ * A constructor node parser that creates a constructor type so that mapped
+ * types can use constructors as values. There is no formatter for constructor
+ * types.
+ */
+export class ConstructorNodeParser implements SubNodeParser {
+    public supportsNode(node: ts.ConstructorTypeNode): boolean {
+        return node.kind === ts.SyntaxKind.ConstructorType;
+    }
+    public createType(): BaseType {
+        return new ConstructorType();
+    }
+}

--- a/src/Type/ConstructorType.ts
+++ b/src/Type/ConstructorType.ts
@@ -1,0 +1,7 @@
+import { BaseType } from "./BaseType";
+
+export class ConstructorType extends BaseType {
+    public getId(): string {
+        return "constructor";
+    }
+}

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -8,7 +8,9 @@ import { createFormatter } from "../factory/formatter";
 import { createParser } from "../factory/parser";
 import { createProgram } from "../factory/program";
 import { Config } from "../src/Config";
+import { UnknownTypeError } from "../src/Error/UnknownTypeError";
 import { SchemaGenerator } from "../src/SchemaGenerator";
+import { BaseType } from "../src/Type/BaseType";
 
 const validator = new Ajv();
 addFormats(validator);
@@ -109,6 +111,16 @@ export function assertValidSchema(
                 }
                 expect(isValid).toBe(true);
             }
+        }
+    };
+}
+
+export function assertMissingFormatterFor(missingType: BaseType, relativePath: string, type?: string) {
+    return (): void => {
+        try {
+            assertValidSchema(relativePath, type)();
+        } catch (error) {
+            expect(error).toEqual(new UnknownTypeError(missingType));
         }
     };
 }

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -1,4 +1,5 @@
-import { assertValidSchema } from "./utils";
+import { ConstructorType } from "../src/Type/ConstructorType";
+import { assertMissingFormatterFor, assertValidSchema } from "./utils";
 
 describe("valid-data-type", () => {
     it("type-aliases-primitive", assertValidSchema("type-aliases-primitive", "MyString"));
@@ -121,6 +122,8 @@ describe("valid-data-type", () => {
     it("type-conditional-infer-rest", assertValidSchema("type-conditional-infer-rest", "MyType"));
     it("type-conditional-infer-tail-recursion", assertValidSchema("type-conditional-infer-tail-recursion", "MyType"));
     it("type-conditional-infer-tuple-xor", assertValidSchema("type-conditional-infer-tuple-xor", "MyType"));
+
+    it("type-constructor", assertMissingFormatterFor(new ConstructorType(), "type-constructor", "MyType"));
 
     it("type-tuple-nested-rest", assertValidSchema("type-tuple-nested-rest", "MyType"));
     it("type-tuple-nested-rest-to-union", assertValidSchema("type-tuple-nested-rest-to-union", "MyType"));

--- a/test/valid-data/type-constructor/main.ts
+++ b/test/valid-data/type-constructor/main.ts
@@ -1,0 +1,5 @@
+type MyConstructor = new () => any;
+
+export type MyType = {
+    a: MyConstructor;
+};


### PR DESCRIPTION
Hi again! Sorry for "spamming" with PRs - hope you find them useful.

This time I would like to propose a new parser for constructor types, kind of like what the package currently has for function nodes. And similarly to functions, there's no built-in formatter for constructors, so that's kind of up to the user. But it's still nice if the parsing doesn't fail when referencing a type which uses a constructor (even though we're actually not interested in the type at all and have excluded it using `Pick`). One example of such a type is React's `ReactElement` which has a `JSXElementConstructor`, quite similar to the test case I added.

I used the same `assertMissingFormatterFor` utility function as used in the previous PR (https://github.com/vega/ts-json-schema-generator/pull/1511)