### PR TITLE
feat: Add option to generate `markdownDescription`

### DIFF
--- a/factory/parser.ts
+++ b/factory/parser.ts
@@ -77,7 +77,10 @@ export function createParser(program: ts.Program, config: Config, augmentor?: Pa
     function withJsDoc(nodeParser: SubNodeParser): SubNodeParser {
         const extraTags = new Set(mergedConfig.extraTags);
         if (mergedConfig.jsDoc === "extended") {
-            return new AnnotatedNodeParser(nodeParser, new ExtendedAnnotationsReader(typeChecker, extraTags));
+            return new AnnotatedNodeParser(
+                nodeParser,
+                new ExtendedAnnotationsReader(typeChecker, extraTags, mergedConfig.markdownDescription)
+            );
         } else if (mergedConfig.jsDoc === "basic") {
             return new AnnotatedNodeParser(nodeParser, new BasicAnnotationsReader(extraTags));
         } else {

--- a/src/AnnotationsReader/ExtendedAnnotationsReader.ts
+++ b/src/AnnotationsReader/ExtendedAnnotationsReader.ts
@@ -7,7 +7,8 @@ import { BasicAnnotationsReader } from "./BasicAnnotationsReader";
 export class ExtendedAnnotationsReader extends BasicAnnotationsReader {
     public constructor(
         private typeChecker: ts.TypeChecker,
-        extraTags?: Set<string>
+        extraTags?: Set<string>,
+        private markdownDescription?: boolean
     ) {
         super(extraTags);
     }
@@ -48,13 +49,15 @@ export class ExtendedAnnotationsReader extends BasicAnnotationsReader {
             return undefined;
         }
 
-        return {
-            description: comments
-                .map((comment) => comment.text.replace(/\r/g, "").replace(/(?<=[^\n])\n(?=[^\n*-])/g, " "))
-                .join(" ")
-                // strip newlines
-                .replace(/^\s+|\s+$/g, ""),
-        };
+        const markdownDescription = comments
+            .map((comment) => comment.text)
+            .join(" ")
+            .replace(/\r/g, "")
+            .trim();
+
+        const description = markdownDescription.replace(/(?<=[^\n])\n(?=[^\n*-])/g, " ").trim();
+
+        return this.markdownDescription ? { description, markdownDescription } : { description };
     }
     private getTypeAnnotation(node: ts.Node): Annotations | undefined {
         const symbol = symbolAtNode(node);

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -7,6 +7,7 @@ export interface Config {
     expose?: "all" | "none" | "export";
     topRef?: boolean;
     jsDoc?: "none" | "extended" | "basic";
+    markdownDescription?: boolean;
     sortProps?: boolean;
     strictTuples?: boolean;
     skipTypeCheck?: boolean;
@@ -20,6 +21,7 @@ export const DEFAULT_CONFIG: Omit<Required<Config>, "path" | "type" | "schemaId"
     expose: "export",
     topRef: true,
     jsDoc: "extended",
+    markdownDescription: false,
     sortProps: true,
     strictTuples: false,
     skipTypeCheck: false,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -55,6 +55,7 @@ function assertSchema(
         const validator = new Ajv({
             // skip full check if we are not encoding refs
             validateFormats: config.encodeRefs === false ? undefined : true,
+            keywords: config.markdownDescription ? ["markdownDescription"] : undefined,
         });
 
         addFormats(validator);
@@ -317,7 +318,17 @@ describe("config", () => {
             skipTypeCheck: true,
         })
     );
-
+    it(
+        "markdown-description",
+        assertSchema("markdown-description", {
+            type: "MyObject",
+            expose: "export",
+            topRef: false,
+            jsDoc: "extended",
+            sortProps: true,
+            markdownDescription: true,
+        })
+    );
     it(
         "tsconfig-support",
         assertSchema(

--- a/test/config/markdown-description/main.ts
+++ b/test/config/markdown-description/main.ts
@@ -1,0 +1,97 @@
+/**
+ * @title Some title here
+ * @description Some description here
+ */
+export interface MyObject {
+    /**
+     * @title String field title
+     * @minLength 10
+     * @format date-time
+     * @pattern /^\d+$/
+     */
+    stringValue: string;
+
+    /**
+     * @title Required value
+     */
+    requiredValue: number | string;
+    /**
+     * @title Nullable value
+     */
+    nullableValue: number | string |null;
+    /**
+     * @title Optional value
+     */
+    optionalValue: number | string | undefined;
+
+    /**
+     * Some ignored comment description
+     *
+     * @description Export field description
+     * @default {"length": 10}
+     * @nullable
+     */
+    exportString: MyExportString;
+    /**
+     * @description Export field description
+     * @default "private"
+     */
+    privateString: MyPrivateString;
+
+    /**
+     * @title Non empty array
+     */
+    numberArray: MyNonEmptyArray<number>;
+
+    /**
+     * @nullable
+     */
+    number: number;
+
+    /**
+     * Some more examples:
+     * ```yaml
+     * name: description
+     * length: 42
+     * ```
+     */
+    description: InheritedExample['description'];
+
+    /**
+     * @default ""
+     */
+    inheritedDescription: InheritedExample['description'];
+}
+
+/**
+ * @title My export string
+ */
+export type MyExportString = string;
+/**
+ * @title My private string
+ */
+type MyPrivateString = string;
+/**
+ * @minItems 1
+ */
+export type MyNonEmptyArray<T> = T[];
+
+interface InheritedExample {
+    /**
+     * We have a bit more text.
+     *
+     * Usage: It is possible to add markdown in the JSDoc comment.
+     *
+     * ```ts
+     * // comment
+     * async function readFile(path: string): Promise<string>;
+     * ```
+     *
+     * It is stored raw.
+     * @title description
+     *
+     * More comments.
+     *
+     */
+    description: string;
+}

--- a/test/config/markdown-description/schema.json
+++ b/test/config/markdown-description/schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "definitions": {
+    "MyExportString": {
+      "title": "My export string",
+      "type": "string"
+    },
+    "MyNonEmptyArray<number>": {
+      "items": {
+        "type": "number"
+      },
+      "minItems": 1,
+      "type": "array"
+    }
+  },
+  "description": "Some description here",
+  "properties": {
+    "description": {
+      "description": "Some more examples: ```yaml name: description length: 42 ```",
+      "markdownDescription": "Some more examples:\n```yaml\nname: description\nlength: 42\n```",
+      "title": "description\n\nMore comments.",
+      "type": "string"
+    },
+    "exportString": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/MyExportString",
+          "markdownDescription": "Some ignored comment description"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": {
+        "length": 10
+      },
+      "description": "Export field description"
+    },
+    "inheritedDescription": {
+      "default": "",
+      "description": "We have a bit more text.\n\nUsage: It is possible to add markdown in the JSDoc comment.\n\n```ts // comment async function readFile(path: string): Promise<string>; ```\n\nIt is stored raw.",
+      "markdownDescription": "We have a bit more text.\n\nUsage: It is possible to add markdown in the JSDoc comment.\n\n```ts\n// comment\nasync function readFile(path: string): Promise<string>;\n```\n\nIt is stored raw.",
+      "title": "description\n\nMore comments.",
+      "type": "string"
+    },
+    "nullableValue": {
+      "title": "Nullable value",
+      "type": [
+        "number",
+        "string",
+        "null"
+      ]
+    },
+    "number": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "numberArray": {
+      "$ref": "#/definitions/MyNonEmptyArray%3Cnumber%3E",
+      "title": "Non empty array"
+    },
+    "optionalValue": {
+      "title": "Optional value",
+      "type": [
+        "number",
+        "string"
+      ]
+    },
+    "privateString": {
+      "default": "private",
+      "description": "Export field description",
+      "title": "My private string",
+      "type": "string"
+    },
+    "requiredValue": {
+      "title": "Required value",
+      "type": [
+        "number",
+        "string"
+      ]
+    },
+    "stringValue": {
+      "format": "date-time",
+      "minLength": 10,
+      "pattern": "/^\\d+$/",
+      "title": "String field title",
+      "type": "string"
+    }
+  },
+  "required": [
+    "stringValue",
+    "requiredValue",
+    "nullableValue",
+    "exportString",
+    "privateString",
+    "numberArray",
+    "number",
+    "description",
+    "inheritedDescription"
+  ],
+  "title": "Some title here",
+  "type": "object"
+}

--- a/ts-json-schema-generator.ts
+++ b/ts-json-schema-generator.ts
@@ -21,6 +21,11 @@ const args = new Command()
             .choices(["none", "basic", "extended"])
             .default("extended")
     )
+    .addOption(
+        new Option("--markdown-description", "Generate `markdownDescription` in addition to `description`.").implies({
+            jsDoc: "extended",
+        })
+    )
     .option("--minify", "Minify generated schema", false)
     .option("--unstable", "Do not sort properties")
     .option("--strict-tuples", "Do not allow additional items on tuples")
@@ -53,6 +58,7 @@ const config: Config = {
     expose: args.expose,
     topRef: args.topRef,
     jsDoc: args.jsDoc,
+    markdownDescription: args.markdownDescription,
     sortProps: !args.unstable,
     strictTuples: args.strictTuples,
     skipTypeCheck: !args.typeCheck,


### PR DESCRIPTION
fixes #1544

I have been running into a lot of trouble generating schemas that can be use by VS Code to display readable descriptions if they contain markdown.

I saw #1544 and took the approach of adding a new option: `--markdown-description`. This option will will cause `markdownDescription` to be generated as well a `description`.

Note: this option will only populate `markdownDescription` is will not parse it or attempt to validate that the markdown is valid. I think that is beyond the scope of this PR.

Markdown validation could be done at a later date.