### PR TITLE
bug: Identifiers can't be parsed cross module boundaries

### DIFF
--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -49,6 +49,7 @@ describe("valid-data-other", () => {
     it("import-exposed", assertValidSchema("import-exposed", "MyObject"));
     it("import-internal", assertValidSchema("import-internal", "MyObject", "basic"));
     it("import-anonymous", assertValidSchema("import-anonymous", "MyObject"));
+    it.only("import-identifier", assertValidSchema("import-identifier", "MyObject"));
 
     it("generic-simple", assertValidSchema("generic-simple", "MyObject"));
     it("generic-arrays", assertValidSchema("generic-arrays", "MyObject"));

--- a/test/valid-data/import-identifier/main.ts
+++ b/test/valid-data/import-identifier/main.ts
@@ -1,0 +1,7 @@
+import { x } from "./module";
+
+type Identifier = typeof x;
+
+export interface MyObject {
+    field: Identifier;
+}

--- a/test/valid-data/import-identifier/module.ts
+++ b/test/valid-data/import-identifier/module.ts
@@ -1,0 +1,5 @@
+const y = "hello";
+
+export const x = {
+    z: y,
+};

--- a/test/valid-data/import-identifier/schema.json
+++ b/test/valid-data/import-identifier/schema.json
@@ -1,0 +1,22 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "$ref": "#/definitions/Identifier"
+        }
+      },
+      "required": [
+        "field"
+      ],
+      "type": "object"
+    },
+    "Identifier": {
+      "type": "number",
+      "const": 10
+    }
+  }
+}


### PR DESCRIPTION
This is a minimal reproduction of existing behavior around the `NodeParser` throwing an `UnknownNodeError` for valid in scope identifiers.

eg.

```
// module.ts
const y = "hello";

export const x = {
    z: y,
};
// main.ts
import { x } from "./module";

type Identifier = typeof x;

export interface MyObject {
    field: Identifier;
}

```

Error:
> Unknown node " y" of kind "Identifier"

My expectation of is that this would be able to be parsed - as this kind of type inference via an identifier is a common use case.