### PR TITLE
fix: support partial config in createGenerator

### DIFF
--- a/factory/generator.ts
+++ b/factory/generator.ts
@@ -1,13 +1,14 @@
-import { CompletedConfig } from "../src/Config";
+import { Config, DEFAULT_CONFIG } from "../src/Config";
 import { SchemaGenerator } from "../src/SchemaGenerator";
 import { createFormatter } from "./formatter";
 import { createParser } from "./parser";
 import { createProgram } from "./program";
 
-export function createGenerator(config: CompletedConfig): SchemaGenerator {
-    const program = createProgram(config);
-    const parser = createParser(program, config);
-    const formatter = createFormatter(config);
+export function createGenerator(config: Config): SchemaGenerator {
+    const completedConfig = { ...DEFAULT_CONFIG, ...config };
+    const program = createProgram(completedConfig);
+    const parser = createParser(program, completedConfig);
+    const formatter = createFormatter(completedConfig);
 
-    return new SchemaGenerator(program, parser, formatter, config);
+    return new SchemaGenerator(program, parser, formatter, completedConfig);
 }

--- a/ts-json-schema-generator.ts
+++ b/ts-json-schema-generator.ts
@@ -1,7 +1,7 @@
 import { Command, Option } from "commander";
 import stableStringify from "safe-stable-stringify";
 import { createGenerator } from "./factory/generator";
-import { CompletedConfig, DEFAULT_CONFIG } from "./src/Config";
+import { Config } from "./src/Config";
 import { BaseError } from "./src/Error/BaseError";
 import { formatError } from "./src/Utils/formatError";
 import * as pkg from "./package.json";
@@ -53,8 +53,7 @@ const args = new Command()
     .parse(process.argv)
     .opts();
 
-const config: CompletedConfig = {
-    ...DEFAULT_CONFIG,
+const config: Config = {
     minify: args.minify,
     path: args.path,
     tsconfig: args.tsconfig,


### PR DESCRIPTION
fixes #1918
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.1--canary.1919.a643bee.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install ts-json-schema-generator@2.0.1--canary.1919.a643bee.0
  # or 
  yarn add ts-json-schema-generator@2.0.1--canary.1919.a643bee.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.0.1-next.0`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - fix: support partial config in createGenerator [#1919](https://github.com/vega/ts-json-schema-generator/pull/1919) ([@domoritz](https://github.com/domoritz))
  
  #### Authors: 1
  
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
