### PR TITLE
fix: remove ts-expose-types temporarily

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.7",
     "@types/normalize-path": "^3.0.2",
-    "@types/ts-expose-internals": "npm:ts-expose-internals@^5.4.5",
     "ajv": "^8.12.0",
     "ajv-formats": "^3.0.1",
     "auto": "^11.1.6",

--- a/src/NodeParser/FunctionNodeParser.ts
+++ b/src/NodeParser/FunctionNodeParser.ts
@@ -1,11 +1,11 @@
 import ts from "typescript";
-import { SubNodeParser } from "../SubNodeParser.js";
-import { BaseType } from "../Type/BaseType.js";
+import type { SubNodeParser } from "../SubNodeParser.js";
+import type { BaseType } from "../Type/BaseType.js";
 import { FunctionType } from "../Type/FunctionType.js";
-import { FunctionOptions } from "../Config.js";
+import type { FunctionOptions } from "../Config.js";
 import { NeverType } from "../Type/NeverType.js";
 import { DefinitionType } from "../Type/DefinitionType.js";
-import { Context, NodeParser } from "../NodeParser.js";
+import type { Context, NodeParser } from "../NodeParser.js";
 import { ObjectProperty, ObjectType } from "../Type/ObjectType.js";
 import { getKey } from "../Utils/nodeKey.js";
 
@@ -15,14 +15,11 @@ export class FunctionNodeParser implements SubNodeParser {
         protected functions: FunctionOptions,
     ) {}
 
-    public supportsNode(node: ts.TypeNode): boolean {
+    public supportsNode(node: ts.Node): boolean {
         return (
             node.kind === ts.SyntaxKind.FunctionType ||
-            // @ts-expect-error internals type bug
             node.kind === ts.SyntaxKind.FunctionExpression ||
-            // @ts-expect-error internals type bug
             node.kind === ts.SyntaxKind.ArrowFunction ||
-            // @ts-expect-error internals type bug
             node.kind === ts.SyntaxKind.FunctionDeclaration
         );
     }

--- a/src/NodeParser/PromiseNodeParser.ts
+++ b/src/NodeParser/PromiseNodeParser.ts
@@ -32,6 +32,7 @@ export class PromiseNodeParser implements SubNodeParser {
 
         const type = this.typeChecker.getTypeAtLocation(node);
 
+        //@ts-expect-error - internal typescript API
         const awaitedType = this.typeChecker.getAwaitedType(type);
 
         // ignores non awaitable types
@@ -60,7 +61,8 @@ export class PromiseNodeParser implements SubNodeParser {
         context: Context,
     ): BaseType {
         const type = this.typeChecker.getTypeAtLocation(node);
-        const awaitedType = this.typeChecker.getAwaitedType(type)!; // supportsNode ensures this
+        //@ts-expect-error - internal typescript API
+        const awaitedType = this.typeChecker.getAwaitedType(type);
         const awaitedNode = this.typeChecker.typeToTypeNode(awaitedType, undefined, ts.NodeBuilderFlags.IgnoreErrors);
 
         if (!awaitedNode) {

--- a/src/NodeParser/TypeReferenceNodeParser.ts
+++ b/src/NodeParser/TypeReferenceNodeParser.ts
@@ -6,6 +6,7 @@ import { AnyType } from "../Type/AnyType.js";
 import { ArrayType } from "../Type/ArrayType.js";
 import type { BaseType } from "../Type/BaseType.js";
 import { StringType } from "../Type/StringType.js";
+import { symbolAtNode } from "../Utils/symbolAtNode.js";
 
 const invalidTypes: Record<number, boolean> = {
     [ts.SyntaxKind.ModuleDeclaration]: true,
@@ -28,7 +29,7 @@ export class TypeReferenceNodeParser implements SubNodeParser {
             // When the node doesn't have a valid source file, its position is -1, so we can't
             // search for a symbol based on its location. In that case, the ts.factory defines a symbol
             // property on the node itself.
-            (node.typeName as unknown as ts.Type).symbol;
+            symbolAtNode(node.typeName)!;
 
         if (typeSymbol.flags & ts.SymbolFlags.Alias) {
             const aliasedSymbol = this.typeChecker.getAliasedSymbol(typeSymbol);

--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -10,6 +10,7 @@ import type { TypeFormatter } from "./TypeFormatter.js";
 import type { StringMap } from "./Utils/StringMap.js";
 import { hasJsDocTag } from "./Utils/hasJsDocTag.js";
 import { removeUnreachable } from "./Utils/removeUnreachable.js";
+import { symbolAtNode } from "./Utils/symbolAtNode.js";
 
 export class SchemaGenerator {
     public constructor(
@@ -262,6 +263,7 @@ export class SchemaGenerator {
             return false;
         }
 
+        //@ts-expect-error - internal typescript API
         return !!node.localSymbol?.exportSymbol;
     }
 
@@ -270,6 +272,6 @@ export class SchemaGenerator {
     }
 
     protected getFullName(node: ts.Declaration, typeChecker: ts.TypeChecker): string {
-        return typeChecker.getFullyQualifiedName(node.symbol).replace(/".*"\./, "");
+        return typeChecker.getFullyQualifiedName(symbolAtNode(node)!).replace(/".*"\./, "");
     }
 }

--- a/src/Utils/symbolAtNode.ts
+++ b/src/Utils/symbolAtNode.ts
@@ -1,5 +1,6 @@
 import type ts from "typescript";
 
 export function symbolAtNode(node: ts.Node): ts.Symbol | undefined {
-    return (node as ts.Declaration).symbol;
+    //@ts-expect-error - internal typescript API
+    return node.symbol;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1976,11 +1976,6 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
 
-"@types/ts-expose-internals@npm:ts-expose-internals@^5.4.5":
-  version "5.4.5"
-  resolved "https://registry.yarnpkg.com/ts-expose-internals/-/ts-expose-internals-5.4.5.tgz#94da2b665627135ad1281d98af3ccb08cb4c1950"
-  integrity sha512-0HfRwjgSIOyuDlHzkFedMWU4aHWq9pu4MUKHgH75U+L76wCAtK5WB0rc/dAIhulMRcPUlcKONeiiR5Sxy/7XcA==
-
 "@types/yargs-parser@*":
   version "21.0.3"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"


### PR DESCRIPTION
closes #1967

This PR removes `ts-expose-internals` until https://github.com/nonara/ts-expose-internals/issues/14 has a solution.

Published at `2.3.0--canary.1968.a70651a.0`
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.3.0-next.1`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - Remove ts-expose-types temporarily [#1968](https://github.com/vega/ts-json-schema-generator/pull/1968) ([@arthurfiorette](https://github.com/arthurfiorette))
  - Added diagnostics to all errors [#1963](https://github.com/vega/ts-json-schema-generator/pull/1963) ([@arthurfiorette](https://github.com/arthurfiorette))
  
  #### Authors: 1
  
  - Arthur Fiorette ([@arthurfiorette](https://github.com/arthurfiorette))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.3.0--canary.1968.c39cb48.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install ts-json-schema-generator@2.3.0--canary.1968.c39cb48.0
  # or 
  yarn add ts-json-schema-generator@2.3.0--canary.1968.c39cb48.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
