### PR TITLE
fix: `--expose all` with generic types

### DIFF
--- a/src/Error/Errors.ts
+++ b/src/Error/Errors.ts
@@ -17,7 +17,7 @@ export class UnknownTypeError extends BaseError {
     constructor(readonly type: BaseType) {
         super({
             code: 101,
-            messageText: `Unknown type "${type.getId()}"`,
+            messageText: `Unknown type "${type?.getId()}"`,
         });
     }
 }

--- a/src/NodeParser/InterfaceAndClassNodeParser.ts
+++ b/src/NodeParser/InterfaceAndClassNodeParser.ts
@@ -113,7 +113,7 @@ export class InterfaceAndClassNodeParser implements SubNodeParser {
                     if (ts.isConstructorDeclaration(member)) {
                         const params = member.parameters.filter((param) =>
                             ts.isParameterPropertyDeclaration(param, param.parent),
-                        ) as ts.ParameterPropertyDeclaration[];
+                        );
                         members.push(...params);
                     } else if (ts.isPropertySignature(member) || ts.isPropertyDeclaration(member)) {
                         members.push(member);

--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -166,8 +166,8 @@ export class SchemaGenerator {
             ts.isTypeAliasDeclaration(node)
         ) {
             if (
-                this.config?.expose === "all" ||
-                (this.isExportType(node) && !this.isGenericType(node as ts.TypeAliasDeclaration))
+                (this.config?.expose === "all" || this.isExportType(node)) &&
+                !this.isGenericType(node as ts.TypeAliasDeclaration)
             ) {
                 allTypes.set(this.getFullName(node, typeChecker), node);
                 return;

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -46,13 +46,10 @@ describe("valid-data-other", () => {
     it("generic-simple", assertValidSchema("generic-simple", "*", { expose: "all" }));
     it("generic-arrays", assertValidSchema("generic-arrays", "MyObject"));
     it("generic-multiple", assertValidSchema("generic-multiple", "MyObject"));
-    it("generic-multiple", assertValidSchema("generic-multiple", "*", { expose: "all" }));
     it("generic-multiargs", assertValidSchema("generic-multiargs", "MyObject"));
     it("generic-anonymous", assertValidSchema("generic-anonymous", "MyObject"));
-    it("generic-anonymous", assertValidSchema("generic-anonymous", "*", { expose: "all" }));
     it("generic-recursive", assertValidSchema("generic-recursive", "MyObject"));
     it("generic-hell", assertValidSchema("generic-hell", "MyObject"));
-    it("generic-hell", assertValidSchema("generic-hell", "*", { expose: "all" }));
     it("generic-default-conditional", assertValidSchema("generic-default-conditional", "MyObject"));
     it("generic-default", assertValidSchema("generic-default", "MyObject"));
     it("generic-nested", assertValidSchema("generic-nested", "MyObject"));

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -43,6 +43,7 @@ describe("valid-data-other", () => {
     it("import-anonymous", assertValidSchema("import-anonymous", "MyObject"));
 
     it("generic-simple", assertValidSchema("generic-simple", "MyObject"));
+    it("generic-simple", assertValidSchema("generic-simple", "*", { expose: "all" }));
     it("generic-arrays", assertValidSchema("generic-arrays", "MyObject"));
     it("generic-multiple", assertValidSchema("generic-multiple", "MyObject"));
     it("generic-multiargs", assertValidSchema("generic-multiargs", "MyObject"));

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -46,10 +46,13 @@ describe("valid-data-other", () => {
     it("generic-simple", assertValidSchema("generic-simple", "*", { expose: "all" }));
     it("generic-arrays", assertValidSchema("generic-arrays", "MyObject"));
     it("generic-multiple", assertValidSchema("generic-multiple", "MyObject"));
+    it("generic-multiple", assertValidSchema("generic-multiple", "*", { expose: "all" }));
     it("generic-multiargs", assertValidSchema("generic-multiargs", "MyObject"));
     it("generic-anonymous", assertValidSchema("generic-anonymous", "MyObject"));
+    it("generic-anonymous", assertValidSchema("generic-anonymous", "*", { expose: "all" }));
     it("generic-recursive", assertValidSchema("generic-recursive", "MyObject"));
     it("generic-hell", assertValidSchema("generic-hell", "MyObject"));
+    it("generic-hell", assertValidSchema("generic-hell", "*", { expose: "all" }));
     it("generic-default-conditional", assertValidSchema("generic-default-conditional", "MyObject"));
     it("generic-default", assertValidSchema("generic-default", "MyObject"));
     it("generic-nested", assertValidSchema("generic-nested", "MyObject"));


### PR DESCRIPTION
This PR fixes #2002, which was trying to generate schemad for base generic types, and not its "implementations"

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.3.1--canary.2009.7311b71.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install ts-json-schema-generator@2.3.1--canary.2009.7311b71.0
  # or 
  yarn add ts-json-schema-generator@2.3.1--canary.2009.7311b71.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.4.0-next.0`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - fix: `--expose all` with generic types [#2009](https://github.com/vega/ts-json-schema-generator/pull/2009) ([@arthurfiorette](https://github.com/arthurfiorette))
  
  #### 🐛 Bug Fix
  
  - chore: update deps [#2007](https://github.com/vega/ts-json-schema-generator/pull/2007) ([@domoritz](https://github.com/domoritz))
  
  #### ⚠️ Pushed to `next`
  
  - docs: overrides ([@domoritz](https://github.com/domoritz))
  
  #### 🔩 Dependency Updates
  
  - chore(deps): bump typescript from 5.4.5 to 5.5.2 [#2005](https://github.com/vega/ts-json-schema-generator/pull/2005) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.10.5 to 4.16.0 [#2006](https://github.com/vega/ts-json-schema-generator/pull/2006) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.24.6 to 7.24.7 [#1999](https://github.com/vega/ts-json-schema-generator/pull/1999) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.4.0 to 9.5.0 [#2000](https://github.com/vega/ts-json-schema-generator/pull/2000) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump braces from 3.0.2 to 3.0.3 [#1993](https://github.com/vega/ts-json-schema-generator/pull/1993) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.24.1 to 7.24.7 [#1995](https://github.com/vega/ts-json-schema-generator/pull/1995) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 3.2.5 to 3.3.1 [#1988](https://github.com/vega/ts-json-schema-generator/pull/1988) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump tslib from 2.6.2 to 2.6.3 [#1989](https://github.com/vega/ts-json-schema-generator/pull/1989) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.24.6 to 7.24.7 [#1991](https://github.com/vega/ts-json-schema-generator/pull/1991) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 3
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Arthur Fiorette ([@arthurfiorette](https://github.com/arthurfiorette))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
