### PR TITLE
feat: add unhandled error to append useful information

### DIFF
--- a/src/ChainNodeParser.ts
+++ b/src/ChainNodeParser.ts
@@ -1,5 +1,5 @@
 import type ts from "typescript";
-import { UnknownNodeError } from "./Error/Errors.js";
+import { UnhandledError, UnknownNodeError } from "./Error/Errors.js";
 import type { MutableParser } from "./MutableParser.js";
 import type { Context } from "./NodeParser.js";
 import type { SubNodeParser } from "./SubNodeParser.js";
@@ -32,7 +32,11 @@ export class ChainNodeParser implements SubNodeParser, MutableParser {
         const contextCacheKey = context.getCacheKey();
         let type = typeCache.get(contextCacheKey);
         if (!type) {
-            type = this.getNodeParser(node).createType(node, context, reference);
+            try {
+                type = this.getNodeParser(node).createType(node, context, reference);
+            } catch (error) {
+                throw UnhandledError.from("Unhandled error while creating Base Type.", node, error);
+            }
             if (!(type instanceof ReferenceType)) {
                 typeCache.set(contextCacheKey, type);
             }

--- a/src/Error/Errors.ts
+++ b/src/Error/Errors.ts
@@ -118,6 +118,6 @@ export class UnhandledError extends BaseError {
     static from(message: string, node?: ts.Node, cause?: unknown) {
         // This might be called deeply inside the parser chain
         // this ensures it doesn't end up with error.cause.cause.cause...
-        return cause instanceof UnhandledError ? cause : new UnhandledError(message, node, cause);
+        return cause instanceof BaseError ? cause : new UnhandledError(message, node, cause);
     }
 }

--- a/src/Error/Errors.ts
+++ b/src/Error/Errors.ts
@@ -102,3 +102,22 @@ export class BuildError extends BaseError {
         });
     }
 }
+
+export class UnhandledError extends BaseError {
+    private constructor(
+        messageText: string,
+        node?: ts.Node,
+        readonly cause?: unknown,
+    ) {
+        super({ code: 109, messageText, node });
+    }
+
+    /**
+     * Creates a new error with a cause and optional node information and ensures it is not wrapped in another UnhandledError
+     */
+    static from(message: string, node?: ts.Node, cause?: unknown) {
+        // This might be called deeply inside the parser chain
+        // this ensures it doesn't end up with error.cause.cause.cause...
+        return cause instanceof UnhandledError ? cause : new UnhandledError(message, node, cause);
+    }
+}

--- a/src/Error/Errors.ts
+++ b/src/Error/Errors.ts
@@ -1,7 +1,7 @@
-import ts from "typescript";
-import { type PartialDiagnostic, BaseError } from "./BaseError.js";
-import type { BaseType } from "../Type/BaseType.js";
 import type { JSONSchema7 } from "json-schema";
+import ts from "typescript";
+import type { BaseType } from "../Type/BaseType.js";
+import { BaseError, type PartialDiagnostic } from "./BaseError.js";
 
 export class UnknownNodeError extends BaseError {
     constructor(readonly node: ts.Node) {

--- a/src/NodeParser/BooleanTypeNodeParser.ts
+++ b/src/NodeParser/BooleanTypeNodeParser.ts
@@ -9,8 +9,6 @@ export class BooleanTypeNodeParser implements SubNodeParser {
         return node.kind === ts.SyntaxKind.BooleanKeyword;
     }
     public createType(node: ts.KeywordTypeNode, context: Context): BaseType {
-        let a = undefined;
-        a.toString();
         return new BooleanType();
     }
 }

--- a/src/NodeParser/BooleanTypeNodeParser.ts
+++ b/src/NodeParser/BooleanTypeNodeParser.ts
@@ -9,6 +9,8 @@ export class BooleanTypeNodeParser implements SubNodeParser {
         return node.kind === ts.SyntaxKind.BooleanKeyword;
     }
     public createType(node: ts.KeywordTypeNode, context: Context): BaseType {
+        let a = undefined;
+        a.toString();
         return new BooleanType();
     }
 }

--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -1,6 +1,6 @@
 import ts from "typescript";
 import type { Config } from "./Config.js";
