### PR TITLE
fix: correctly generate anyOf on unions with string and boolean constant

### DIFF
--- a/src/TypeFormatter/LiteralUnionTypeFormatter.ts
+++ b/src/TypeFormatter/LiteralUnionTypeFormatter.ts
@@ -55,12 +55,18 @@ export class LiteralUnionTypeFormatter implements SubTypeFormatter {
             appendTypeValues(type, typeValues);
         }
 
-        const schema = {
-            type: toEnumType(Array.from(typeNames)),
-            enum: Array.from(typeValues),
-        };
+        const schema =
+            typeNames.size === 1 && typeValues.size === 1
+                ? {
+                      type: toEnumType(Array.from(typeNames)),
+                      const: Array.from(typeValues)[0],
+                  }
+                : {
+                      type: toEnumType(Array.from(typeNames)),
+                      enum: Array.from(typeValues),
+                  };
 
-        return preserveLiterals ? { anyOf: [{ type: "string" }, schema] } : schema;
+        return hasString ? { anyOf: [{ type: "string" }, schema] } : schema;
     }
 
     public getChildren(): BaseType[] {

--- a/test/valid-data/type-union/main.ts
+++ b/test/valid-data/type-union/main.ts
@@ -6,6 +6,9 @@ type MyType4 = "s" | 1;
 type MyType5 = "s" | 1[];
 type MyType6 = ("s" | 1)[];
 
+type MyType7 = string | true;
+type MyType8 = "s" | true;
+
 export interface TypeUnion {
     var1: MyType1;
     var2: MyType2;
@@ -14,4 +17,7 @@ export interface TypeUnion {
     var4: MyType4;
     var5: MyType5;
     var6: MyType6;
+
+    var7: MyType7;
+    var8: MyType8;
 }

--- a/test/valid-data/type-union/schema.json
+++ b/test/valid-data/type-union/schema.json
@@ -70,6 +70,27 @@
             ]
           },
           "type": "array"
+        },
+        "var7": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "const": true,
+              "type": "boolean"
+            }
+          ]
+        },
+        "var8": {
+          "enum": [
+            "s",
+            true
+          ],
+          "type": [
+            "string",
+            "boolean"
+          ]
         }
       },
       "required": [
@@ -78,7 +99,9 @@
         "var3",
         "var4",
         "var5",
-        "var6"
+        "var6",
+        "var7",
+        "var8"
       ],
       "type": "object"
     }


### PR DESCRIPTION
~~as far as I understood while debugging through the test code, `StringType` is used for `string` while `LiteralType` is used for a string constant like `"s"`, thus `StringType` cannot be part of a literal union.~~

noticed that there is some magic regarding `string` which is hard to incorporate outside of `LiterallUnionTypeFormatter`. but it appears to me that a `StringType` could get discarded when it is not marked as preserve literals

