### PR TITLE
fix: add DefinitionTypes to extractLiterals()

### DIFF
--- a/src/Utils/extractLiterals.ts
+++ b/src/Utils/extractLiterals.ts
@@ -2,6 +2,7 @@ import { UnknownTypeError } from "../Error/UnknownTypeError";
 import { AliasType } from "../Type/AliasType";
 import { BaseType } from "../Type/BaseType";
 import { BooleanType } from "../Type/BooleanType";
+import { DefinitionType } from "../Type/DefinitionType";
 import { EnumType } from "../Type/EnumType";
 import { LiteralType } from "../Type/LiteralType";
 import { UnionType } from "../Type/UnionType";
@@ -20,7 +21,7 @@ function* _extractLiterals(type: BaseType): Iterable<string> {
         }
         return;
     }
-    if (type instanceof AliasType) {
+    if (type instanceof AliasType || type instanceof DefinitionType) {
         yield* _extractLiterals(type.getType());
         return;
     }

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -41,6 +41,10 @@ describe("valid-data-other", () => {
     it("string-literals-null", assertValidSchema("string-literals-null", "MyObject"));
     it("string-template-literals", assertValidSchema("string-template-literals", "MyObject"));
     it("string-template-expression-literals", assertValidSchema("string-template-expression-literals", "MyObject"));
+    it(
+        "string-template-expression-literals-import",
+        assertValidSchema("string-template-expression-literals-import", "MyObject")
+    );
 
     it("namespace-deep-1", assertValidSchema("namespace-deep-1", "RootNamespace.Def"));
     it("namespace-deep-2", assertValidSchema("namespace-deep-2", "RootNamespace.SubNamespace.HelperA"));

--- a/test/valid-data/string-template-expression-literals-import/main.ts
+++ b/test/valid-data/string-template-expression-literals-import/main.ts
@@ -1,0 +1,5 @@
+import { MyType } from './types';
+
+export interface MyObject {
+    value: `_${MyType}`;
+}

--- a/test/valid-data/string-template-expression-literals-import/schema.json
+++ b/test/valid-data/string-template-expression-literals-import/schema.json
@@ -1,0 +1,23 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "enum": [
+            "_one",
+            "_two",
+            "_three"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/test/valid-data/string-template-expression-literals-import/types.ts
+++ b/test/valid-data/string-template-expression-literals-import/types.ts
@@ -1,0 +1,1 @@
+export type MyType = 'one' | 'two' | 'three';


### PR DESCRIPTION
Fixes  #1716.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v1.3.0-next.7`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: Chris ([@cengels](https://github.com/cengels))
  
  :heart: Grigas ([@grigasp](https://github.com/grigasp))
  
  :heart: Mario DeSousa ([@mdesousa](https://github.com/mdesousa))
  
  :heart: Grant Dickinson ([@grant-d](https://github.com/grant-d))
  
  #### 🚀 Enhancement
  
  - feat: update to ts 5 [#1612](https://github.com/vega/ts-json-schema-generator/pull/1612) ([@domoritz](https://github.com/domoritz))
  - fix: support indexed circular access [#1593](https://github.com/vega/ts-json-schema-generator/pull/1593) ([@domoritz](https://github.com/domoritz))
  - feat: add `discriminatorOpenApi` tag to generate `discriminator` schemas [#1572](https://github.com/vega/ts-json-schema-generator/pull/1572) ([@mdesousa](https://github.com/mdesousa))
  
  #### 🐛 Bug Fix
  
  - fix: add DefinitionTypes to extractLiterals() [#1717](https://github.com/vega/ts-json-schema-generator/pull/1717) ([@cengels](https://github.com/cengels))
  - chore: upgrade deps [#1710](https://github.com/vega/ts-json-schema-generator/pull/1710) ([@domoritz](https://github.com/domoritz))
  - fix: downgrade glob ([@domoritz](https://github.com/domoritz))
  - fix: Support `enum` type discriminators when using the `@discriminator` annotation [#1683](https://github.com/vega/ts-json-schema-generator/pull/1683) ([@daanboer](https://github.com/daanboer))
  - fix: support enum template literals [#1637](https://github.com/vega/ts-json-schema-generator/pull/1637) ([@grigasp](https://github.com/grigasp))
  - chore: assertValidSchema should take config as argument [#1578](https://github.com/vega/ts-json-schema-generator/pull/1578) ([@mdesousa](https://github.com/mdesousa))
  - fix: errors for sourceless nodes [#1552](https://github.com/vega/ts-json-schema-generator/pull/1552) ([@arthurfiorette](https://github.com/arthurfiorette))
  - style: simplify return [#1546](https://github.com/vega/ts-json-schema-generator/pull/1546) ([@domoritz](https://github.com/domoritz))
  - fix: Handle multiple sourceless nodes [#1545](https://github.com/vega/ts-json-schema-generator/pull/1545) ([@arthurfiorette](https://github.com/arthurfiorette))
  - fix: imported string-key loses annotations [#1293](https://github.com/vega/ts-json-schema-generator/pull/1293) ([@grant-d](https://github.com/grant-d) p-spacek@email.cz)
  
  #### ⚠️ Pushed to `next`
  
  - ci: remove pr limit ([@domoritz](https://github.com/domoritz))
  - chore: upgrade deps ([@domoritz](https://github.com/domoritz))
  - Revert "chore(deps-dev): bump vega from 5.22.1 to 5.23.0 (#1592)" ([@domoritz](https://github.com/domoritz))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.60.0 to 5.60.1 [#1714](https://github.com/vega/ts-json-schema-generator/pull/1714) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.43.0 to 8.44.0 [#1712](https://github.com/vega/ts-json-schema-generator/pull/1712) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.60.0 to 5.60.1 [#1713](https://github.com/vega/ts-json-schema-generator/pull/1713) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 20.3.1 to 20.3.3 [#1715](https://github.com/vega/ts-json-schema-generator/pull/1715) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.59.11 to 5.60.0 [#1706](https://github.com/vega/ts-json-schema-generator/pull/1706) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.42.0 to 8.43.0 [#1707](https://github.com/vega/ts-json-schema-generator/pull/1707) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.59.11 to 5.60.0 [#1708](https://github.com/vega/ts-json-schema-generator/pull/1708) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 10.0.1 to 11.0.0 [#1700](https://github.com/vega/ts-json-schema-generator/pull/1700) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.59.9 to 5.59.11 [#1702](https://github.com/vega/ts-json-schema-generator/pull/1702) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 20.2.5 to 20.3.1 [#1701](https://github.com/vega/ts-json-schema-generator/pull/1701) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.59.8 to 5.59.11 [#1703](https://github.com/vega/ts-json-schema-generator/pull/1703) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.22.4 to 7.22.5 [#1696](https://github.com/vega/ts-json-schema-generator/pull/1696) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.22.1 to 7.22.5 [#1698](https://github.com/vega/ts-json-schema-generator/pull/1698) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.59.8 to 5.59.9 [#1697](https://github.com/vega/ts-json-schema-generator/pull/1697) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.21.5 to 7.22.5 [#1699](https://github.com/vega/ts-json-schema-generator/pull/1699) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.41.0 to 8.42.0 [#1692](https://github.com/vega/ts-json-schema-generator/pull/1692) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 29.5.1 to 29.5.2 [#1693](https://github.com/vega/ts-json-schema-generator/pull/1693) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.59.7 to 5.59.8 [#1694](https://github.com/vega/ts-json-schema-generator/pull/1694) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.22.2 to 7.22.4 [#1695](https://github.com/vega/ts-json-schema-generator/pull/1695) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.59.6 to 5.59.7 [#1684](https://github.com/vega/ts-json-schema-generator/pull/1684) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.21.8 to 7.22.1 [#1687](https://github.com/vega/ts-json-schema-generator/pull/1687) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump @types/json-schema from 7.0.11 to 7.0.12 [#1685](https://github.com/vega/ts-json-schema-generator/pull/1685) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.59.6 to 5.59.7 [#1686](https://github.com/vega/ts-json-schema-generator/pull/1686) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.21.5 to 7.22.2 [#1688](https://github.com/vega/ts-json-schema-generator/pull/1688) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 20.2.1 to 20.2.5 [#1689](https://github.com/vega/ts-json-schema-generator/pull/1689) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.59.5 to 5.59.6 [#1678](https://github.com/vega/ts-json-schema-generator/pull/1678) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 20.1.4 to 20.2.1 [#1677](https://github.com/vega/ts-json-schema-generator/pull/1677) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.40.0 to 8.41.0 [#1679](https://github.com/vega/ts-json-schema-generator/pull/1679) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.59.5 to 5.59.6 [#1680](https://github.com/vega/ts-json-schema-generator/pull/1680) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.59.2 to 5.59.5 [#1673](https://github.com/vega/ts-json-schema-generator/pull/1673) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 20.1.0 to 20.1.4 [#1674](https://github.com/vega/ts-json-schema-generator/pull/1674) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.59.2 to 5.59.5 [#1675](https://github.com/vega/ts-json-schema-generator/pull/1675) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 18.16.3 to 20.1.0 [#1667](https://github.com/vega/ts-json-schema-generator/pull/1667) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.59.0 to 5.59.2 [#1666](https://github.com/vega/ts-json-schema-generator/pull/1666) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.45.0 to 10.46.0 [#1664](https://github.com/vega/ts-json-schema-generator/pull/1664) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.45.0 to 10.46.0 [#1665](https://github.com/vega/ts-json-schema-generator/pull/1665) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.21.5 to 7.21.8 [#1668](https://github.com/vega/ts-json-schema-generator/pull/1668) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.59.1 to 5.59.2 [#1670](https://github.com/vega/ts-json-schema-generator/pull/1670) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.39.0 to 8.40.0 [#1671](https://github.com/vega/ts-json-schema-generator/pull/1671) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega from 5.22.1 to 5.25.0 [#1660](https://github.com/vega/ts-json-schema-generator/pull/1660) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@domoritz](https://github.com/domoritz))
  - chore(deps-dev): bump @babel/core from 7.21.4 to 7.21.5 [#1655](https://github.com/vega/ts-json-schema-generator/pull/1655) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.21.4 to 7.21.5 [#1657](https://github.com/vega/ts-json-schema-generator/pull/1657) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 18.15.11 to 18.16.3 [#1654](https://github.com/vega/ts-json-schema-generator/pull/1654) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.38.0 to 8.39.0 [#1656](https://github.com/vega/ts-json-schema-generator/pull/1656) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.45.0 to 10.46.0 [#1658](https://github.com/vega/ts-json-schema-generator/pull/1658) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.59.0 to 5.59.1 [#1659](https://github.com/vega/ts-json-schema-generator/pull/1659) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.21.4 to 7.21.5 [#1661](https://github.com/vega/ts-json-schema-generator/pull/1661) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.44.0 to 10.45.0 [#1647](https://github.com/vega/ts-json-schema-generator/pull/1647) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.58.0 to 5.59.0 [#1649](https://github.com/vega/ts-json-schema-generator/pull/1649) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.44.0 to 10.45.0 [#1650](https://github.com/vega/ts-json-schema-generator/pull/1650) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 29.5.0 to 29.5.1 [#1648](https://github.com/vega/ts-json-schema-generator/pull/1648) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.44.0 to 10.45.0 [#1651](https://github.com/vega/ts-json-schema-generator/pull/1651) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.58.0 to 5.59.0 [#1652](https://github.com/vega/ts-json-schema-generator/pull/1652) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.8.7 to 2.8.8 [#1653](https://github.com/vega/ts-json-schema-generator/pull/1653) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest-junit from 15.0.0 to 16.0.0 [#1643](https://github.com/vega/ts-json-schema-generator/pull/1643) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.57.1 to 5.58.0 [#1639](https://github.com/vega/ts-json-schema-generator/pull/1639) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.43.0 to 10.44.0 [#1638](https://github.com/vega/ts-json-schema-generator/pull/1638) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 10.0.0 to 10.0.1 [#1640](https://github.com/vega/ts-json-schema-generator/pull/1640) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.57.1 to 5.58.0 [#1641](https://github.com/vega/ts-json-schema-generator/pull/1641) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.57.0 to 5.57.1 [#1632](https://github.com/vega/ts-json-schema-generator/pull/1632) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 18.15.10 to 18.15.11 [#1633](https://github.com/vega/ts-json-schema-generator/pull/1633) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.43.0 to 10.44.0 [#1627](https://github.com/vega/ts-json-schema-generator/pull/1627) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.43.0 to 10.44.0 [#1628](https://github.com/vega/ts-json-schema-generator/pull/1628) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.57.0 to 5.57.1 [#1629](https://github.com/vega/ts-json-schema-generator/pull/1629) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.37.0 to 8.38.0 [#1630](https://github.com/vega/ts-json-schema-generator/pull/1630) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 5.0.3 to 5.0.4 [#1631](https://github.com/vega/ts-json-schema-generator/pull/1631) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.56.0 to 5.57.0 [#1620](https://github.com/vega/ts-json-schema-generator/pull/1620) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.21.0 to 7.21.4 [#1621](https://github.com/vega/ts-json-schema-generator/pull/1621) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.21.3 to 7.21.4 [#1622](https://github.com/vega/ts-json-schema-generator/pull/1622) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.36.0 to 8.37.0 [#1623](https://github.com/vega/ts-json-schema-generator/pull/1623) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.20.2 to 7.21.4 [#1624](https://github.com/vega/ts-json-schema-generator/pull/1624) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 5.0.2 to 5.0.3 [#1625](https://github.com/vega/ts-json-schema-generator/pull/1625) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.56.0 to 5.57.0 [#1626](https://github.com/vega/ts-json-schema-generator/pull/1626) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.55.0 to 5.56.0 [#1613](https://github.com/vega/ts-json-schema-generator/pull/1613) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 8.7.0 to 8.8.0 [#1614](https://github.com/vega/ts-json-schema-generator/pull/1614) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 18.15.3 to 18.15.10 [#1615](https://github.com/vega/ts-json-schema-generator/pull/1615) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump safe-stable-stringify from 2.4.2 to 2.4.3 [#1616](https://github.com/vega/ts-json-schema-generator/pull/1616) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.55.0 to 5.56.0 [#1617](https://github.com/vega/ts-json-schema-generator/pull/1617) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.8.4 to 2.8.7 [#1618](https://github.com/vega/ts-json-schema-generator/pull/1618) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.54.0 to 5.54.1 [#1609](https://github.com/vega/ts-json-schema-generator/pull/1609) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 8.6.0 to 8.7.0 [#1605](https://github.com/vega/ts-json-schema-generator/pull/1605) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 29.4.3 to 29.5.0 [#1606](https://github.com/vega/ts-json-schema-generator/pull/1606) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.35.0 to 8.36.0 [#1607](https://github.com/vega/ts-json-schema-generator/pull/1607) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 18.14.6 to 18.15.0 [#1608](https://github.com/vega/ts-json-schema-generator/pull/1608) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.54.0 to 5.54.1 [#1611](https://github.com/vega/ts-json-schema-generator/pull/1611) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.53.0 to 5.54.0 [#1596](https://github.com/vega/ts-json-schema-generator/pull/1596) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.42.2 to 10.43.0 [#1600](https://github.com/vega/ts-json-schema-generator/pull/1600) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.42.2 to 10.43.0 [#1597](https://github.com/vega/ts-json-schema-generator/pull/1597) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.53.0 to 5.54.0 [#1598](https://github.com/vega/ts-json-schema-generator/pull/1598) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.42.2 to 10.43.0 [#1601](https://github.com/vega/ts-json-schema-generator/pull/1601) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 18.14.1 to 18.14.6 [#1603](https://github.com/vega/ts-json-schema-generator/pull/1603) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.34.0 to 8.35.0 [#1602](https://github.com/vega/ts-json-schema-generator/pull/1602) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega from 5.22.1 to 5.23.0 [#1592](https://github.com/vega/ts-json-schema-generator/pull/1592) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.42.0 to 10.42.2 [#1583](https://github.com/vega/ts-json-schema-generator/pull/1583) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.52.0 to 5.53.0 [#1586](https://github.com/vega/ts-json-schema-generator/pull/1586) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 18.14.0 to 18.14.1 [#1582](https://github.com/vega/ts-json-schema-generator/pull/1582) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/glob from 8.0.1 to 8.1.0 [#1584](https://github.com/vega/ts-json-schema-generator/pull/1584) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.20.12 to 7.21.0 [#1585](https://github.com/vega/ts-json-schema-generator/pull/1585) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.18.6 to 7.21.0 [#1587](https://github.com/vega/ts-json-schema-generator/pull/1587) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.42.0 to 10.42.2 [#1588](https://github.com/vega/ts-json-schema-generator/pull/1588) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.52.0 to 5.53.0 [#1589](https://github.com/vega/ts-json-schema-generator/pull/1589) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.42.0 to 10.42.2 [#1590](https://github.com/vega/ts-json-schema-generator/pull/1590) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.51.0 to 5.52.0 [#1573](https://github.com/vega/ts-json-schema-generator/pull/1573) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 18.13.0 to 18.14.0 [#1574](https://github.com/vega/ts-json-schema-generator/pull/1574) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 29.4.2 to 29.4.3 [#1575](https://github.com/vega/ts-json-schema-generator/pull/1575) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.51.0 to 5.52.0 [#1576](https://github.com/vega/ts-json-schema-generator/pull/1576) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.50.0 to 5.51.0 [#1563](https://github.com/vega/ts-json-schema-generator/pull/1563) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.38.5 to 10.42.0 [#1564](https://github.com/vega/ts-json-schema-generator/pull/1564) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 18.11.19 to 18.13.0 [#1565](https://github.com/vega/ts-json-schema-generator/pull/1565) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.8.3 to 2.8.4 [#1566](https://github.com/vega/ts-json-schema-generator/pull/1566) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.33.0 to 8.34.0 [#1567](https://github.com/vega/ts-json-schema-generator/pull/1567) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.50.0 to 5.51.0 [#1568](https://github.com/vega/ts-json-schema-generator/pull/1568) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 29.4.1 to 29.4.2 [#1569](https://github.com/vega/ts-json-schema-generator/pull/1569) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.38.5 to 10.42.0 [#1562](https://github.com/vega/ts-json-schema-generator/pull/1562) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.38.5 to 10.42.0 [#1570](https://github.com/vega/ts-json-schema-generator/pull/1570) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.49.0 to 5.50.0 [#1553](https://github.com/vega/ts-json-schema-generator/pull/1553) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 10.37.6 to 10.38.5 [#1555](https://github.com/vega/ts-json-schema-generator/pull/1555) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 10.37.6 to 10.38.5 [#1556](https://github.com/vega/ts-json-schema-generator/pull/1556) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 4.9.4 to 4.9.5 [#1554](https://github.com/vega/ts-json-schema-generator/pull/1554) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 18.11.18 to 18.11.19 [#1557](https://github.com/vega/ts-json-schema-generator/pull/1557) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 10.37.6 to 10.38.5 [#1558](https://github.com/vega/ts-json-schema-generator/pull/1558) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.49.0 to 5.50.0 [#1559](https://github.com/vega/ts-json-schema-generator/pull/1559) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.48.2 to 5.49.0 [#1549](https://github.com/vega/ts-json-schema-generator/pull/1549) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.32.0 to 8.33.0 [#1547](https://github.com/vega/ts-json-schema-generator/pull/1547) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 29.3.1 to 29.4.1 [#1548](https://github.com/vega/ts-json-schema-generator/pull/1548) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.48.2 to 5.49.0 [#1550](https://github.com/vega/ts-json-schema-generator/pull/1550) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.48.1 to 5.48.2 [#1540](https://github.com/vega/ts-json-schema-generator/pull/1540) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.48.1 to 5.48.2 [#1541](https://github.com/vega/ts-json-schema-generator/pull/1541) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 29.2.5 to 29.2.6 [#1542](https://github.com/vega/ts-json-schema-generator/pull/1542) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/glob from 8.0.0 to 8.0.1 [#1543](https://github.com/vega/ts-json-schema-generator/pull/1543) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 9.5.0 to 10.0.0 [#1538](https://github.com/vega/ts-json-schema-generator/pull/1538) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.48.0 to 5.48.1 [#1534](https://github.com/vega/ts-json-schema-generator/pull/1534) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.8.2 to 2.8.3 [#1533](https://github.com/vega/ts-json-schema-generator/pull/1533) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.31.0 to 8.32.0 [#1535](https://github.com/vega/ts-json-schema-generator/pull/1535) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.48.0 to 5.48.1 [#1536](https://github.com/vega/ts-json-schema-generator/pull/1536) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump glob from 8.0.3 to 8.1.0 [#1537](https://github.com/vega/ts-json-schema-generator/pull/1537) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.47.1 to 5.48.0 [#1524](https://github.com/vega/ts-json-schema-generator/pull/1524) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 8.5.0 to 8.6.0 [#1525](https://github.com/vega/ts-json-schema-generator/pull/1525) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.47.1 to 5.48.0 [#1526](https://github.com/vega/ts-json-schema-generator/pull/1526) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv from 8.11.2 to 8.12.0 [#1527](https://github.com/vega/ts-json-schema-generator/pull/1527) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 9.4.1 to 9.5.0 [#1528](https://github.com/vega/ts-json-schema-generator/pull/1528) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 2.8.1 to 2.8.2 [#1529](https://github.com/vega/ts-json-schema-generator/pull/1529) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.20.7 to 7.20.12 [#1530](https://github.com/vega/ts-json-schema-generator/pull/1530) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.47.0 to 5.47.1 [#1520](https://github.com/vega/ts-json-schema-generator/pull/1520) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump safe-stable-stringify from 2.4.1 to 2.4.2 [#1517](https://github.com/vega/ts-json-schema-generator/pull/1517) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 29.2.4 to 29.2.5 [#1518](https://github.com/vega/ts-json-schema-generator/pull/1518) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump json5 from 2.2.2 to 2.2.3 [#1519](https://github.com/vega/ts-json-schema-generator/pull/1519) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 18.11.17 to 18.11.18 [#1521](https://github.com/vega/ts-json-schema-generator/pull/1521) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.47.0 to 5.47.1 [#1522](https://github.com/vega/ts-json-schema-generator/pull/1522) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.30.0 to 8.31.0 [#1523](https://github.com/vega/ts-json-schema-generator/pull/1523) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 5.46.1 to 5.47.0 [#1514](https://github.com/vega/ts-json-schema-generator/pull/1514) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 5.46.1 to 5.47.0 [#1515](https://github.com/vega/ts-json-schema-generator/pull/1515) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.20.5 to 7.20.7 [#1516](https://github.com/vega/ts-json-schema-generator/pull/1516) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 9
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Arthur Fiorette ([@arthurfiorette](https://github.com/arthurfiorette))
  - Chris ([@cengels](https://github.com/cengels))
  - Daan Boer ([@daanboer](https://github.com/daanboer))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
  - Grant Dickinson ([@grant-d](https://github.com/grant-d))
  - Grigas ([@grigasp](https://github.com/grigasp))
  - Mario DeSousa ([@mdesousa](https://github.com/mdesousa))
  - Petr Spacek (p-spacek@email.cz)
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
