### PR TITLE
fix: schema generation when property name cannot be escaped

### DIFF
--- a/src/NodeParser/TypeLiteralNodeParser.ts
+++ b/src/NodeParser/TypeLiteralNodeParser.ts
@@ -93,8 +93,10 @@ export class TypeLiteralNodeParser implements SubNodeParser {
         } catch {
             // When propertyName was programmatically created, it doesn't have a source file.
             // Then, getText() will throw an error. But, for programmatically created nodes,`
-            // `escapedText` is available.
-            return (propertyName as ts.Identifier).escapedText as string;
+            // `escapedText` or `text` is available.
+            // Only `text` will be available when propertyName contains strange characters and it cannot be escaped
+            // or if it is a number.
+            return ((propertyName as ts.Identifier).escapedText as string) ?? (propertyName as ts.StringLiteral).text;
         }
     }
 }

--- a/test/valid-data-struct.test.ts
+++ b/test/valid-data-struct.test.ts
@@ -36,4 +36,6 @@ describe("valid-data-struct", () => {
     it("structure-anonymous", assertValidSchema("structure-anonymous", "MyObject"));
     it("structure-recursion", assertValidSchema("structure-recursion", "MyObject"));
     it("structure-extra-props", assertValidSchema("structure-extra-props", "MyObject"));
+
+    it("string-literal-property-names", assertValidSchema("string-literal-property-names", "*"));
 });

--- a/test/valid-data/string-literal-property-names/main.ts
+++ b/test/valid-data/string-literal-property-names/main.ts
@@ -1,0 +1,38 @@
+// Class props has only implicit types!
+export class MyClass {
+    PROP_1 = '';
+    "PROP_2" = '';
+    "PROP.3" = '';
+    "{PROP_4}" =  '';
+    "400" = '';
+    500 = '';
+    '' = '';
+    CHILD = {
+        PROP_1: '',
+        "PROP_2": '',
+        "PROP.3": '',
+        "{PROP_4}":  '',
+        "400": '',
+        500: '',
+        '': '',
+    };
+}
+
+export interface MyInterface {
+    PROP_1: string;
+    "PROP_2": string;
+    "PROP.3": string;
+    "{PROP_4}":  string;
+    "400": string;
+    500: string;
+    '': string;
+    CHILD : {
+        PROP_1: string,
+        "PROP_2": string,
+        "PROP.3": string,
+        "{PROP_4}":  string,
+        "400": string,
+        500: string,
+        '': string
+    };
+}

