### PR TITLE
fix: keyof typeof fields inside objects

### DIFF
--- a/src/NodeParser/ObjectLiteralExpressionNodeParser.ts
+++ b/src/NodeParser/ObjectLiteralExpressionNodeParser.ts
@@ -88,7 +88,7 @@ export class ObjectLiteralExpressionNodeParser implements SubNodeParser {
             return new ObjectProperty(
                 t.name.getText(),
                 this.childNodeParser.createType(type, context),
-                !(t as ts).questionToken,
+                !(t as any).questionToken,
             );
         });
     }

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -144,7 +144,7 @@ describe("valid-data-type", () => {
 
     it("lowercase", assertValidSchema("lowercase", "MyType"));
     it("const-spread", assertValidSchema("const-spread", "MyType"));
-    it.only("keyof-typeof-x", assertValidSchema("keyof-typeof-x", "MyType"));
+    it("keyof-typeof-x", assertValidSchema("keyof-typeof-x", "MyType"));
 
     it("promise-extensions", assertValidSchema("promise-extensions", "*"));
 

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -144,6 +144,7 @@ describe("valid-data-type", () => {
 
     it("lowercase", assertValidSchema("lowercase", "MyType"));
     it("const-spread", assertValidSchema("const-spread", "MyType"));
+    it.only("keyof-typeof-x", assertValidSchema("keyof-typeof-x", "MyType"));
 
     it("promise-extensions", assertValidSchema("promise-extensions", "*"));
 

--- a/test/valid-data/keyof-typeof-x/main.ts
+++ b/test/valid-data/keyof-typeof-x/main.ts
@@ -1,0 +1,3 @@
+const myprop = 0;
+export const mymap = { myprop };
+export type MyType = keyof typeof mymap;

--- a/test/valid-data/keyof-typeof-x/schema.json
+++ b/test/valid-data/keyof-typeof-x/schema.json
@@ -1,0 +1,10 @@
+{
+  "$ref": "#/definitions/MyType",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyType": {
+      "const": "myprop",
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
closes #2034

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.3.1--canary.2040.6bbd048.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install ts-json-schema-generator@2.3.1--canary.2040.6bbd048.0
  # or 
  yarn add ts-json-schema-generator@2.3.1--canary.2040.6bbd048.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.4.0-next.3`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Bence Balogh ([@baloghbence0915](https://github.com/baloghbence0915)), for all your work!
  
  #### 🚀 Enhancement
  
  - fix: `--expose all` with generic types [#2009](https://github.com/vega/ts-json-schema-generator/pull/2009) ([@arthurfiorette](https://github.com/arthurfiorette))
  
  #### 🐛 Bug Fix
  
  - fix: keyof typeof fields inside objects [#2040](https://github.com/vega/ts-json-schema-generator/pull/2040) ([@arthurfiorette](https://github.com/arthurfiorette))
  - fix: TypeError on const spread [#2039](https://github.com/vega/ts-json-schema-generator/pull/2039) ([@arthurfiorette](https://github.com/arthurfiorette))
  - fix: schema generation when property name cannot be escaped [#2018](https://github.com/vega/ts-json-schema-generator/pull/2018) (bence.balogh@ingenimind.com)
  - chore: update deps [#2007](https://github.com/vega/ts-json-schema-generator/pull/2007) ([@domoritz](https://github.com/domoritz))
  
  #### ⚠️ Pushed to `next`
  
  - docs: overrides ([@domoritz](https://github.com/domoritz))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump @eslint/js from 9.8.0 to 9.9.0 [#2035](https://github.com/vega/ts-json-schema-generator/pull/2035) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 11.1.6 to 11.2.0 [#2036](https://github.com/vega/ts-json-schema-generator/pull/2036) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 5.5.3 to 5.5.4 [#2037](https://github.com/vega/ts-json-schema-generator/pull/2037) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.16.2 to 4.17.0 [#2038](https://github.com/vega/ts-json-schema-generator/pull/2038) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega-lite from 5.19.0 to 5.20.1 [#2030](https://github.com/vega/ts-json-schema-generator/pull/2030) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@domoritz](https://github.com/domoritz))
  - chore(deps-dev): bump @babel/core from 7.24.7 to 7.25.2 [#2031](https://github.com/vega/ts-json-schema-generator/pull/2031) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 11.1.6 to 11.2.0 [#2032](https://github.com/vega/ts-json-schema-generator/pull/2032) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.1.3 to 5.2.1 [#2033](https://github.com/vega/ts-json-schema-generator/pull/2033) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 20.14.10 to 22.0.0 [#2029](https://github.com/vega/ts-json-schema-generator/pull/2029) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint and @types/eslint [#2027](https://github.com/vega/ts-json-schema-generator/pull/2027) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 7.16.0 to 7.17.0 [#2028](https://github.com/vega/ts-json-schema-generator/pull/2028) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.24.7 to 7.24.8 [#2019](https://github.com/vega/ts-json-schema-generator/pull/2019) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv from 8.16.0 to 8.17.1 [#2020](https://github.com/vega/ts-json-schema-generator/pull/2020) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 7.15.0 to 7.16.0 [#2021](https://github.com/vega/ts-json-schema-generator/pull/2021) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 3.3.2 to 3.3.3 [#2022](https://github.com/vega/ts-json-schema-generator/pull/2022) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 7.14.1 to 7.15.0 [#2013](https://github.com/vega/ts-json-schema-generator/pull/2013) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.16.0 to 4.16.2 [#2014](https://github.com/vega/ts-json-schema-generator/pull/2014) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 5.5.2 to 5.5.3 [#2015](https://github.com/vega/ts-json-schema-generator/pull/2015) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 20.14.9 to 20.14.10 [#2016](https://github.com/vega/ts-json-schema-generator/pull/2016) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 5.4.5 to 5.5.2 [#2005](https://github.com/vega/ts-json-schema-generator/pull/2005) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.10.5 to 4.16.0 [#2006](https://github.com/vega/ts-json-schema-generator/pull/2006) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.24.6 to 7.24.7 [#1999](https://github.com/vega/ts-json-schema-generator/pull/1999) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.4.0 to 9.5.0 [#2000](https://github.com/vega/ts-json-schema-generator/pull/2000) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump braces from 3.0.2 to 3.0.3 [#1993](https://github.com/vega/ts-json-schema-generator/pull/1993) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.24.1 to 7.24.7 [#1995](https://github.com/vega/ts-json-schema-generator/pull/1995) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 3.2.5 to 3.3.1 [#1988](https://github.com/vega/ts-json-schema-generator/pull/1988) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump tslib from 2.6.2 to 2.6.3 [#1989](https://github.com/vega/ts-json-schema-generator/pull/1989) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.24.6 to 7.24.7 [#1991](https://github.com/vega/ts-json-schema-generator/pull/1991) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 4
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Arthur Fiorette ([@arthurfiorette](https://github.com/arthurfiorette))
  - Bence Balogh ([@baloghbence0915](https://github.com/baloghbence0915))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
