### PR TITLE
feat: improve literal union type handling

### DIFF
--- a/src/NodeParser/IntersectionNodeParser.ts
+++ b/src/NodeParser/IntersectionNodeParser.ts
@@ -9,6 +9,8 @@ import { derefType } from "../Utils/derefType.js";
 import { uniqueTypeArray } from "../Utils/uniqueTypeArray.js";
 import { UndefinedType } from "../Type/UndefinedType.js";
 import { NeverType } from "../Type/NeverType.js";
+import { ObjectType } from "../Type/ObjectType.js";
+import { StringType } from "../Type/StringType.js";
 
 export class IntersectionNodeParser implements SubNodeParser {
     public constructor(
@@ -28,8 +30,18 @@ export class IntersectionNodeParser implements SubNodeParser {
             return new NeverType();
         }
 
+        // handle autocomplete hacks like `string & {}`
+        if (types.length === 2 && types.some((t) => t instanceof StringType) && types.some((t) => isEmptyObject(t))) {
+            return new StringType(true);
+        }
+
         return translate(types);
     }
+}
+
+function isEmptyObject(x: BaseType) {
+    const t = derefType(x);
+    return t instanceof ObjectType && !t.getAdditionalProperties() && !t.getProperties().length;
 }
 
 function derefAndFlattenUnions(type: BaseType): BaseType[] {

--- a/src/NodeParser/MappedTypeNodeParser.ts
+++ b/src/NodeParser/MappedTypeNodeParser.ts
@@ -164,7 +164,7 @@ export class MappedTypeNodeParser implements SubNodeParser {
 
     protected createSubContext(
         node: ts.MappedTypeNode,
-        key: LiteralType | StringType,
+        key: LiteralType | StringType | NumberType,
         parentContext: Context,
     ): Context {
         const subContext = new Context(node);

--- a/src/Type/LiteralType.ts
+++ b/src/Type/LiteralType.ts
@@ -14,4 +14,8 @@ export class LiteralType extends BaseType {
     public getValue(): LiteralValue {
         return this.value;
     }
+
+    public isString(): boolean {
+        return typeof this.value === "string";
+    }
 }

--- a/src/Type/StringType.ts
+++ b/src/Type/StringType.ts
@@ -1,7 +1,15 @@
 import { PrimitiveType } from "./PrimitiveType.js";
 
 export class StringType extends PrimitiveType {
+    constructor(protected preserveLiterals = false) {
+        super();
+    }
+
     public getId(): string {
         return "string";
+    }
+
+    public getPreserveLiterals(): boolean {
+        return this.preserveLiterals;
     }
 }

--- a/src/TypeFormatter/AnnotatedTypeFormatter.ts
+++ b/src/TypeFormatter/AnnotatedTypeFormatter.ts
@@ -61,9 +61,7 @@ export class AnnotatedTypeFormatter implements SubTypeFormatter {
                 delete annotations.discriminator;
             } else {
                 throw new Error(
-                    `Cannot assign discriminator tag to type: ${JSON.stringify(
-                        derefed,
-                    )}. This tag can only be assigned to union types.`,
+                    `Cannot assign discriminator tag to type: ${derefed.getName()}. This tag can only be assigned to union types.`,
                 );
             }
         }

--- a/src/TypeFormatter/LiteralUnionTypeFormatter.ts
+++ b/src/TypeFormatter/LiteralUnionTypeFormatter.ts
@@ -6,7 +6,7 @@ import { LiteralType, LiteralValue } from "../Type/LiteralType.js";
 import { NullType } from "../Type/NullType.js";
 import { StringType } from "../Type/StringType.js";
 import { UnionType } from "../Type/UnionType.js";
-import { derefAliasedType } from "../Utils/derefType.js";
+import { derefAliasedType, isHiddenType } from "../Utils/derefType.js";
 import { typeName } from "../Utils/typeName.js";
 import { uniqueArray } from "../Utils/uniqueArray.js";
 
@@ -71,6 +71,7 @@ export class LiteralUnionTypeFormatter implements SubTypeFormatter {
 function flattenTypes(type: UnionType): (StringType | LiteralType | NullType)[] {
     return type
         .getTypes()
+        .filter((t) => !isHiddenType(t))
         .map(derefAliasedType)
         .flatMap((t) => {
             if (t instanceof UnionType) {

--- a/src/TypeFormatter/LiteralUnionTypeFormatter.ts
+++ b/src/TypeFormatter/LiteralUnionTypeFormatter.ts
@@ -18,6 +18,7 @@ export class LiteralUnionTypeFormatter implements SubTypeFormatter {
         let hasString = false;
         let preserveLiterals = false;
         let allStrings = true;
+        let hasNull = false;
 
         const flattenedTypes = flattenTypes(type);
 
@@ -27,9 +28,10 @@ export class LiteralUnionTypeFormatter implements SubTypeFormatter {
                 hasString = true;
                 preserveLiterals = preserveLiterals || t.getPreserveLiterals();
                 return false;
-            }
-
-            if (t instanceof LiteralType && !t.isString()) {
+            } else if (t instanceof NullType) {
+                hasNull = true;
+                return true;
+            } else if (t instanceof LiteralType && !t.isString()) {
                 allStrings = false;
             }
 
@@ -38,7 +40,7 @@ export class LiteralUnionTypeFormatter implements SubTypeFormatter {
 
         if (allStrings && hasString && !preserveLiterals) {
             return {
-                type: "string",
+                type: hasNull ? ["string", "null"] : "string",
             };
         }
 

--- a/src/TypeFormatter/UnionTypeFormatter.ts
+++ b/src/TypeFormatter/UnionTypeFormatter.ts
@@ -40,9 +40,7 @@ export class UnionTypeFormatter implements SubTypeFormatter {
 
         if (undefinedIndex != -1) {
             throw new Error(
-                `Cannot find discriminator keyword "${discriminator}" in type ${JSON.stringify(
-                    type.getTypes()[undefinedIndex],
-                )}.`,
+                `Cannot find discriminator keyword "${discriminator}" in type ${type.getTypes()[undefinedIndex].getName()}.`,
             );
         }
 

--- a/src/TypeFormatter/UnionTypeFormatter.ts
+++ b/src/TypeFormatter/UnionTypeFormatter.ts
@@ -98,38 +98,6 @@ export class UnionTypeFormatter implements SubTypeFormatter {
 
         const definitions = this.getTypeDefinitions(type);
 
-        // TODO: why is this not covered by LiteralUnionTypeFormatter?
-        // special case for string literals | string -> string
-        let stringType = true;
-        let oneNotEnum = false;
-        for (const def of definitions) {
-            if (def.type !== "string") {
-                stringType = false;
-                break;
-            }
-            if (def.enum === undefined) {
-                oneNotEnum = true;
-            }
-        }
-        if (stringType && oneNotEnum) {
-            const values = [];
-            for (const def of definitions) {
-                if (def.enum) {
-                    values.push(...def.enum);
-                } else if (def.const) {
-                    values.push(def.const);
-                } else {
-                    return {
-                        type: "string",
-                    };
-                }
-            }
-            return {
-                type: "string",
-                enum: values,
-            };
-        }
-
         const flattenedDefinitions: JSONSchema7[] = [];
 
         // Flatten anyOf inside anyOf unless the anyOf has an annotation

--- a/src/Utils/derefType.ts
+++ b/src/Utils/derefType.ts
@@ -2,6 +2,8 @@ import { AliasType } from "../Type/AliasType.js";
 import { AnnotatedType } from "../Type/AnnotatedType.js";
 import { BaseType } from "../Type/BaseType.js";
 import { DefinitionType } from "../Type/DefinitionType.js";
+import { HiddenType } from "../Type/HiddenType.js";
+import { NeverType } from "../Type/NeverType.js";
 import { ReferenceType } from "../Type/ReferenceType.js";
 
 /**
@@ -24,6 +26,16 @@ export function derefAnnotatedType(type: BaseType): BaseType {
     }
 
     return type;
+}
+
+export function isHiddenType(type: BaseType): boolean {
+    if (type instanceof HiddenType || type instanceof NeverType) {
+        return true;
+    } else if (type instanceof DefinitionType || type instanceof AliasType || type instanceof AnnotatedType) {
+        return isHiddenType(type.getType());
+    }
+
+    return false;
 }
 
 export function derefAliasedType(type: BaseType): BaseType {

--- a/src/Utils/derefType.ts
+++ b/src/Utils/derefType.ts
@@ -25,3 +25,11 @@ export function derefAnnotatedType(type: BaseType): BaseType {
 
     return type;
 }
+
+export function derefAliasedType(type: BaseType): BaseType {
+    if (type instanceof AliasType) {
+        return derefAliasedType(type.getType());
+    }
+
+    return type;
+}

--- a/src/Utils/typeKeys.ts
+++ b/src/Utils/typeKeys.ts
@@ -47,7 +47,7 @@ export function getTypeKeys(type: BaseType): LiteralType[] {
     return [];
 }
 
-export function getTypeByKey(type: BaseType, index: LiteralType | StringType): BaseType | undefined {
+export function getTypeByKey(type: BaseType, index: LiteralType | StringType | NumberType): BaseType | undefined {
     type = derefType(type);
 
     if (type instanceof IntersectionType || type instanceof UnionType) {

--- a/test/invalid-data.test.ts
+++ b/test/invalid-data.test.ts
@@ -36,24 +36,14 @@ describe("invalid-data", () => {
     it("duplicates", assertSchema("duplicates", "MyType", `Type "A" has multiple definitions.`));
     it(
         "missing-discriminator",
-        assertSchema(
-            "missing-discriminator",
-            "MyType",
-            'Cannot find discriminator keyword "type" in type ' +
-                '{"name":"B","type":{"id":"interface-1119825560-40-63-1119825560-0-124",' +
-                '"baseTypes":[],"properties":[],"additionalProperties":false,"nonPrimitive":false}}.',
-        ),
+        assertSchema("missing-discriminator", "MyType", 'Cannot find discriminator keyword "type" in type B.'),
     );
     it(
         "non-union-discriminator",
         assertSchema(
             "non-union-discriminator",
             "MyType",
-            "Cannot assign discriminator tag to type: " +
-                '{"id":"interface-2103469249-0-76-2103469249-0-77","baseTypes":[],' +
-                '"properties":[{"name":"name","type":{},"required":true}],' +
-                '"additionalProperties":false,"nonPrimitive":false}. ' +
-                "This tag can only be assigned to union types.",
+            "Cannot assign discriminator tag to type: interface-2103469249-0-76-2103469249-0-77. This tag can only be assigned to union types.",
         ),
     );
     it(

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -25,6 +25,7 @@ describe("valid-data-other", () => {
     it("string-literals-inline", assertValidSchema("string-literals-inline", "MyObject"));
     it("string-literals-intrinsic", assertValidSchema("string-literals-intrinsic", "MyObject"));
     it("string-literals-null", assertValidSchema("string-literals-null", "MyObject"));
+    it("string-literals-hack", assertValidSchema("string-literals-hack", "MyObject"));
     it("string-template-literals", assertValidSchema("string-template-literals", "MyObject"));
     it("string-template-expression-literals", assertValidSchema("string-template-expression-literals", "MyObject"));
     it(

--- a/test/valid-data/string-literals-hack/main.ts
+++ b/test/valid-data/string-literals-hack/main.ts
@@ -1,0 +1,13 @@
+type Union = "a" | "b";
+
+export type MyObject = {
+    literals: "foo" | "bar";
+    stringWithNull: string | null;
+    literalWithNull: "foo" | "bar" | null;
+    literalWithString: "foo" | "bar" | string;
+    withRef: "foo" | Union;
+    withRefWithString: Union | string;
+    withHack: "foo" | "bar" | (string & {});
+    withHackRecord: "foo" | "bar" | (string & Record<never, never>);
+    withHackNull: "foo" | "bar" | null | (string & Record<never, never>);
+};

--- a/test/valid-data/string-literals-hack/main.ts
+++ b/test/valid-data/string-literals-hack/main.ts
@@ -5,6 +5,7 @@ export type MyObject = {
     stringWithNull: string | null;
     literalWithNull: "foo" | "bar" | null;
     literalWithString: "foo" | "bar" | string;
+    literalWithStringAndNull: "foo" | "bar" | string | null;
     withRef: "foo" | Union;
     withRefWithString: Union | string;
     withHack: "foo" | "bar" | (string & {});

--- a/test/valid-data/string-literals-hack/schema.json
+++ b/test/valid-data/string-literals-hack/schema.json
@@ -19,6 +19,12 @@
         "literalWithString": {
           "type": "string"
         },
+        "literalWithStringAndNull": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "literals": {
           "enum": [
             "foo",
@@ -95,6 +101,7 @@
         "stringWithNull",
         "literalWithNull",
         "literalWithString",
+        "literalWithStringAndNull",
         "withRef",
         "withRefWithString",
         "withHack",

--- a/test/valid-data/string-literals-hack/schema.json
+++ b/test/valid-data/string-literals-hack/schema.json
@@ -1,0 +1,107 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "literalWithNull": {
+          "enum": [
+            "foo",
+            "bar",
+            null
+          ],
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "literalWithString": {
+          "type": "string"
+        },
+        "literals": {
+          "enum": [
+            "foo",
+            "bar"
+          ],
+          "type": "string"
+        },
+        "stringWithNull": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "withHack": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "enum": [
+                "foo",
+                "bar"
+              ],
+              "type": "string"
+            }
+          ]
+        },
+        "withHackNull": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "enum": [
+                "foo",
+                "bar",
+                null
+              ],
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          ]
+        },
+        "withHackRecord": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "enum": [
+                "foo",
+                "bar"
+              ],
+              "type": "string"
+            }
+          ]
+        },
+        "withRef": {
+          "enum": [
+            "foo",
+            "a",
+            "b"
+          ],
+          "type": "string"
+        },
+        "withRefWithString": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "literals",
+        "stringWithNull",
+        "literalWithNull",
+        "literalWithString",
+        "withRef",
+        "withRefWithString",
+        "withHack",
+        "withHackRecord",
+        "withHackNull"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/test/vega-lite/schema.json
+++ b/test/vega-lite/schema.json
@@ -4428,46 +4428,37 @@
       ]
     },
     "BinnedTimeUnit": {
-      "anyOf": [
-        {
-          "enum": [
-            "binnedyear",
-            "binnedyearquarter",
-            "binnedyearquartermonth",
-            "binnedyearmonth",
-            "binnedyearmonthdate",
-            "binnedyearmonthdatehours",
-            "binnedyearmonthdatehoursminutes",
-            "binnedyearmonthdatehoursminutesseconds",
-            "binnedyearweek",
-            "binnedyearweekday",
-            "binnedyearweekdayhours",
-            "binnedyearweekdayhoursminutes",
-            "binnedyearweekdayhoursminutesseconds",
-            "binnedyeardayofyear"
-          ],
-          "type": "string"
-        },
-        {
-          "enum": [
-            "binnedutcyear",
-            "binnedutcyearquarter",
-            "binnedutcyearquartermonth",
-            "binnedutcyearmonth",
-            "binnedutcyearmonthdate",
-            "binnedutcyearmonthdatehours",
-            "binnedutcyearmonthdatehoursminutes",
-            "binnedutcyearmonthdatehoursminutesseconds",
-            "binnedutcyearweek",
-            "binnedutcyearweekday",
-            "binnedutcyearweekdayhours",
-            "binnedutcyearweekdayhoursminutes",
-            "binnedutcyearweekdayhoursminutesseconds",
-            "binnedutcyeardayofyear"
-          ],
-          "type": "string"
-        }
-      ]
+      "enum": [
+        "binnedyear",
+        "binnedyearquarter",
+        "binnedyearquartermonth",
+        "binnedyearmonth",
+        "binnedyearmonthdate",
+        "binnedyearmonthdatehours",
+        "binnedyearmonthdatehoursminutes",
+        "binnedyearmonthdatehoursminutesseconds",
+        "binnedyearweek",
+        "binnedyearweekday",
+        "binnedyearweekdayhours",
+        "binnedyearweekdayhoursminutes",
+        "binnedyearweekdayhoursminutesseconds",
+        "binnedyeardayofyear",
+        "binnedutcyear",
+        "binnedutcyearquarter",
+        "binnedutcyearquartermonth",
+        "binnedutcyearmonth",
+        "binnedutcyearmonthdate",
+        "binnedutcyearmonthdatehours",
+        "binnedutcyearmonthdatehoursminutes",
+        "binnedutcyearmonthdatehoursminutesseconds",
+        "binnedutcyearweek",
+        "binnedutcyearweekday",
+        "binnedutcyearweekdayhours",
+        "binnedutcyearweekdayhoursminutes",
+        "binnedutcyearweekdayhoursminutesseconds",
+        "binnedutcyeardayofyear"
+      ],
+      "type": "string"
     },
     "Blend": {
       "enum": [
@@ -19228,29 +19219,9 @@
       "type": "object"
     },
     "ParseValue": {
-      "anyOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "string"
-        },
-        {
-          "const": "string",
-          "type": "string"
-        },
-        {
-          "const": "boolean",
-          "type": "string"
-        },
-        {
-          "const": "date",
-          "type": "string"
-        },
-        {
-          "const": "number",
-          "type": "string"
-        }
+      "type": [
+        "string",
+        "null"
       ]
     },
     "PivotTransform": {


### PR DESCRIPTION
Fixes #1921
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.2--canary.1927.45e4021.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install ts-json-schema-generator@2.0.2--canary.1927.45e4021.0
  # or 
  yarn add ts-json-schema-generator@2.0.2--canary.1927.45e4021.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.1.0-next.1`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - feat: improve literal union type handling [#1927](https://github.com/vega/ts-json-schema-generator/pull/1927) ([@domoritz](https://github.com/domoritz))
  - feat: update to eslint 9, switch to esm [#1922](https://github.com/vega/ts-json-schema-generator/pull/1922) ([@domoritz](https://github.com/domoritz))
  
  #### 🐛 Bug Fix
  
  - style: prettier [#1925](https://github.com/vega/ts-json-schema-generator/pull/1925) ([@domoritz](https://github.com/domoritz))
  
  #### ⚠️ Pushed to `next`
  
  - refactor: minor code improvements ([@domoritz](https://github.com/domoritz))
  
  #### Authors: 1
  
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
