### PR TITLE
feat: support `export *` statements

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -6,7 +6,6 @@ const config = {
     coverageDirectory: "./coverage/",
     collectCoverage: false,
     testEnvironment: "node",
-    maxWorkers: '50%', // speeds up tests
     transform: {
         ".*": "babel-jest",
     },

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -6,6 +6,7 @@ const config = {
     coverageDirectory: "./coverage/",
     collectCoverage: false,
     testEnvironment: "node",
+    maxWorkers: '50%', // speeds up tests
     transform: {
         ".*": "babel-jest",
     },

--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -226,8 +226,8 @@ export class SchemaGenerator {
                             return;
                         }
 
-                        for (const node of nodes) {
-                            this.inspectNode(node, typeChecker, allTypes);
+                        for (const subnodes of nodes) {
+                            this.inspectNode(subnodes, typeChecker, allTypes);
                         }
                     }
                 }

--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -10,7 +10,6 @@ import type { TypeFormatter } from "./TypeFormatter.js";
 import type { StringMap } from "./Utils/StringMap.js";
 import { hasJsDocTag } from "./Utils/hasJsDocTag.js";
 import { removeUnreachable } from "./Utils/removeUnreachable.js";
-import { symbolAtNode } from "./Utils/symbolAtNode.js";
 
 export class SchemaGenerator {
     public constructor(
@@ -189,8 +188,8 @@ export class SchemaGenerator {
 
                 if (ts.isImportSpecifier(declaration)) {
                     // Handling the `Foo` in `import { Foo } from "./lib"; export { Foo };`
-                    const importSpecifierNode = declaration as ts.ImportSpecifier;
-                    const type = typeChecker.getTypeAtLocation(importSpecifierNode);
+                    const type = typeChecker.getTypeAtLocation(declaration);
+
                     if (type.symbol?.declarations?.length === 1) {
                         this.inspectNode(type.symbol.declarations[0], typeChecker, allTypes);
                     }

--- a/src/Utils/symbolAtNode.ts
+++ b/src/Utils/symbolAtNode.ts
@@ -1,8 +1,5 @@
-import ts from "typescript";
+import type ts from "typescript";
 
 export function symbolAtNode(node: ts.Node): ts.Symbol | undefined {
-    return (node as any).symbol;
-}
-export function localSymbolAtNode(node: ts.Node): ts.Symbol | undefined {
-    return (node as any).localSymbol;
+    return (node as ts.Declaration).symbol;
 }

--- a/test/sourceless-nodes/index.test.ts
+++ b/test/sourceless-nodes/index.test.ts
@@ -41,7 +41,7 @@ describe("sourceless-nodes", () => {
     });
 });
 
-// From github.com/arthurfiorette/kita/blob/main/packages/generator/src/util/type-resolver.ts
+// From https://github.com/kitajs/kitajs/blob/ebf23297de07887c78becff52120f941e69386ec/packages/parser/src/util/nodes.ts#L64
 function getReturnType(node: ts.SignatureDeclaration, typeChecker: ts.TypeChecker) {
     const signature = typeChecker.getSignatureFromDeclaration(node);
     const implicitType = typeChecker.getReturnTypeOfSignature(signature!);

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -145,4 +145,6 @@ describe("valid-data-type", () => {
     it("lowercase", assertValidSchema("lowercase", "MyType"));
 
     it("promise-extensions", assertValidSchema("promise-extensions", "*"));
+
+    it("export-star", assertValidSchema("export-star", "*", undefined, { mainTsOnly: true }));
 });

--- a/test/valid-data/export-star/literal.ts
+++ b/test/valid-data/export-star/literal.ts
@@ -1,0 +1,5 @@
+export type A = 1;
+
+export type B = "string";
+
+type C = "internal";

--- a/test/valid-data/export-star/main.ts
+++ b/test/valid-data/export-star/main.ts
@@ -2,3 +2,5 @@ export * from "./literal";
 export * from "./object";
 
 export type External = 1;
+
+type Internal = 2;

--- a/test/valid-data/export-star/main.ts
+++ b/test/valid-data/export-star/main.ts
@@ -1,0 +1,4 @@
+export * from "./literal";
+export * from "./object";
+
+export type External = 1;

--- a/test/valid-data/export-star/object.ts
+++ b/test/valid-data/export-star/object.ts
@@ -1,0 +1,11 @@
+export interface D {
+    a: 1;
+}
+
+export class E {
+    b: 2;
+}
+
+interface F {
+    internal: true;
+}

--- a/test/valid-data/export-star/schema.json
+++ b/test/valid-data/export-star/schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "A": {
+      "const": 1,
+      "type": "number"
+    },
+    "B": {
+      "const": "string",
+      "type": "string"
+    },
+    "D": {
+      "additionalProperties": false,
+      "properties": {
+        "a": {
+          "const": 1,
+          "type": "number"
+        }
+      },
+      "required": [
+        "a"
+      ],
+      "type": "object"
+    },
+    "E": {
+      "additionalProperties": false,
+      "properties": {
+        "b": {
+          "const": 2,
+          "type": "number"
+        }
+      },
+      "required": [
+        "b"
+      ],
+      "type": "object"
+    },
+    "External": {
+      "const": 1,
+      "type": "number"
+    }
+  }
+}


### PR DESCRIPTION
Adds support for `export *` statements.

I could not get `export { variable }` statements to work with `--expose *` for now, but I pushed some wip code at [`arthur/export-braces`](https://github.com/kitajs/ts-json-schema-generator/tree/arthur/export-braces) in case someone wants to continue it.

This PR also refactors some things at `SchemaGenerator` to improve readability and type safety.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.2.0-next.1`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: Sampsa Kaskela ([@SampsaKaskela](https://github.com/SampsaKaskela))
  
  :heart: Rama Krishna Ghanta ([@ramaghanta](https://github.com/ramaghanta))
  
  :heart: Tim ([@timothympace](https://github.com/timothympace))
  
  #### 🚀 Enhancement
  
  - feat: support `export *` statements [#1962](https://github.com/vega/ts-json-schema-generator/pull/1962) ([@arthurfiorette](https://github.com/arthurfiorette))
  - feat: Improved Promise handling to support packages like Prisma [#1924](https://github.com/vega/ts-json-schema-generator/pull/1924) ([@arthurfiorette](https://github.com/arthurfiorette))
  
  #### 🐛 Bug Fix
  
  - ci: update node version [#1961](https://github.com/vega/ts-json-schema-generator/pull/1961) ([@domoritz](https://github.com/domoritz))
  - bug: fix usage of * in type on Windows [#1942](https://github.com/vega/ts-json-schema-generator/pull/1942) ([@SampsaKaskela](https://github.com/SampsaKaskela) [@domoritz](https://github.com/domoritz))
  - removed import assertion [#1944](https://github.com/vega/ts-json-schema-generator/pull/1944) ([@ramaghanta](https://github.com/ramaghanta))
  - Provide more type saftey for vega-lite fixme [#1947](https://github.com/vega/ts-json-schema-generator/pull/1947) ([@timothympace](https://github.com/timothympace))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump vega-lite from 5.18.0 to 5.18.1 [#1960](https://github.com/vega/ts-json-schema-generator/pull/1960) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 12.0.0 to 12.1.0 [#1959](https://github.com/vega/ts-json-schema-generator/pull/1959) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.2.0 to 9.3.0 [#1958](https://github.com/vega/ts-json-schema-generator/pull/1958) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.9.1 to 4.10.5 [#1957](https://github.com/vega/ts-json-schema-generator/pull/1957) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega from 5.28.0 to 5.29.0 [#1955](https://github.com/vega/ts-json-schema-generator/pull/1955) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.24.4 to 7.24.5 [#1953](https://github.com/vega/ts-json-schema-generator/pull/1953) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump chai from 5.1.0 to 5.1.1 [#1952](https://github.com/vega/ts-json-schema-generator/pull/1952) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.24.4 to 7.24.5 [#1954](https://github.com/vega/ts-json-schema-generator/pull/1954) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 7.7.1 to 7.8.0 [#1948](https://github.com/vega/ts-json-schema-generator/pull/1948) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv from 8.12.0 to 8.13.0 [#1950](https://github.com/vega/ts-json-schema-generator/pull/1950) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.7.3 to 4.9.1 [#1951](https://github.com/vega/ts-json-schema-generator/pull/1951) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.1.1 to 9.2.0 [#1949](https://github.com/vega/ts-json-schema-generator/pull/1949) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.7.2 to 4.7.3 [#1940](https://github.com/vega/ts-json-schema-generator/pull/1940) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.1.0 to 9.1.1 [#1939](https://github.com/vega/ts-json-schema-generator/pull/1939) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 6
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Arthur Fiorette ([@arthurfiorette](https://github.com/arthurfiorette))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
  - Rama Krishna Ghanta ([@ramaghanta](https://github.com/ramaghanta))
  - Sampsa Kaskela ([@SampsaKaskela](https://github.com/SampsaKaskela))
  - Tim ([@timothympace](https://github.com/timothympace))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
