### PR TITLE
feat: support autocomplete hack on literals or unions of literals

### DIFF
--- a/src/NodeParser/IntersectionNodeParser.ts
+++ b/src/NodeParser/IntersectionNodeParser.ts
@@ -11,6 +11,8 @@ import { UndefinedType } from "../Type/UndefinedType.js";
 import { NeverType } from "../Type/NeverType.js";
 import { ObjectType } from "../Type/ObjectType.js";
 import { StringType } from "../Type/StringType.js";
+import { LiteralType } from "../Type/LiteralType.js";
+import { isLiteralUnion } from "../TypeFormatter/LiteralUnionTypeFormatter.js";
 
 export class IntersectionNodeParser implements SubNodeParser {
     public constructor(
@@ -31,8 +33,14 @@ export class IntersectionNodeParser implements SubNodeParser {
         }
 
         // handle autocomplete hacks like `string & {}`
-        if (types.length === 2 && types.some((t) => t instanceof StringType) && types.some((t) => isEmptyObject(t))) {
-            return new StringType(true);
+        if (types.length === 2 && types.some((t) => isEmptyObject(t))) {
+            if (types.some((t) => t instanceof StringType)) {
+                return new StringType(true);
+            }
+            const nonObject = types.find((t) => !isEmptyObject(t));
+            if (nonObject instanceof LiteralType || (nonObject instanceof UnionType && isLiteralUnion(nonObject))) {
+                return nonObject;
+            }
         }
 
         return translate(types);

--- a/src/TypeFormatter/LiteralUnionTypeFormatter.ts
+++ b/src/TypeFormatter/LiteralUnionTypeFormatter.ts
@@ -83,7 +83,7 @@ function flattenTypes(type: UnionType): (StringType | LiteralType | NullType)[] 
         });
 }
 
-function isLiteralUnion(type: UnionType): boolean {
+export function isLiteralUnion(type: UnionType): boolean {
     return flattenTypes(type).every(
         (item) => item instanceof LiteralType || item instanceof NullType || item instanceof StringType,
     );

--- a/test/valid-data/string-literals-hack/main.ts
+++ b/test/valid-data/string-literals-hack/main.ts
@@ -11,4 +11,5 @@ export type MyObject = {
     withHack: "foo" | "bar" | (string & {});
     withHackRecord: "foo" | "bar" | (string & Record<never, never>);
     withHackNull: "foo" | "bar" | null | (string & Record<never, never>);
+    hackOnLiteral: ("foo" & Record<never, never>) | "bar";
 };

--- a/test/valid-data/string-literals-hack/schema.json
+++ b/test/valid-data/string-literals-hack/schema.json
@@ -5,6 +5,13 @@
     "MyObject": {
       "additionalProperties": false,
       "properties": {
+        "hackOnLiteral": {
+          "enum": [
+            "foo",
+            "bar"
+          ],
+          "type": "string"
+        },
         "literalWithNull": {
           "enum": [
             "foo",
@@ -106,7 +113,8 @@
         "withRefWithString",
         "withHack",
         "withHackRecord",
-        "withHackNull"
+        "withHackNull",
+        "hackOnLiteral"
       ],
       "type": "object"
     }


### PR DESCRIPTION
Fixes #1929
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.1.0--canary.1930.0e24c4c.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install ts-json-schema-generator@2.1.0--canary.1930.0e24c4c.0
  # or 
  yarn add ts-json-schema-generator@2.1.0--canary.1930.0e24c4c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.1.0-next.2`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - feat: support autocomplete hack on literals or unions of literals [#1930](https://github.com/vega/ts-json-schema-generator/pull/1930) ([@domoritz](https://github.com/domoritz))
  - feat: improve literal union type handling [#1927](https://github.com/vega/ts-json-schema-generator/pull/1927) ([@domoritz](https://github.com/domoritz))
  - feat: update to eslint 9, switch to esm [#1922](https://github.com/vega/ts-json-schema-generator/pull/1922) ([@domoritz](https://github.com/domoritz))
  
  #### 🐛 Bug Fix
  
  - style: prettier [#1925](https://github.com/vega/ts-json-schema-generator/pull/1925) ([@domoritz](https://github.com/domoritz))
  
  #### ⚠️ Pushed to `next`
  
  - refactor: minor code improvements ([@domoritz](https://github.com/domoritz))
  
  #### Authors: 1
  
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
