### PR TITLE
fix: Handle multiple sourceless nodes

### DIFF
--- a/src/Utils/nodeKey.ts
+++ b/src/Utils/nodeKey.ts
@@ -36,10 +36,9 @@ export function getKey(node: Node, context: Context): string {
     while (node) {
         const source = node.getSourceFile();
 
-        // When the node has no source file, we use a random number as id.
-        // to prevent collisions with other sourceless nodes.
-        // As sourceless nodes does not have any kind of reference to them,
-        // Math.random is the best we can do to differentiate them.
+        // When the node has no source file, we need to prevent collisions  with other sourceless nodes.
+        // As they does not have any kind of reference to their parents, Math.random is the best we can
+        // do to make them unique
         if (!source) {
             ids.push(Math.random());
         } else {

--- a/src/Utils/nodeKey.ts
+++ b/src/Utils/nodeKey.ts
@@ -49,9 +49,12 @@ export function getKey(node: Node, context: Context): string {
         node = node.parent;
     }
 
-    const id = ids.join("-");
+    let id = ids.join("-");
+    const args = context.getArguments();
 
-    const argumentIds = context.getArguments().map((arg) => arg?.getId());
+    if (args.length) {
+        id += `<${args.map((arg) => arg.getId()).join(",")}>`;
+    }
 
-    return argumentIds.length ? `${id}<${argumentIds.join(",")}>` : id;
+    return id;
 }

--- a/src/Utils/nodeKey.ts
+++ b/src/Utils/nodeKey.ts
@@ -35,12 +35,17 @@ export function getKey(node: Node, context: Context): string {
 
     while (node) {
         const source = node.getSourceFile();
-        const file = !source
-            ? // TODO: Use better filename for unknown files (See #1386)
-              "unresolved"
-            : source.fileName.substring(process.cwd().length + 1).replace(/\//g, "_");
 
-        ids.push(hash(file), node.pos, node.end);
+        // When the node has no source file, we use a random number as id.
+        // to prevent collisions with other sourceless nodes.
+        // As sourceless nodes does not have any kind of reference to them,
+        // Math.random is the best we can do to differentiate them.
+        if (!source) {
+            ids.push(Math.random());
+        } else {
+            const filename = source.fileName.substring(process.cwd().length + 1).replace(/\//g, "_");
+            ids.push(hash(filename), node.pos, node.end);
+        }
 
         node = node.parent;
     }

--- a/test/sourceless-nodes/key/const.ts
+++ b/test/sourceless-nodes/key/const.ts
@@ -1,0 +1,23 @@
+import "./types1";
+import "./types2";
+
+// A super complex type that uses global scope, arrays and unions
+export const Value: {
+    a: number;
+    b: Test.GlobalType;
+    c: {
+        d: number;
+        e: string;
+        f: {
+            g: string;
+            h: string;
+        };
+        i: {
+            j: {
+                k: number;
+                l: string;
+                m: string | null;
+            };
+        }[];
+    };
+} = {} as any;

--- a/test/sourceless-nodes/key/index.test.ts
+++ b/test/sourceless-nodes/key/index.test.ts
@@ -1,0 +1,50 @@
+import path from "path";
+import ts from "typescript";
+import { createParser } from "../../../factory";
+import { Context } from "../../../src/NodeParser";
+import { DefinitionType } from "../../../src/Type/DefinitionType";
+import { ObjectType } from "../../../src/Type/ObjectType";
+
+const SOURCE = path.resolve(__dirname, "./source.ts");
+
+describe("multiple sourceless nodes shouldn't conflict", () => {
+    it("ensure all sourceless nodes have different ids", () => {
+        const program = ts.createProgram([SOURCE], {});
+        const parser = createParser(program, {});
+
+        // Finds the Typescript function declaration node
+        const source = program.getSourceFile(SOURCE);
+        const fn = source!.statements[2] as ts.FunctionDeclaration;
+
+        // Creates a sourceless type by inferring the function return type.
+        const inferredReturnType = getReturnType(fn, program.getTypeChecker());
+
+        // Checks that the inferred return type does not have any real source file.
+        expect(inferredReturnType.getSourceFile()).toBeUndefined();
+
+        const createdType = parser.createType(inferredReturnType, new Context(inferredReturnType)) as DefinitionType;
+
+        expect(createdType).toBeInstanceOf(DefinitionType);
+
+        const returnType = createdType.getType() as ObjectType;
+
+        expect(returnType).toBeInstanceOf(ObjectType);
+
+        const ids = [returnType.getId()];
+
+        for (const property of returnType.getProperties()) {
+            ids.push(property.getType().getId());
+        }
+
+        // Ensures all generated ids are unique
+        expect(ids).toStrictEqual(Array(...new Set(ids)));
+    });
+});
+
+// github.com/kitajs/kitajs/blob/1d1ae58c96c9a35cc426206f4fb19344be1cd3aa/packages/generator/src/util/node.ts#L44
+function getReturnType(node: ts.SignatureDeclaration, typeChecker: ts.TypeChecker) {
+    const signature = typeChecker.getSignatureFromDeclaration(node);
+    const implicitType = typeChecker.getReturnTypeOfSignature(signature!);
+
+    return typeChecker.typeToTypeNode(implicitType, undefined, ts.NodeBuilderFlags.NoTruncation) as ts.TypeNode;
+}

--- a/test/sourceless-nodes/key/source.ts
+++ b/test/sourceless-nodes/key/source.ts
@@ -1,0 +1,14 @@
+import { Value } from "./const";
+import { B } from "./types1";
+
+export async function withSemiInferredReturnType() {
+    return {
+        a: {
+            b: Value.c.d,
+            c: Value.c.e,
+        },
+        d: Value.c.i[0]!.j,
+        e: Value.c.f,
+        f: Value.b as B[],
+    };
+}

--- a/test/sourceless-nodes/key/types1.ts
+++ b/test/sourceless-nodes/key/types1.ts
@@ -1,0 +1,3 @@
+export type A = 1;
+export type B = 2;
+export type C = 3;

--- a/test/sourceless-nodes/key/types2.ts
+++ b/test/sourceless-nodes/key/types2.ts
@@ -1,0 +1,9 @@
+import { A, B, C } from "./types1";
+
+// Uses global scope to test for types without direct import
+declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    namespace Test {
+        type GlobalType = A | B[] | C;
+    }
+}


### PR DESCRIPTION
Hello @domoritz, it's me again 🤡👍

At #1386 I let a todo to resolve later because I didn't think that it would impact on anything.

https://github.com/vega/ts-json-schema-generator/blob/b428d2d625669c7349bf210111d35249aa833c83/src/Utils/nodeKey.ts#L38-L40

Seems out that we can have conflicts with sourceless nodes for objects with deep properties. And by conflicts I mean different types having the same ID, overriding each other when joining definitions.

This PR introduces the fix and a very deep test case for it.

_P.S. Would you release as soon as you can? I have two a critical issue waiting for this 😁_
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v1.2.1-next.1`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Grant Dickinson ([@grant-d](https://github.com/grant-d)), for all your work!
  
  #### 🐛 Bug Fix
  
  - fix: Handle multiple sourceless nodes [#1545](https://github.com/vega/ts-json-schema-generator/pull/1545) ([@arthurfiorette](https://github.com/arthurfiorette))
  - fix: imported string-key loses annotations [#1293](https://github.com/vega/ts-json-schema-generator/pull/1293) ([@grant-d](https://github.com/grant-d) p-spacek@email.cz)
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump @typescript-eslint/parser from 5.48.1 to 5.48.2 [#1540](https://github.com/vega/ts-json-schema-generator/pull/1540) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.48.1 to 5.48.2 [#1541](https://github.com/vega/ts-json-schema-generator/pull/1541) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 29.2.5 to 29.2.6 [#1542](https://github.com/vega/ts-json-schema-generator/pull/1542) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/glob from 8.0.0 to 8.0.1 [#1543](https://github.com/vega/ts-json-schema-generator/pull/1543) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 9.5.0 to 10.0.0 [#1538](https://github.com/vega/ts-json-schema-generator/pull/1538) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.48.0 to 5.48.1 [#1534](https://github.com/vega/ts-json-schema-generator/pull/1534) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.8.2 to 2.8.3 [#1533](https://github.com/vega/ts-json-schema-generator/pull/1533) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.31.0 to 8.32.0 [#1535](https://github.com/vega/ts-json-schema-generator/pull/1535) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.48.0 to 5.48.1 [#1536](https://github.com/vega/ts-json-schema-generator/pull/1536) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump glob from 8.0.3 to 8.1.0 [#1537](https://github.com/vega/ts-json-schema-generator/pull/1537) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.47.1 to 5.48.0 [#1524](https://github.com/vega/ts-json-schema-generator/pull/1524) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 8.5.0 to 8.6.0 [#1525](https://github.com/vega/ts-json-schema-generator/pull/1525) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.47.1 to 5.48.0 [#1526](https://github.com/vega/ts-json-schema-generator/pull/1526) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv from 8.11.2 to 8.12.0 [#1527](https://github.com/vega/ts-json-schema-generator/pull/1527) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 9.4.1 to 9.5.0 [#1528](https://github.com/vega/ts-json-schema-generator/pull/1528) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.8.1 to 2.8.2 [#1529](https://github.com/vega/ts-json-schema-generator/pull/1529) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.20.7 to 7.20.12 [#1530](https://github.com/vega/ts-json-schema-generator/pull/1530) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.47.0 to 5.47.1 [#1520](https://github.com/vega/ts-json-schema-generator/pull/1520) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump safe-stable-stringify from 2.4.1 to 2.4.2 [#1517](https://github.com/vega/ts-json-schema-generator/pull/1517) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 29.2.4 to 29.2.5 [#1518](https://github.com/vega/ts-json-schema-generator/pull/1518) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump json5 from 2.2.2 to 2.2.3 [#1519](https://github.com/vega/ts-json-schema-generator/pull/1519) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 18.11.17 to 18.11.18 [#1521](https://github.com/vega/ts-json-schema-generator/pull/1521) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.47.0 to 5.47.1 [#1522](https://github.com/vega/ts-json-schema-generator/pull/1522) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.30.0 to 8.31.0 [#1523](https://github.com/vega/ts-json-schema-generator/pull/1523) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.46.1 to 5.47.0 [#1514](https://github.com/vega/ts-json-schema-generator/pull/1514) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.46.1 to 5.47.0 [#1515](https://github.com/vega/ts-json-schema-generator/pull/1515) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.20.5 to 7.20.7 [#1516](https://github.com/vega/ts-json-schema-generator/pull/1516) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 4
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Arthur Fiorette ([@arthurfiorette](https://github.com/arthurfiorette))
  - Grant Dickinson ([@grant-d](https://github.com/grant-d))
  - Petr Spacek (p-spacek@email.cz)
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
