### PR TITLE
Fix for union types of union types in Records. 

### DIFF
--- a/src/NodeParser/MappedTypeNodeParser.ts
+++ b/src/NodeParser/MappedTypeNodeParser.ts
@@ -18,7 +18,6 @@ import { derefAnnotatedType, derefType } from "../Utils/derefType.js";
 import { getKey } from "../Utils/nodeKey.js";
 import { preserveAnnotation } from "../Utils/preserveAnnotation.js";
 import { removeUndefined } from "../Utils/removeUndefined.js";
-import { AliasType } from "../Type/AliasType.js";
 
 export class MappedTypeNodeParser implements SubNodeParser {
     public constructor(
@@ -104,39 +103,8 @@ export class MappedTypeNodeParser implements SubNodeParser {
 
     protected getProperties(node: ts.MappedTypeNode, keyListType: UnionType, context: Context): ObjectProperty[] {
         return keyListType
-            .getTypes()
-            .flatMap((type) => {
-                if (type instanceof LiteralType) {
-                    return type;
-                } else if (type instanceof AliasType) {
-                    const itemsToProcess = [type.getType()];
-                    const processedTypes = [];
-                    while (itemsToProcess.length > 0) {
-                        const currentType = itemsToProcess[0];
-                        if (currentType instanceof LiteralType) {
-                            processedTypes.push(currentType);
-                        } else if (currentType instanceof AliasType) {
-                            itemsToProcess.push(currentType.getType());
-                        } else if (currentType instanceof UnionType) {
-                            itemsToProcess.push(...currentType.getTypes());
-                        }
-                        itemsToProcess.shift();
-                    }
-                    return processedTypes;
-                }
-                return [];
-            })
+            .getFlattenedTypes()
             .filter((type): type is LiteralType => type instanceof LiteralType)
-            .reduce((acc: LiteralType[], curr: LiteralType) => {
-                if (
-                    acc.findIndex((val: LiteralType) => {
-                        return val.getId() === curr.getId();
-                    }) < 0
-                ) {
-                    acc.push(curr);
-                }
-                return acc;
-            }, [])
             .map((type) => [type, this.mapKey(node, type, context)])
             .filter((value): value is [LiteralType, LiteralType] => value[1] instanceof LiteralType)
             .reduce((result: ObjectProperty[], [key, mappedKey]: [LiteralType, LiteralType]) => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -64,6 +64,7 @@ function assertSchema(
             // skip full check if we are not encoding refs
             validateFormats: config.encodeRefs === false ? undefined : true,
             keywords: config.markdownDescription ? ["markdownDescription"] : undefined,
+            allowUnionTypes: true,
         });
 
         addFormats(validator);

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -102,6 +102,7 @@ describe("valid-data-type", () => {
     it("type-mapped-additional-props", assertValidSchema("type-mapped-additional-props", "MyObject"));
     it("type-mapped-array", assertValidSchema("type-mapped-array", "MyObject"));
     it("type-mapped-union-intersection", assertValidSchema("type-mapped-union-intersection", "MyObject"));
+    it("type-mapped-union-union", assertValidSchema("type-mapped-union-union", "MyType"));
     it("type-mapped-enum", assertValidSchema("type-mapped-enum", "MyObject"));
     it("type-mapped-enum-optional", assertValidSchema("type-mapped-enum-optional", "MyObject"));
     it("type-mapped-enum-null", assertValidSchema("type-mapped-enum-null", "MyObject"));

--- a/test/valid-data/type-mapped-union-union/main.ts
+++ b/test/valid-data/type-mapped-union-union/main.ts
@@ -1,0 +1,6 @@
+type MyType1 = "s1";
+type MyType2 = MyType1 | "s2" | "s3";
+type MyType3 = MyType2 | "s4" | "s5";
+type MyType10 = MyType3 | MyType2 | 's6';
+
+export type MyType = Record<MyType10, string>;

--- a/test/valid-data/type-mapped-union-union/schema.json
+++ b/test/valid-data/type-mapped-union-union/schema.json
@@ -1,0 +1,40 @@
+{
+  "$ref": "#/definitions/MyType",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyType": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {
+        "s1": {
+          "type": "string"
+        },
+        "s2": {
+          "type": "string"
+        },
+        "s3": {
+          "type": "string"
+        },
+        "s4": {
+          "type": "string"
+        },
+        "s5": {
+          "type": "string"
+        },
+        "s6": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "s4",
+        "s5",
+        "s2",
+        "s3",
+        "s1",
+        "s6"
+      ],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
Existing code was just allowing LiteralType through. The fix now puts the types in the queue and saves if it is a LiteralType. If not then it would be an AliasType or UnionType. These items are then added to the queue and processed one at a time. 

The reduce function is there to remove any duplicates in case a type is referenced multiple times in varying sub types
type1 = type2 | type3;
type4 = type1 | type2;

type2 would show up twice in the processing of types. so one of the two would need to be removed.