### PR TITLE
fix: conditional-generic-default

### DIFF
--- a/src/Utils/nodeKey.ts
+++ b/src/Utils/nodeKey.ts
@@ -52,5 +52,5 @@ export function getKey(node: Node, context: Context): string {
     const id = ids.join("-");
     const args = context.getArguments();
 
-    return args.length ? `${id}<${args.map((arg) => arg.getId()).join(",")}>` : id;
+    return args.length ? `${id}<${args.map((arg) => arg?.getId()).join(",")}>` : id;
 }

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -63,6 +63,7 @@ describe("valid-data-other", () => {
     it("generic-anonymous", assertValidSchema("generic-anonymous", "MyObject"));
     it("generic-recursive", assertValidSchema("generic-recursive", "MyObject"));
     it("generic-hell", assertValidSchema("generic-hell", "MyObject"));
+    it("generic-default-conditional", assertValidSchema("generic-default-conditional", "MyObject"));
     it("generic-default", assertValidSchema("generic-default", "MyObject"));
     it("generic-nested", assertValidSchema("generic-nested", "MyObject"));
     it("generic-prefixed-number", assertValidSchema("generic-prefixed-number", "MyObject"));

--- a/test/valid-data/generic-default-conditional/main.ts
+++ b/test/valid-data/generic-default-conditional/main.ts
@@ -1,0 +1,5 @@
+export type MyObject = ConditionalGeneric;
+
+export type ConditionalGeneric<T = string extends 'foo' ? 'bar' : 'baz'> = {
+    foo: T;
+}

--- a/test/valid-data/generic-default-conditional/schema.json
+++ b/test/valid-data/generic-default-conditional/schema.json
@@ -1,0 +1,22 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "ConditionalGeneric": {
+      "additionalProperties": false,
+      "properties": {
+        "foo": {
+          "type": "string",
+          "const": "baz"
+        }
+      },
+      "required": [
+        "foo"
+      ],
+      "type": "object"
+    },
+    "MyObject": {
+      "$ref": "#/definitions/ConditionalGeneric"
+    }
+  }
+}


### PR DESCRIPTION
Hello again. 

It seems like this [commit](https://github.com/vega/ts-json-schema-generator/pull/1545/files) broke generics that have a conditional set as a default value. 

The implementation before this change considered this when mapping over the types:

`const argumentIds = context.getArguments().map((arg) => arg?.getId());`

I kept the inline version but added the conditional check back again. 

It doesn't seem to be any tests for generics that have a conditional set as a default value, so I've added this as well. Let me know if you'd like me to make any other changes 😃 
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v1.5.1-next.0`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - fix: conditional-generic-default [#1830](https://github.com/vega/ts-json-schema-generator/pull/1830) ([@marcus-josendal](https://github.com/marcus-josendal))
  
  #### Authors: 1
  
  - Marcus Jøsendal ([@marcus-josendal](https://github.com/marcus-josendal))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
