### PR TITLE
fix: avoid incorrect additionalProperties for Pick<..., AliasLiteralUnion>

### DIFF
--- a/src/NodeParser/MappedTypeNodeParser.ts
+++ b/src/NodeParser/MappedTypeNodeParser.ts
@@ -158,7 +158,7 @@ export class MappedTypeNodeParser implements SubNodeParser {
         keyListType: UnionType,
         context: Context,
     ): BaseType | boolean {
-        const key = keyListType.getTypes().filter((type) => !(type instanceof LiteralType))[0];
+        const key = keyListType.getTypes().filter((type) => !(derefType(type) instanceof LiteralType))[0];
 
         if (key) {
             return (

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -88,6 +88,7 @@ describe("valid-data-type", () => {
     it("type-keyof-tuple", assertValidSchema("type-keyof-tuple", "MyType"));
     it("type-keyof-object", assertValidSchema("type-keyof-object", "MyType"));
     it("type-keyof-object-function", assertValidSchema("type-keyof-object-function", "MyType"));
+    it("type-mapped-pick-union-alias", assertValidSchema("type-mapped-pick-union-alias", "PickAliasedLiteralUnion"));
     it("type-mapped-simple", assertValidSchema("type-mapped-simple", "MyObject"));
     it("type-mapped-index", assertValidSchema("type-mapped-index", "MyObject"));
     it("type-mapped-index-as", assertValidSchema("type-mapped-index-as", "MyObject"));

--- a/test/valid-data/type-mapped-pick-union-alias/main.ts
+++ b/test/valid-data/type-mapped-pick-union-alias/main.ts
@@ -1,0 +1,9 @@
+interface SomeInterface {
+    foo: string;
+    bar: number;
+}
+
+type KeyFoo = "foo";
+type KeyBar = "bar";
+
+export type PickAliasedLiteralUnion = Pick<SomeInterface, KeyFoo | KeyBar>;

--- a/test/valid-data/type-mapped-pick-union-alias/schema.json
+++ b/test/valid-data/type-mapped-pick-union-alias/schema.json
@@ -1,0 +1,22 @@
+{
+  "$ref": "#/definitions/PickAliasedLiteralUnion",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "PickAliasedLiteralUnion": {
+      "additionalProperties": false,
+      "properties": {
+        "bar": {
+          "type": "number"
+        },
+        "foo": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "foo",
+        "bar"
+      ],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
Closes #2229 
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.4.1-next.0`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, null[@alexchexes](https://github.com/alexchexes), for all your work!
  
  #### 🐛 Bug Fix
  
  - fix: avoid incorrect additionalProperties for Pick<..., AliasLiteralUnion> [#2230](https://github.com/vega/ts-json-schema-generator/pull/2230) ([@alexchexes](https://github.com/alexchexes))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump @types/node from 22.14.0 to 22.14.1 [#2225](https://github.com/vega/ts-json-schema-generator/pull/2225) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.29.0 to 8.29.1 [#2226](https://github.com/vega/ts-json-schema-generator/pull/2226) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 10.1.1 to 10.1.2 [#2227](https://github.com/vega/ts-json-schema-generator/pull/2227) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.23.0 to 9.24.0 [#2228](https://github.com/vega/ts-json-schema-generator/pull/2228) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 2
  
  - [@alexchexes](https://github.com/alexchexes)
  - [@dependabot[bot]](https://github.com/dependabot[bot])
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
