### PR TITLE
fix(deepMerge): deepMerge is altering parameter definitions

### DIFF
--- a/src/Utils/deepMerge.ts
+++ b/src/Utils/deepMerge.ts
@@ -15,7 +15,7 @@ export function deepMerge(
     a: { [key: string]: JSONSchema7Definition },
     b: { [key: string]: JSONSchema7Definition }
 ): { [x: string]: JSONSchema7Definition } {
-    const output = { ...a, ...b };
+    const output = { ...structuredClone(a), ...structuredClone(b) };
 
     for (const key in a) {
         if (b.hasOwnProperty(key)) {

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -45,6 +45,14 @@ describe("valid-data-type", () => {
     it("type-intersection-partial-conflict", assertValidSchema("type-intersection-partial-conflict", "MyType"));
     it("type-intersection-partial-conflict-ref", assertValidSchema("type-intersection-partial-conflict", "MyType"));
     it(
+        "type-intersection-partial-conflict-union",
+        assertValidSchema("type-intersection-partial-conflict-union", "MyType")
+    );
+    it(
+        "type-intersection-partial-conflict-union-alias",
+        assertValidSchema("type-intersection-partial-conflict-union-alias", "MyType")
+    );
+    it(
         "type-intersection-recursive-interface",
         assertValidSchema("type-intersection-recursive-interface", "Intersection")
     );

--- a/test/valid-data/type-intersection-partial-conflict-union-alias/main.ts
+++ b/test/valid-data/type-intersection-partial-conflict-union-alias/main.ts
@@ -1,0 +1,15 @@
+type X = 'a' | 'b'
+
+type Foo = {
+    foo: X
+}
+
+export type A = Foo & {
+    foo: 'a'
+}
+
+export type B = Foo & {
+    foo: 'b'
+}
+
+export type MyType = A | B

--- a/test/valid-data/type-intersection-partial-conflict-union-alias/schema.json
+++ b/test/valid-data/type-intersection-partial-conflict-union-alias/schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/MyType",
+  "definitions": {
+    "MyType": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/A"
+        },
+        {
+          "$ref": "#/definitions/B"
+        }
+      ]
+    },
+    "A": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "foo": {
+          "type": "string",
+          "const": "a"
+        }
+      },
+      "required": [
+        "foo"
+      ]
+    },
+    "B": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "foo": {
+          "type": "string",
+          "const": "b"
+        }
+      },
+      "required": [
+        "foo"
+      ]
+    }
+  }
+}

--- a/test/valid-data/type-intersection-partial-conflict-union/main.ts
+++ b/test/valid-data/type-intersection-partial-conflict-union/main.ts
@@ -1,0 +1,13 @@
+type Foo = {
+    foo: 'a' | 'b'
+}
+
+export type A = Foo & {
+    foo: 'a'
+}
+
+export type B = Foo & {
+    foo: 'b'
+}
+
+export type MyType = A | B