-import { FailedTypeCreation, MultipleDefinitionsError, RootlessError, UnhandledError } from "./Error/Errors.js";
+import { MultipleDefinitionsError, RootlessError, UnhandledError } from "./Error/Errors.js";
 import { Context, type NodeParser } from "./NodeParser.js";
 import type { Definition } from "./Schema/Definition.js";
 import type { Schema } from "./Schema/Schema.js";

--- a/ts-json-schema-generator.ts
+++ b/ts-json-schema-generator.ts
@@ -86,13 +86,19 @@ try {
         writeFileSync(args.out, schemaString);
     } else {
         // write to stdout
-        process.stdout.write(`${schemaString}\n`);
+        console.log(`${schemaString}\n`);
     }
 } catch (error) {
     if (error instanceof BaseError) {
-        process.stderr.write(error.format());
-        process.exit(1);
-    }
+        console.error(error.format());
 
-    throw error;
+        if (error.cause) {
+            console.error(error.cause);
+        }
+
+        // Maybe we are being imported by another script
+        process.exitCode = 1;
+    } else {
+        throw error;
+    }
 }


### PR DESCRIPTION
This PR wraps every interaction with node parsers and type formatters aroung a catch that rethrows an `UnhandledError`. 

This way, for example, if `BooleanTypeNodeParser` had a code like this:

```ts
public createType(node: ts.KeywordTypeNode, context: Context): BaseType {
    let a = undefined;
    a.toString();
    return new BooleanType();
}
```

