### PR TITLE
fix: support enums/unions as record indexed access keys

### DIFF
--- a/src/NodeParser/IndexedAccessTypeNodeParser.ts
+++ b/src/NodeParser/IndexedAccessTypeNodeParser.ts
@@ -12,6 +12,7 @@ import { UnionType } from "../Type/UnionType.js";
 import { derefType } from "../Utils/derefType.js";
 import { getTypeByKey } from "../Utils/typeKeys.js";
 import { LogicError } from "../Error/Errors.js";
+import { EnumType } from "../Type/EnumType.js";
 
 export class IndexedAccessTypeNodeParser implements SubNodeParser {
     public constructor(
@@ -58,7 +59,8 @@ export class IndexedAccessTypeNodeParser implements SubNodeParser {
             return new NeverType();
         }
 
-        const indexTypes = indexType instanceof UnionType ? indexType.getTypes() : [indexType];
+        const indexTypes =
+            indexType instanceof UnionType || indexType instanceof EnumType ? indexType.getTypes() : [indexType];
         const propertyTypes = indexTypes.map((type) => {
             if (!(type instanceof LiteralType || type instanceof StringType || type instanceof NumberType)) {
                 throw new LogicError(

--- a/src/Utils/typeKeys.ts
+++ b/src/Utils/typeKeys.ts
@@ -97,7 +97,7 @@ export function getTypeByKey(type: BaseType, index: LiteralType | StringType | N
     }
     if (type instanceof ObjectType) {
         if (index instanceof LiteralType) {
-            const property = type.getProperties().find((it) => it.getName() === index.getValue());
+            const property = type.getProperties().find((it) => it.getName() === index.getName());
             if (property) {
                 const propertyType = property.getType();
                 if (propertyType === undefined) {

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -83,6 +83,8 @@ describe("valid-data-type", () => {
     it("type-indexed-access-object-1", assertValidSchema("type-indexed-access-object-1", "MyType"));
     it("type-indexed-access-object-2", assertValidSchema("type-indexed-access-object-2", "MyType"));
     it("type-indexed-access-keyof", assertValidSchema("type-indexed-access-keyof", "MyType"));
+    it("type-indexed-access-object-key-enum", assertValidSchema("type-indexed-access-object-key-enum", "Value"));
+    it("type-indexed-access-object-key-union", assertValidSchema("type-indexed-access-object-key-union", "Value"));
     it("type-indexed-circular-access", assertValidSchema("type-indexed-circular-access", "*"));
     it("type-indexed-circular", assertValidSchema("type-indexed-circular", "MyType"));
     it("type-keyof-tuple", assertValidSchema("type-keyof-tuple", "MyType"));

--- a/test/valid-data/type-indexed-access-object-key-enum/main.ts
+++ b/test/valid-data/type-indexed-access-object-key-enum/main.ts
@@ -1,0 +1,11 @@
+enum Variant {
+    A = 0,
+    B = "STR",
+}
+
+type KVMap = {
+    [Variant.A]: boolean;
+    [Variant.B]: number;
+};
+
+export type Value = KVMap[Variant];

--- a/test/valid-data/type-indexed-access-object-key-enum/schema.json
+++ b/test/valid-data/type-indexed-access-object-key-enum/schema.json
@@ -1,0 +1,12 @@
+{
+  "$ref": "#/definitions/Value",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Value": {
+      "type": [
+        "boolean",
+        "number"
+      ]
+    }
+  }
+}

--- a/test/valid-data/type-indexed-access-object-key-union/main.ts
+++ b/test/valid-data/type-indexed-access-object-key-union/main.ts
@@ -1,0 +1,8 @@
+type Variant = 0 | "ONE";
+
+type KVMap = {
+    0: boolean;
+    ONE: number;
+};
+
+export type Value = KVMap[Variant];

--- a/test/valid-data/type-indexed-access-object-key-union/schema.json
+++ b/test/valid-data/type-indexed-access-object-key-union/schema.json
@@ -1,0 +1,12 @@
+{
+  "$ref": "#/definitions/Value",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Value": {
+      "type": [
+        "boolean",
+        "number"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Add support for using enums and union types as indexes on record types.

fixes #2164