### PR TITLE
feat: generate type maps.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /*.ts
+!/ts-json-schema-generator.ts
 coverage/
 dist/
 node_modules/

--- a/ts-json-schema-generator.ts
+++ b/ts-json-schema-generator.ts
@@ -1,6 +1,5 @@
 import { Command, Option } from "commander";
 import stableStringify from "safe-stable-stringify";
-import { isExternalModule } from "typescript";
 import { createGenerator } from "./factory/generator";
 import { Config, DEFAULT_CONFIG } from "./src/Config";
 import { BaseError } from "./src/Error/BaseError";
@@ -96,16 +95,13 @@ try {
 
 function writeTypeMapFile(typeMaps: TypeMap[], typeMapeFile: string) {
     const typeMapDir = dirname(typeMapeFile);
-    const typesSeen = new Set<string>();
     let code = "";
 
     typeMaps.forEach((typeMap) => {
-        const fileName = relative(typeMapDir, typeMap.sourceFile.fileName);
-        const imported = typeMap.exports.filter((type) => !typesSeen.has(type));
-        imported.forEach((type) => typesSeen.add(type));
+        const fileName = relative(typeMapDir, typeMap.fileName);
 
-        if (isExternalModule(typeMap.sourceFile)) {
-            code += `import type { ${imported.join(", ")} } from "./${fileName}";\n`;
+        if (typeMap.exports) {
+            code += `import type { ${typeMap.exports.join(", ")} } from "./${fileName}";\n`;
         } else {
             code += `import "./${fileName}";\n`;
         }


### PR DESCRIPTION
I'm testing the waters here; not sure how you feel about this. I could maintain a fork of course, but I'd prefer not to ...

This PR adds support for generating some schema metadata in addition to the actual JSON schema. The metadata could be used to generate type-safe validation functions directly by a tool that embeds this library.

To demonstrate, I also added a CLI option `-m` that writes out a TypeScript "type map"—similar to how "event maps" are often used when defining `on()` or `addEventListener()`:

```ts
import type { MyObject, Base } from "./test/valid-data/class-generics/main.ts";

export default interface Definitions {
    [`MyObject`]: MyObject;
    [`Base<string>`]: Base<string>;
    [`Base<boolean>`]: Base<boolean>;
}
```

This type map makes it possible to define the following function:

```ts
import type Definitions from "./schema.d.ts";
import schema from "./schema.json";

export function is<K extends keyof Definitions>(type: K, value: object): value is Definitions[K] {
    console.log("validating using subschema", schema.definitions[type]);
    return true; // FIXME: Use Ajv or something to check
}
```

which, in turn, may be used like this:

```ts
const obj = { a: 1, b: "2", c: { a: "3" }, d: { a: true } };

if (is("MyObject", obj)) {
    console.assert(typeof obj.a === "number");
}
```

(That is, inside the `if` branch, TypeScript now knows that `obj` is `MyObject`, and the editor can show completions for the `type` argument to `is()`.)