Instead of just seeing: _(Which almost always doesn't say anything useful)_

```
TypeError: Cannot read properties of undefined (reading 'toString')
    at BooleanTypeNodeParser.createType (/ts-json-schema-generator/dist/src/NodeParser/BooleanTypeNodeParser.js:13:11)
```

we can see which part of user's code triggered this error.

![image](https://github.com/user-attachments/assets/c8d16d64-e2ed-43ef-ae44-200c4c5548fc)

This is a big improvement to users, so they can debug issues themselves with more clarity of what is breaking and for us in reported issues to reduce the number of issues where the only useful information is the stack trace, like #1861 or #1756 and many others I'm sure you've already saw.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.3.1--canary.2063.403e019.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install ts-json-schema-generator@2.3.1--canary.2063.403e019.0
  # or 
  yarn add ts-json-schema-generator@2.3.1--canary.2063.403e019.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.4.0-next.4`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Bence Balogh ([@baloghbence0915](https://github.com/baloghbence0915)), for all your work!
  
  #### 🚀 Enhancement
  
  - feat: add unhandled error to append useful information [#2063](https://github.com/vega/ts-json-schema-generator/pull/2063) ([@arthurfiorette](https://github.com/arthurfiorette))
  - fix: `--expose all` with generic types [#2009](https://github.com/vega/ts-json-schema-generator/pull/2009) ([@arthurfiorette](https://github.com/arthurfiorette))
  
  #### 🐛 Bug Fix
  
  - fix: keyof typeof fields inside objects [#2040](https://github.com/vega/ts-json-schema-generator/pull/2040) ([@arthurfiorette](https://github.com/arthurfiorette))
  - fix: TypeError on const spread [#2039](https://github.com/vega/ts-json-schema-generator/pull/2039) ([@arthurfiorette](https://github.com/arthurfiorette))
  - fix: schema generation when property name cannot be escaped [#2018](https://github.com/vega/ts-json-schema-generator/pull/2018) (bence.balogh@ingenimind.com)
  - chore: update deps [#2007](https://github.com/vega/ts-json-schema-generator/pull/2007) ([@domoritz](https://github.com/domoritz))
  
  #### ⚠️ Pushed to `next`
  
  - docs: overrides ([@domoritz](https://github.com/domoritz))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump @auto-it/first-time-contributor from 11.2.0 to 11.2.1 [#2057](https://github.com/vega/ts-json-schema-generator/pull/2057) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump tslib from 2.6.3 to 2.7.0 [#2056](https://github.com/vega/ts-json-schema-generator/pull/2056) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 11.2.0 to 11.2.1 [#2059](https://github.com/vega/ts-json-schema-generator/pull/2059) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump safe-stable-stringify from 2.4.3 to 2.5.0 [#2049](https://github.com/vega/ts-json-schema-generator/pull/2049) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump micromatch from 4.0.7 to 4.0.8 [#2052](https://github.com/vega/ts-json-schema-generator/pull/2052) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.25.3 to 7.25.4 [#2050](https://github.com/vega/ts-json-schema-generator/pull/2050) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.9.0 to 9.9.1 [#2051](https://github.com/vega/ts-json-schema-generator/pull/2051) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.24.8 to 7.25.3 [#2041](https://github.com/vega/ts-json-schema-generator/pull/2041) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.0.0 to 22.4.0 [#2042](https://github.com/vega/ts-json-schema-generator/pull/2042) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 11.1.6 to 11.2.0 [#2043](https://github.com/vega/ts-json-schema-generator/pull/2043) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.8.0 to 9.9.0 [#2044](https://github.com/vega/ts-json-schema-generator/pull/2044) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.8.0 to 9.9.0 [#2035](https://github.com/vega/ts-json-schema-generator/pull/2035) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 11.1.6 to 11.2.0 [#2036](https://github.com/vega/ts-json-schema-generator/pull/2036) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 5.5.3 to 5.5.4 [#2037](https://github.com/vega/ts-json-schema-generator/pull/2037) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.16.2 to 4.17.0 [#2038](https://github.com/vega/ts-json-schema-generator/pull/2038) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega-lite from 5.19.0 to 5.20.1 [#2030](https://github.com/vega/ts-json-schema-generator/pull/2030) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@domoritz](https://github.com/domoritz))
  - chore(deps-dev): bump @babel/core from 7.24.7 to 7.25.2 [#2031](https://github.com/vega/ts-json-schema-generator/pull/2031) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 11.1.6 to 11.2.0 [#2032](https://github.com/vega/ts-json-schema-generator/pull/2032) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.1.3 to 5.2.1 [#2033](https://github.com/vega/ts-json-schema-generator/pull/2033) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 20.14.10 to 22.0.0 [#2029](https://github.com/vega/ts-json-schema-generator/pull/2029) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint and @types/eslint [#2027](https://github.com/vega/ts-json-schema-generator/pull/2027) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 7.16.0 to 7.17.0 [#2028](https://github.com/vega/ts-json-schema-generator/pull/2028) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.24.7 to 7.24.8 [#2019](https://github.com/vega/ts-json-schema-generator/pull/2019) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv from 8.16.0 to 8.17.1 [#2020](https://github.com/vega/ts-json-schema-generator/pull/2020) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 7.15.0 to 7.16.0 [#2021](https://github.com/vega/ts-json-schema-generator/pull/2021) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 3.3.2 to 3.3.3 [#2022](https://github.com/vega/ts-json-schema-generator/pull/2022) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 7.14.1 to 7.15.0 [#2013](https://github.com/vega/ts-json-schema-generator/pull/2013) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.16.0 to 4.16.2 [#2014](https://github.com/vega/ts-json-schema-generator/pull/2014) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 5.5.2 to 5.5.3 [#2015](https://github.com/vega/ts-json-schema-generator/pull/2015) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 20.14.9 to 20.14.10 [#2016](https://github.com/vega/ts-json-schema-generator/pull/2016) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 5.4.5 to 5.5.2 [#2005](https://github.com/vega/ts-json-schema-generator/pull/2005) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.10.5 to 4.16.0 [#2006](https://github.com/vega/ts-json-schema-generator/pull/2006) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.24.6 to 7.24.7 [#1999](https://github.com/vega/ts-json-schema-generator/pull/1999) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.4.0 to 9.5.0 [#2000](https://github.com/vega/ts-json-schema-generator/pull/2000) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump braces from 3.0.2 to 3.0.3 [#1993](https://github.com/vega/ts-json-schema-generator/pull/1993) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.24.1 to 7.24.7 [#1995](https://github.com/vega/ts-json-schema-generator/pull/1995) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 3.2.5 to 3.3.1 [#1988](https://github.com/vega/ts-json-schema-generator/pull/1988) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump tslib from 2.6.2 to 2.6.3 [#1989](https://github.com/vega/ts-json-schema-generator/pull/1989) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.24.6 to 7.24.7 [#1991](https://github.com/vega/ts-json-schema-generator/pull/1991) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 4
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Arthur Fiorette ([@arthurfiorette](https://github.com/arthurfiorette))
  - Bence Balogh ([@baloghbence0915](https://github.com/baloghbence0915))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
