### PR TITLE
Provide more type saftey for vega-lite fixme

### DIFF
--- a/src/NodeParser/CallExpressionParser.ts
+++ b/src/NodeParser/CallExpressionParser.ts
@@ -20,7 +20,7 @@ export class CallExpressionParser implements SubNodeParser {
         const type = this.typeChecker.getTypeAtLocation(node);
 
         // FIXME: remove special case
-        if ((type as any)?.typeArguments) {
+        if (Array.isArray((type as any)?.typeArguments?.[0]?.types)) {
             return new TupleType([
                 new UnionType((type as any).typeArguments[0].types.map((t: any) => new LiteralType(t.value))),
             ]);


### PR DESCRIPTION
### Description
A `FIXME` was introduced [here](https://github.com/vega/ts-json-schema-generator/commit/80589d608e0b9efd125ccfeb5d28b0150ba358c1) that prevents zod's `z.infer` type helper from being processed properly. I don't have any knowledge of TypeScripts AST, but the `if` statement that is throwing the error (see https://github.com/vega/ts-json-schema-generator/issues/758) assumes that if `type.typeArguments` is present, it can safely `map` over `type.typeArguments[0].types`. Instead of assuming this true, I added additional type checking so `z.infer` doesn't fall into this `if` statement and attempt to `map` unless it is an array.

### Fixes
https://github.com/vega/ts-json-schema-generator/issues/758
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.1.2-next.0`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Tim ([@timothympace](https://github.com/timothympace)), for all your work!
  
  #### 🐛 Bug Fix
  
  - Provide more type saftey for vega-lite fixme [#1947](https://github.com/vega/ts-json-schema-generator/pull/1947) ([@timothympace](https://github.com/timothympace))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump typescript-eslint from 7.7.1 to 7.8.0 [#1948](https://github.com/vega/ts-json-schema-generator/pull/1948) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv from 8.12.0 to 8.13.0 [#1950](https://github.com/vega/ts-json-schema-generator/pull/1950) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.7.3 to 4.9.1 [#1951](https://github.com/vega/ts-json-schema-generator/pull/1951) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.1.1 to 9.2.0 [#1949](https://github.com/vega/ts-json-schema-generator/pull/1949) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.7.2 to 4.7.3 [#1940](https://github.com/vega/ts-json-schema-generator/pull/1940) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.1.0 to 9.1.1 [#1939](https://github.com/vega/ts-json-schema-generator/pull/1939) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 2
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Tim ([@timothympace](https://github.com/timothympace))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