--- a/test/valid-data/type-intersection-partial-conflict-union/schema.json
+++ b/test/valid-data/type-intersection-partial-conflict-union/schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/MyType",
+  "definitions": {
+    "MyType": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/A"
+        },
+        {
+          "$ref": "#/definitions/B"
+        }
+      ]
+    },
+    "A": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "foo": {
+          "type": "string",
+          "const": "a"
+        }
+      },
+      "required": [
+        "foo"
+      ]
+    },
+    "B": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "foo": {
+          "type": "string",
+          "const": "b"
+        }
+      },
+      "required": [
+        "foo"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Hi there !

I tried to fix the following issue: 

```typescript
type X = 'a' | 'b'
type Foo = { foo: X }
export type A = Foo & { foo: 'a' }
export type B = Foo & { foo: 'b' }
export type MyType = A | B
```

generate a json schema with properties `foo` of `A` and `B` 

```json
 "foo": { "type": "string", "enum": [] }
```

where 

```typescript
type Foo = { foo: 'a' | 'b' }
export type A = Foo & { foo: 'a' }
export type B = Foo & { foo: 'b' }
export type MyType = A | B
```

generate as expected.

Added two tests to explicit the case (I'm not sure about the test names)

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v1.5.1-next.2`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: Guillaume Châtelet ([@chatelgu](https://github.com/chatelgu))
  
  :heart: Joshua ([@Josh-a-e](https://github.com/Josh-a-e))
  
  #### 🐛 Bug Fix
  
  - fix(deepMerge): deepMerge is altering parameter definitions [#1888](https://github.com/vega/ts-json-schema-generator/pull/1888) ([@chatelgu](https://github.com/chatelgu))
  - Consistent camelCase variable names in README.md [#1883](https://github.com/vega/ts-json-schema-generator/pull/1883) ([@Josh-a-e](https://github.com/Josh-a-e))
  - chore: update vega and Vega-Lite [#1846](https://github.com/vega/ts-json-schema-generator/pull/1846) ([@domoritz](https://github.com/domoritz))
  - fix: conditional-generic-default [#1830](https://github.com/vega/ts-json-schema-generator/pull/1830) ([@marcus-josendal](https://github.com/marcus-josendal))
  
  #### ⚠️ Pushed to `next`
  
  - chore: update deps ([@domoritz](https://github.com/domoritz))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump @babel/core from 7.23.9 to 7.24.0 [#1886](https://github.com/vega/ts-json-schema-generator/pull/1886) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 20.11.24 to 20.11.25 [#1884](https://github.com/vega/ts-json-schema-generator/pull/1884) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 5.3.3 to 5.4.2 [#1885](https://github.com/vega/ts-json-schema-generator/pull/1885) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 20.11.17 to 20.11.24 [#1880](https://github.com/vega/ts-json-schema-generator/pull/1880) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 11.0.4 to 11.1.1 [#1881](https://github.com/vega/ts-json-schema-generator/pull/1881) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump chai from 5.0.0 to 5.1.0 [#1882](https://github.com/vega/ts-json-schema-generator/pull/1882) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 11.0.4 to 11.1.1 [#1876](https://github.com/vega/ts-json-schema-generator/pull/1876) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.56.0 to 8.57.0 [#1877](https://github.com/vega/ts-json-schema-generator/pull/1877) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 11.0.4 to 11.1.1 [#1878](https://github.com/vega/ts-json-schema-generator/pull/1878) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.23.8 to 7.23.9 [#1870](https://github.com/vega/ts-json-schema-generator/pull/1870) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 3.2.4 to 3.2.5 [#1871](https://github.com/vega/ts-json-schema-generator/pull/1871) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/jest from 29.5.11 to 29.5.12 [#1869](https://github.com/vega/ts-json-schema-generator/pull/1869) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 6.20.0 to 6.21.0 [#1867](https://github.com/vega/ts-json-schema-generator/pull/1867) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 20.11.16 to 20.11.17 [#1866](https://github.com/vega/ts-json-schema-generator/pull/1866) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 6.19.1 to 6.21.0 [#1868](https://github.com/vega/ts-json-schema-generator/pull/1868) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 11.1.0 to 12.0.0 [#1864](https://github.com/vega/ts-json-schema-generator/pull/1864) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 20.11.0 to 20.11.16 [#1862](https://github.com/vega/ts-json-schema-generator/pull/1862) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 6.18.0 to 6.20.0 [#1863](https://github.com/vega/ts-json-schema-generator/pull/1863) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump codecov/codecov-action from 3 to 4 [#1860](https://github.com/vega/ts-json-schema-generator/pull/1860) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.23.6 to 7.23.9 [#1856](https://github.com/vega/ts-json-schema-generator/pull/1856) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.1.2 to 5.1.3 [#1857](https://github.com/vega/ts-json-schema-generator/pull/1857) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 6.19.0 to 6.19.1 [#1858](https://github.com/vega/ts-json-schema-generator/pull/1858) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 3.2.2 to 3.2.4 [#1852](https://github.com/vega/ts-json-schema-generator/pull/1852) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 6.18.1 to 6.19.0 [#1853](https://github.com/vega/ts-json-schema-generator/pull/1853) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.23.6 to 7.23.8 [#1854](https://github.com/vega/ts-json-schema-generator/pull/1854) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 6.18.0 to 6.18.1 [#1848](https://github.com/vega/ts-json-schema-generator/pull/1848) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 20.10.5 to 20.11.0 [#1849](https://github.com/vega/ts-json-schema-generator/pull/1849) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 3.1.1 to 3.2.2 [#1850](https://github.com/vega/ts-json-schema-generator/pull/1850) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/parser from 6.13.2 to 6.18.0 [#1843](https://github.com/vega/ts-json-schema-generator/pull/1843) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 6.13.2 to 6.18.0 [#1844](https://github.com/vega/ts-json-schema-generator/pull/1844) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump chai from 4.3.10 to 5.0.0 [#1840](https://github.com/vega/ts-json-schema-generator/pull/1840) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.0.1 to 5.1.2 [#1839](https://github.com/vega/ts-json-schema-generator/pull/1839) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 8.55.0 to 8.56.0 [#1837](https://github.com/vega/ts-json-schema-generator/pull/1837) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 20.10.4 to 20.10.5 [#1838](https://github.com/vega/ts-json-schema-generator/pull/1838) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.23.5 to 7.23.6 [#1835](https://github.com/vega/ts-json-schema-generator/pull/1835) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.23.5 to 7.23.6 [#1834](https://github.com/vega/ts-json-schema-generator/pull/1834) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @typescript-eslint/eslint-plugin from 6.11.0 to 6.13.2 [#1831](https://github.com/vega/ts-json-schema-generator/pull/1831) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.23.0 to 7.23.5 [#1833](https://github.com/vega/ts-json-schema-generator/pull/1833) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 5
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
  - Guillaume Châtelet ([@chatelgu](https://github.com/chatelgu))
  - Joshua ([@Josh-a-e](https://github.com/Josh-a-e))
  - Marcus Jøsendal ([@marcus-josendal](https://github.com/marcus-josendal))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
