### PR TITLE
fix: support indexed circular access

### DIFF
--- a/src/NodeParser/IndexedAccessTypeNodeParser.ts
+++ b/src/NodeParser/IndexedAccessTypeNodeParser.ts
@@ -6,6 +6,7 @@ import { BaseType } from "../Type/BaseType";
 import { LiteralType } from "../Type/LiteralType";
 import { NeverType } from "../Type/NeverType";
 import { NumberType } from "../Type/NumberType";
+import { ReferenceType } from "../Type/ReferenceType";
 import { StringType } from "../Type/StringType";
 import { TupleType } from "../Type/TupleType";
 import { UnionType } from "../Type/UnionType";
@@ -67,6 +68,9 @@ export class IndexedAccessTypeNodeParser implements SubNodeParser {
                 if (type instanceof NumberType && objectType instanceof TupleType) {
                     return new UnionType(objectType.getTypes());
                 } else if (type instanceof LiteralType) {
+                    if (objectType instanceof ReferenceType) {
+                        return objectType;
+                    }
                     throw new LogicError(`Invalid index "${type.getValue()}" in type "${objectType.getId()}"`);
                 } else {
                     throw new LogicError(`No additional properties in type "${objectType.getId()}"`);

--- a/src/Type/ReferenceType.ts
+++ b/src/Type/ReferenceType.ts
@@ -36,6 +36,10 @@ export class ReferenceType extends BaseType {
         return this.type;
     }
 
+    public hasType(): boolean {
+        return this.type != null;
+    }
+
     public setType(type: BaseType): void {
         this.type = type;
         this.setId(type.getId());

--- a/src/Utils/derefType.ts
+++ b/src/Utils/derefType.ts
@@ -4,13 +4,14 @@ import { BaseType } from "../Type/BaseType";
 import { DefinitionType } from "../Type/DefinitionType";
 import { ReferenceType } from "../Type/ReferenceType";
 
+/**
+ * Dereference the type as far as possible.
+ */
 export function derefType(type: BaseType): BaseType {
-    if (
-        type instanceof ReferenceType ||
-        type instanceof DefinitionType ||
-        type instanceof AliasType ||
-        type instanceof AnnotatedType
-    ) {
+    if (type instanceof DefinitionType || type instanceof AliasType || type instanceof AnnotatedType) {
+        return derefType(type.getType());
+    }
+    if (type instanceof ReferenceType && type.hasType()) {
         return derefType(type.getType());
     }
 

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -82,6 +82,7 @@ describe("valid-data-type", () => {
         assertMissingFormatterFor(new FunctionType(), "type-indexed-access-method-signature", "MyType")
     );
     it("type-indexed-circular-access", assertValidSchema("type-indexed-circular-access", "*"));
+    it("type-indexed-circular", assertValidSchema("type-indexed-circular", "MyType"));
     it("type-keyof-tuple", assertValidSchema("type-keyof-tuple", "MyType"));
     it("type-keyof-object", assertValidSchema("type-keyof-object", "MyType"));
     it("type-keyof-object-function", assertValidSchema("type-keyof-object-function", "MyType"));

--- a/test/valid-data/string-template-expression-literals/schema.json
+++ b/test/valid-data/string-template-expression-literals/schema.json
@@ -13,6 +13,13 @@
           ],
           "type": "string"
         },
+        "bool": {
+          "enum": [
+            "true!",
+            "false!"
+          ],
+          "type": "string"
+        },
         "foo": {
           "enum": [
             "ok",
@@ -21,15 +28,11 @@
           ],
           "type": "string"
         },
-        "ok": {
-          "const": "id_ok",
-          "type": "string"
-        },
         "num": {
           "type": "string"
         },
-        "bool": {
-          "enum": ["true!", "false!"],
+        "ok": {
+          "const": "id_ok",
           "type": "string"
         }
       },

--- a/test/valid-data/type-indexed-circular/main.ts
+++ b/test/valid-data/type-indexed-circular/main.ts
@@ -1,0 +1,9 @@
+export interface GeoJsonObject {
+    type: GeometryCollection["type"];
+}
+
+export interface GeometryCollection extends GeoJsonObject {
+    type: "GeometryCollection";
+}
+
+export type MyType = GeometryCollection;

--- a/test/valid-data/type-indexed-circular/schema.json
+++ b/test/valid-data/type-indexed-circular/schema.json
@@ -1,0 +1,22 @@
+{
+  "$ref": "#/definitions/MyType",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "GeometryCollection": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "GeometryCollection",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "MyType": {
+      "$ref": "#/definitions/GeometryCollection"
+    }
+  }
+}

--- a/test/vega-lite.test.ts
+++ b/test/vega-lite.test.ts
@@ -6,16 +6,15 @@ import stringify from "safe-stable-stringify";
 
 describe("vega-lite", () => {
     it("schema", () => {
-        const type = "TopLevelSpec";
         const config: Config = {
             path: `node_modules/vega-lite/src/index.ts`,
-            type,
+            type: "TopLevelSpec",
             encodeRefs: false,
             skipTypeCheck: true,
         };
 
         const generator = createGenerator(config);
-        const schema = generator.createSchema(type);
+        const schema = generator.createSchema(config.type);
         const schemaFile = resolve("test/vega-lite/schema.json");
 
         if (process.env.UPDATE_SCHEMA) {


### PR DESCRIPTION
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.1--canary.1593.a1dc8a7.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install ts-json-schema-generator@1.2.1--canary.1593.a1dc8a7.0
  # or 
  yarn add ts-json-schema-generator@1.2.1--canary.1593.a1dc8a7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

fixes https://github.com/vega/ts-json-schema-generator/issues/1276
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v1.3.0-next.2`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: Mario DeSousa ([@mdesousa](https://github.com/mdesousa))
  
  :heart: Grant Dickinson ([@grant-d](https://github.com/grant-d))
  
  #### 🚀 Enhancement
  
  - fix: support indexed circular access [#1593](https://github.com/vega/ts-json-schema-generator/pull/1593) ([@domoritz](https://github.com/domoritz))
  - feat: add `discriminatorOpenApi` tag to generate `discriminator` schemas [#1572](https://github.com/vega/ts-json-schema-generator/pull/1572) ([@mdesousa](https://github.com/mdesousa))
  
  #### 🐛 Bug Fix
  
  - chore: assertValidSchema should take config as argument [#1578](https://github.com/vega/ts-json-schema-generator/pull/1578) ([@mdesousa](https://github.com/mdesousa))
  - fix: errors for sourceless nodes [#1552](https://github.com/vega/ts-json-schema-generator/pull/1552) ([@arthurfiorette](https://github.com/arthurfiorette))
  - style: simplify return [#1546](https://github.com/vega/ts-json-schema-generator/pull/1546) ([@domoritz](https://github.com/domoritz))
  - fix: Handle multiple sourceless nodes [#1545](https://github.com/vega/ts-json-schema-generator/pull/1545) ([@arthurfiorette](https://github.com/arthurfiorette))
  - fix: imported string-key loses annotations [#1293](https://github.com/vega/ts-json-schema-generator/pull/1293) ([@grant-d](https://github.com/grant-d) p-spacek@email.cz)
  
  #### ⚠️ Pushed to `next`
  
  - Revert "chore(deps-dev): bump vega from 5.22.1 to 5.23.0 (#1592)" ([@domoritz](https://github.com/domoritz))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump vega from 5.22.1 to 5.23.0 [#1592](https://github.com/vega/ts-json-schema-generator/pull/1592) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.42.0 to 10.42.2 [#1583](https://github.com/vega/ts-json-schema-generator/pull/1583) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.52.0 to 5.53.0 [#1586](https://github.com/vega/ts-json-schema-generator/pull/1586) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 18.14.0 to 18.14.1 [#1582](https://github.com/vega/ts-json-schema-generator/pull/1582) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/glob from 8.0.1 to 8.1.0 [#1584](https://github.com/vega/ts-json-schema-generator/pull/1584) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.20.12 to 7.21.0 [#1585](https://github.com/vega/ts-json-schema-generator/pull/1585) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.18.6 to 7.21.0 [#1587](https://github.com/vega/ts-json-schema-generator/pull/1587) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.42.0 to 10.42.2 [#1588](https://github.com/vega/ts-json-schema-generator/pull/1588) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.52.0 to 5.53.0 [#1589](https://github.com/vega/ts-json-schema-generator/pull/1589) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.42.0 to 10.42.2 [#1590](https://github.com/vega/ts-json-schema-generator/pull/1590) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.51.0 to 5.52.0 [#1573](https://github.com/vega/ts-json-schema-generator/pull/1573) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 18.13.0 to 18.14.0 [#1574](https://github.com/vega/ts-json-schema-generator/pull/1574) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 29.4.2 to 29.4.3 [#1575](https://github.com/vega/ts-json-schema-generator/pull/1575) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.51.0 to 5.52.0 [#1576](https://github.com/vega/ts-json-schema-generator/pull/1576) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.50.0 to 5.51.0 [#1563](https://github.com/vega/ts-json-schema-generator/pull/1563) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.38.5 to 10.42.0 [#1564](https://github.com/vega/ts-json-schema-generator/pull/1564) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 18.11.19 to 18.13.0 [#1565](https://github.com/vega/ts-json-schema-generator/pull/1565) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.8.3 to 2.8.4 [#1566](https://github.com/vega/ts-json-schema-generator/pull/1566) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.33.0 to 8.34.0 [#1567](https://github.com/vega/ts-json-schema-generator/pull/1567) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.50.0 to 5.51.0 [#1568](https://github.com/vega/ts-json-schema-generator/pull/1568) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 29.4.1 to 29.4.2 [#1569](https://github.com/vega/ts-json-schema-generator/pull/1569) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.38.5 to 10.42.0 [#1562](https://github.com/vega/ts-json-schema-generator/pull/1562) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.38.5 to 10.42.0 [#1570](https://github.com/vega/ts-json-schema-generator/pull/1570) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.49.0 to 5.50.0 [#1553](https://github.com/vega/ts-json-schema-generator/pull/1553) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.37.6 to 10.38.5 [#1555](https://github.com/vega/ts-json-schema-generator/pull/1555) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.37.6 to 10.38.5 [#1556](https://github.com/vega/ts-json-schema-generator/pull/1556) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.9.4 to 4.9.5 [#1554](https://github.com/vega/ts-json-schema-generator/pull/1554) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 18.11.18 to 18.11.19 [#1557](https://github.com/vega/ts-json-schema-generator/pull/1557) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.37.6 to 10.38.5 [#1558](https://github.com/vega/ts-json-schema-generator/pull/1558) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.49.0 to 5.50.0 [#1559](https://github.com/vega/ts-json-schema-generator/pull/1559) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.48.2 to 5.49.0 [#1549](https://github.com/vega/ts-json-schema-generator/pull/1549) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.32.0 to 8.33.0 [#1547](https://github.com/vega/ts-json-schema-generator/pull/1547) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 29.3.1 to 29.4.1 [#1548](https://github.com/vega/ts-json-schema-generator/pull/1548) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.48.2 to 5.49.0 [#1550](https://github.com/vega/ts-json-schema-generator/pull/1550) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.48.1 to 5.48.2 [#1540](https://github.com/vega/ts-json-schema-generator/pull/1540) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.48.1 to 5.48.2 [#1541](https://github.com/vega/ts-json-schema-generator/pull/1541) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 29.2.5 to 29.2.6 [#1542](https://github.com/vega/ts-json-schema-generator/pull/1542) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/glob from 8.0.0 to 8.0.1 [#1543](https://github.com/vega/ts-json-schema-generator/pull/1543) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 9.5.0 to 10.0.0 [#1538](https://github.com/vega/ts-json-schema-generator/pull/1538) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.48.0 to 5.48.1 [#1534](https://github.com/vega/ts-json-schema-generator/pull/1534) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.8.2 to 2.8.3 [#1533](https://github.com/vega/ts-json-schema-generator/pull/1533) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.31.0 to 8.32.0 [#1535](https://github.com/vega/ts-json-schema-generator/pull/1535) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.48.0 to 5.48.1 [#1536](https://github.com/vega/ts-json-schema-generator/pull/1536) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump glob from 8.0.3 to 8.1.0 [#1537](https://github.com/vega/ts-json-schema-generator/pull/1537) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.47.1 to 5.48.0 [#1524](https://github.com/vega/ts-json-schema-generator/pull/1524) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 8.5.0 to 8.6.0 [#1525](https://github.com/vega/ts-json-schema-generator/pull/1525) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.47.1 to 5.48.0 [#1526](https://github.com/vega/ts-json-schema-generator/pull/1526) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv from 8.11.2 to 8.12.0 [#1527](https://github.com/vega/ts-json-schema-generator/pull/1527) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 9.4.1 to 9.5.0 [#1528](https://github.com/vega/ts-json-schema-generator/pull/1528) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.8.1 to 2.8.2 [#1529](https://github.com/vega/ts-json-schema-generator/pull/1529) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.20.7 to 7.20.12 [#1530](https://github.com/vega/ts-json-schema-generator/pull/1530) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.47.0 to 5.47.1 [#1520](https://github.com/vega/ts-json-schema-generator/pull/1520) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump safe-stable-stringify from 2.4.1 to 2.4.2 [#1517](https://github.com/vega/ts-json-schema-generator/pull/1517) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 29.2.4 to 29.2.5 [#1518](https://github.com/vega/ts-json-schema-generator/pull/1518) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump json5 from 2.2.2 to 2.2.3 [#1519](https://github.com/vega/ts-json-schema-generator/pull/1519) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 18.11.17 to 18.11.18 [#1521](https://github.com/vega/ts-json-schema-generator/pull/1521) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.47.0 to 5.47.1 [#1522](https://github.com/vega/ts-json-schema-generator/pull/1522) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.30.0 to 8.31.0 [#1523](https://github.com/vega/ts-json-schema-generator/pull/1523) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.46.1 to 5.47.0 [#1514](https://github.com/vega/ts-json-schema-generator/pull/1514) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.46.1 to 5.47.0 [#1515](https://github.com/vega/ts-json-schema-generator/pull/1515) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.20.5 to 7.20.7 [#1516](https://github.com/vega/ts-json-schema-generator/pull/1516) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 6
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Arthur Fiorette ([@arthurfiorette](https://github.com/arthurfiorette))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
  - Grant Dickinson ([@grant-d](https://github.com/grant-d))
  - Mario DeSousa ([@mdesousa](https://github.com/mdesousa))
  - Petr Spacek (p-spacek@email.cz)
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
