### PR TITLE
feat: bigint support

### DIFF
--- a/src/NodeParser/NumberTypeNodeParser.ts
+++ b/src/NodeParser/NumberTypeNodeParser.ts
@@ -6,7 +6,7 @@ import { NumberType } from "../Type/NumberType";
 
 export class NumberTypeNodeParser implements SubNodeParser {
     public supportsNode(node: ts.KeywordTypeNode): boolean {
-        return node.kind === ts.SyntaxKind.NumberKeyword;
+        return node.kind === ts.SyntaxKind.NumberKeyword || node.kind === ts.SyntaxKind.BigIntKeyword;
     }
     public createType(node: ts.KeywordTypeNode, context: Context): BaseType {
         return new NumberType();

--- a/test/valid-data/type-primitives/main.ts
+++ b/test/valid-data/type-primitives/main.ts
@@ -8,6 +8,7 @@ export interface MyObject {
     boolean: boolean;
     number: number;
     string: string;
+    bigint: bigint;
 
     integer: integer;
     double: double;

--- a/test/valid-data/type-primitives/schema.json
+++ b/test/valid-data/type-primitives/schema.json
@@ -25,12 +25,16 @@
         },
         "string": {
           "type": "string"
+        },
+        "bigint": {
+          "type": "number"
         }
       },
       "required": [
         "boolean",
         "number",
         "string",
+        "bigint",
         "integer",
         "double",
         "decimal",


### PR DESCRIPTION
Transforms the `bigint` type to `{ type: 'number' }`. If you try to transform `bigint` today you will get this error:

`UnknownNodeError: Unknown node " bigint" of kind "BigIntKeyword"`.

`bigint` is a [primtive](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html) type added in Typescript 3.2. 
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v1.5.0-next.0`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Marcus Jøsendal ([@marcus-josendal](https://github.com/marcus-josendal)), for all your work!
  
  #### 🚀 Enhancement
  
  - feat: bigint support [#1828](https://github.com/vega/ts-json-schema-generator/pull/1828) ([@marcus-josendal](https://github.com/marcus-josendal))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump @typescript-eslint/parser from 6.12.0 to 6.13.1 [#1826](https://github.com/vega/ts-json-schema-generator/pull/1826) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 20.9.0 to 20.10.2 [#1825](https://github.com/vega/ts-json-schema-generator/pull/1825) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.23.2 to 7.23.5 [#1827](https://github.com/vega/ts-json-schema-generator/pull/1827) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 2
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Marcus Jøsendal ([@marcus-josendal](https://github.com/marcus-josendal))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