closes #2207
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.5.0-next.1`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: Valentyne Stigloher ([@pixunil](https://github.com/pixunil))
  
  :heart: Alex ([@alexchexes](https://github.com/alexchexes))
  
  #### 🚀 Enhancement
  
  - feat(parser): support SpreadElement in array literals [#2269](https://github.com/vega/ts-json-schema-generator/pull/2269) ([@alexchexes](https://github.com/alexchexes))
  
  #### 🐛 Bug Fix
  
  - fix: correctly generate anyOf on unions with string and boolean constant [#2208](https://github.com/vega/ts-json-schema-generator/pull/2208) ([@pixunil](https://github.com/pixunil))
  - fix: fully unwrap union aliases in mapped keys to avoid generating incorrect additionalProperties [#2232](https://github.com/vega/ts-json-schema-generator/pull/2232) ([@alexchexes](https://github.com/alexchexes))
  - fix: avoid incorrect additionalProperties for Pick<..., AliasLiteralUnion> [#2230](https://github.com/vega/ts-json-schema-generator/pull/2230) ([@alexchexes](https://github.com/alexchexes))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump typescript-eslint from 8.32.1 to 8.33.1 [#2270](https://github.com/vega/ts-json-schema-generator/pull/2270) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.29 to 22.15.30 [#2271](https://github.com/vega/ts-json-schema-generator/pull/2271) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.27.0 to 9.28.0 [#2264](https://github.com/vega/ts-json-schema-generator/pull/2264) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.27.1 to 7.27.4 [#2265](https://github.com/vega/ts-json-schema-generator/pull/2265) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.27.0 to 9.28.0 [#2266](https://github.com/vega/ts-json-schema-generator/pull/2266) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.4.0 to 5.4.1 [#2267](https://github.com/vega/ts-json-schema-generator/pull/2267) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.21 to 22.15.29 [#2268](https://github.com/vega/ts-json-schema-generator/pull/2268) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.18 to 22.15.21 [#2262](https://github.com/vega/ts-json-schema-generator/pull/2262) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.27.1 to 7.27.2 [#2263](https://github.com/vega/ts-json-schema-generator/pull/2263) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 13.1.0 to 14.0.0 [#2255](https://github.com/vega/ts-json-schema-generator/pull/2255) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.32.0 to 8.32.1 [#2254](https://github.com/vega/ts-json-schema-generator/pull/2254) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.26.0 to 9.27.0 [#2256](https://github.com/vega/ts-json-schema-generator/pull/2256) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.26.0 to 9.27.0 [#2257](https://github.com/vega/ts-json-schema-generator/pull/2257) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.3 to 22.15.18 [#2258](https://github.com/vega/ts-json-schema-generator/pull/2258) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 10.1.2 to 10.1.5 [#2249](https://github.com/vega/ts-json-schema-generator/pull/2249) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.31.0 to 8.32.0 [#2250](https://github.com/vega/ts-json-schema-generator/pull/2250) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.19.3 to 4.19.4 [#2251](https://github.com/vega/ts-json-schema-generator/pull/2251) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.25.1 to 9.26.0 [#2252](https://github.com/vega/ts-json-schema-generator/pull/2252) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.2.6 to 5.4.0 [#2253](https://github.com/vega/ts-json-schema-generator/pull/2253) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.27.0 to 7.27.1 [#2244](https://github.com/vega/ts-json-schema-generator/pull/2244) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.25.1 to 9.26.0 [#2245](https://github.com/vega/ts-json-schema-generator/pull/2245) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.26.9 to 7.27.1 [#2246](https://github.com/vega/ts-json-schema-generator/pull/2246) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.26.10 to 7.27.1 [#2247](https://github.com/vega/ts-json-schema-generator/pull/2247) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.2 to 22.15.3 [#2248](https://github.com/vega/ts-json-schema-generator/pull/2248) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.14.1 to 22.15.2 [#2239](https://github.com/vega/ts-json-schema-generator/pull/2239) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump glob from 11.0.1 to 11.0.2 [#2240](https://github.com/vega/ts-json-schema-generator/pull/2240) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.25.0 to 9.25.1 [#2242](https://github.com/vega/ts-json-schema-generator/pull/2242) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.30.1 to 8.31.0 [#2243](https://github.com/vega/ts-json-schema-generator/pull/2243) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.29.1 to 8.30.1 [#2235](https://github.com/vega/ts-json-schema-generator/pull/2235) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.24.0 to 9.25.0 [#2236](https://github.com/vega/ts-json-schema-generator/pull/2236) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.24.0 to 9.25.0 [#2237](https://github.com/vega/ts-json-schema-generator/pull/2237) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.14.0 to 22.14.1 [#2225](https://github.com/vega/ts-json-schema-generator/pull/2225) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.29.0 to 8.29.1 [#2226](https://github.com/vega/ts-json-schema-generator/pull/2226) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 10.1.1 to 10.1.2 [#2227](https://github.com/vega/ts-json-schema-generator/pull/2227) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.23.0 to 9.24.0 [#2228](https://github.com/vega/ts-json-schema-generator/pull/2228) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 3
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Alex ([@alexchexes](https://github.com/alexchexes))
  - Valentyne Stigloher ([@pixunil](https://github.com/pixunil))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
