### PR TITLE
fix(factory): Fix deprecated glob import that prevents using from code after glob upgrade

### DIFF
--- a/factory/program.ts
+++ b/factory/program.ts
@@ -1,9 +1,9 @@
-import * as glob from "glob";
 import * as path from "node:path";
 import normalize from "normalize-path";
 import ts from "typescript";
 import type { CompletedConfig, Config } from "../src/Config.js";
 import { BuildError } from "../src/Error/Errors.js";
+import { globSync } from "glob";
 
 function loadTsConfigFile(configFile: string) {
     const raw = ts.sys.readFile(configFile);
@@ -64,7 +64,7 @@ function getTsConfig(config: Config) {
 
 export function createProgram(config: CompletedConfig): ts.Program {
     const rootNamesFromPath = config.path
-        ? glob.sync(normalize(path.resolve(config.path))).map((rootName) => normalize(rootName))
+        ? globSync(normalize(path.resolve(config.path))).map((rootName) => normalize(rootName))
         : [];
     const tsconfig = getTsConfig(config);
     const rootNames = rootNamesFromPath.length ? rootNamesFromPath : tsconfig.fileNames;


### PR DESCRIPTION
After updating glob to `^10.x.x`, [named exports where removed](https://github.com/isaacs/node-glob/blob/main/changelog.md#1000)
There was 1 global import left in the factory that prevented the generation from code-level with the following stack:
```
There was an error generating schema from ./src/models/config/*.ts TypeError: glob.sync is not a function
    at createProgram (file:///home/runner/work/pi-rat/pi-rat/node_modules/ts-json-schema-generator/dist/factory/program.js:51:1[6](https://github.com/furystack/pi-rat/actions/runs/9336662958/job/25697493845?pr=57#step:7:7))
    at createGenerator (file:///home/runner/work/pi-rat/pi-rat/node_modules/ts-json-schema-generator/dist/factory/generator.js:8:21)
    at file:///home/runner/work/pi-rat/pi-rat/common/dist/bin/create-schemas.js:92:28
    at Array.map (<anonymous>)
    at exec (file:///home/runner/work/pi-rat/pi-rat/common/dist/bin/create-schemas.js:8[7](https://github.com/furystack/pi-rat/actions/runs/9336662958/job/25697493845?pr=57#step:7:8):55)
    at file:///home/runner/work/pi-rat/pi-rat/common/dist/bin/create-schemas.js:105:1
    at ModuleJob.run (node:internal/modules/esm/module_job:222:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:316:24)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:123:5)
```

This little PR fixes the invalid import
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.3.0-next.5`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Lajos ([@gallayl](https://github.com/gallayl)), for all your work!
  
  #### 🚀 Enhancement
  
  - feat: get version from package.json [#1979](https://github.com/vega/ts-json-schema-generator/pull/1979) ([@domoritz](https://github.com/domoritz))
  - fix: revert back to commons js [#1975](https://github.com/vega/ts-json-schema-generator/pull/1975) ([@arthurfiorette](https://github.com/arthurfiorette))
  - fix: remove ts-expose-types temporarily [#1968](https://github.com/vega/ts-json-schema-generator/pull/1968) ([@arthurfiorette](https://github.com/arthurfiorette))
  - Added diagnostics to all errors [#1963](https://github.com/vega/ts-json-schema-generator/pull/1963) ([@arthurfiorette](https://github.com/arthurfiorette))
  
  #### 🐛 Bug Fix
  
  - fix(factory): Fix deprecated glob import that prevents using from code after glob upgrade [#1981](https://github.com/vega/ts-json-schema-generator/pull/1981) ([@gallayl](https://github.com/gallayl))
  - fix: Unknown type "undefined" when using generics without base type [#1978](https://github.com/vega/ts-json-schema-generator/pull/1978) ([@arthurfiorette](https://github.com/arthurfiorette))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump @babel/preset-env from 7.24.5 to 7.24.6 [#1982](https://github.com/vega/ts-json-schema-generator/pull/1982) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.3.0 to 9.4.0 [#1984](https://github.com/vega/ts-json-schema-generator/pull/1984) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.24.5 to 7.24.6 [#1983](https://github.com/vega/ts-json-schema-generator/pull/1983) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.3.0 to 9.4.0 [#1985](https://github.com/vega/ts-json-schema-generator/pull/1985) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.2.0 to 9.3.0 [#1970](https://github.com/vega/ts-json-schema-generator/pull/1970) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv from 8.13.0 to 8.14.0 [#1971](https://github.com/vega/ts-json-schema-generator/pull/1971) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 7.8.0 to 7.10.0 [#1972](https://github.com/vega/ts-json-schema-generator/pull/1972) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 4
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Arthur Fiorette ([@arthurfiorette](https://github.com/arthurfiorette))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
  - Lajos ([@gallayl](https://github.com/gallayl))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