--- a/test/valid-data/string-literal-property-names/schema.json
+++ b/test/valid-data/string-literal-property-names/schema.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyClass": {
+      "additionalProperties": false,
+      "properties": {
+        "": {
+          "type": "string"
+        },
+        "400": {
+          "type": "string"
+        },
+        "500": {
+          "type": "string"
+        },
+        "CHILD": {
+          "additionalProperties": false,
+          "properties": {
+            "": {
+              "type": "string"
+            },
+            "400": {
+              "type": "string"
+            },
+            "500": {
+              "type": "string"
+            },
+            "PROP.3": {
+              "type": "string"
+            },
+            "PROP_1": {
+              "type": "string"
+            },
+            "PROP_2": {
+              "type": "string"
+            },
+            "{PROP_4}": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "PROP_1",
+            "PROP_2",
+            "PROP.3",
+            "{PROP_4}",
+            "400",
+            "500",
+            ""
+          ],
+          "type": "object"
+        },
+        "PROP.3": {
+          "type": "string"
+        },
+        "PROP_1": {
+          "type": "string"
+        },
+        "PROP_2": {
+          "type": "string"
+        },
+        "{PROP_4}": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "PROP_1",
+        "PROP_2",
+        "PROP.3",
+        "{PROP_4}",
+        "400",
+        "500",
+        "",
+        "CHILD"
+      ],
+      "type": "object"
+    },
+    "MyInterface": {
+      "additionalProperties": false,
+      "properties": {
+        "": {
+          "type": "string"
+        },
+        "400": {
+          "type": "string"
+        },
+        "500": {
+          "type": "string"
+        },
+        "CHILD": {
+          "additionalProperties": false,
+          "properties": {
+            "": {
+              "type": "string"
+            },
+            "400": {
+              "type": "string"
+            },
+            "500": {
+              "type": "string"
+            },
+            "PROP.3": {
+              "type": "string"
+            },
+            "PROP_1": {
+              "type": "string"
+            },
+            "PROP_2": {
+              "type": "string"
+            },
+            "{PROP_4}": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "PROP_1",
+            "PROP_2",
+            "PROP.3",
+            "{PROP_4}",
+            "400",
+            "500",
+            ""
+          ],
+          "type": "object"
+        },
+        "PROP.3": {
+          "type": "string"
+        },
+        "PROP_1": {
+          "type": "string"
+        },
+        "PROP_2": {
+          "type": "string"
+        },
+        "{PROP_4}": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "PROP_1",
+        "PROP_2",
+        "PROP.3",
+        "{PROP_4}",
+        "400",
+        "500",
+        "",
+        "CHILD"
+      ],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
Fixes: https://github.com/vega/ts-json-schema-generator/issues/2017

Conclusion:
After deeper insight, the described issue only occured, in case of nested properties and when the property doesn't have explict type definition and it's key is a string literal that cannot be escaped or a number.
By that, it didn't impact interfaces since they are explicit type definitions themselves, but unit test was provided for class and interface anyway.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.4.0-next.1`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Bence Balogh ([@baloghbence0915](https://github.com/baloghbence0915)), for all your work!
  
  #### 🚀 Enhancement
  
  - fix: `--expose all` with generic types [#2009](https://github.com/vega/ts-json-schema-generator/pull/2009) ([@arthurfiorette](https://github.com/arthurfiorette))
  
  #### 🐛 Bug Fix
  
  - fix: schema generation when property name cannot be escaped [#2018](https://github.com/vega/ts-json-schema-generator/pull/2018) (bence.balogh@ingenimind.com)
  - chore: update deps [#2007](https://github.com/vega/ts-json-schema-generator/pull/2007) ([@domoritz](https://github.com/domoritz))
  
  #### ⚠️ Pushed to `next`
  
  - docs: overrides ([@domoritz](https://github.com/domoritz))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump typescript-eslint from 7.14.1 to 7.15.0 [#2013](https://github.com/vega/ts-json-schema-generator/pull/2013) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.16.0 to 4.16.2 [#2014](https://github.com/vega/ts-json-schema-generator/pull/2014) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 5.5.2 to 5.5.3 [#2015](https://github.com/vega/ts-json-schema-generator/pull/2015) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 20.14.9 to 20.14.10 [#2016](https://github.com/vega/ts-json-schema-generator/pull/2016) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 5.4.5 to 5.5.2 [#2005](https://github.com/vega/ts-json-schema-generator/pull/2005) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.10.5 to 4.16.0 [#2006](https://github.com/vega/ts-json-schema-generator/pull/2006) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.24.6 to 7.24.7 [#1999](https://github.com/vega/ts-json-schema-generator/pull/1999) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.4.0 to 9.5.0 [#2000](https://github.com/vega/ts-json-schema-generator/pull/2000) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump braces from 3.0.2 to 3.0.3 [#1993](https://github.com/vega/ts-json-schema-generator/pull/1993) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.24.1 to 7.24.7 [#1995](https://github.com/vega/ts-json-schema-generator/pull/1995) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 3.2.5 to 3.3.1 [#1988](https://github.com/vega/ts-json-schema-generator/pull/1988) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump tslib from 2.6.2 to 2.6.3 [#1989](https://github.com/vega/ts-json-schema-generator/pull/1989) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.24.6 to 7.24.7 [#1991](https://github.com/vega/ts-json-schema-generator/pull/1991) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 4
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Arthur Fiorette ([@arthurfiorette](https://github.com/arthurfiorette))
  - Bence Balogh ([@baloghbence0915](https://github.com/baloghbence0915))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
