### PR TITLE
fix: fully unwrap union aliases in mapped keys to avoid generating incorrect additionalProperties

### DIFF
--- a/src/NodeParser/MappedTypeNodeParser.ts
+++ b/src/NodeParser/MappedTypeNodeParser.ts
@@ -16,7 +16,7 @@ import { ObjectProperty, ObjectType } from "../Type/ObjectType.js";
 import { StringType } from "../Type/StringType.js";
 import { SymbolType } from "../Type/SymbolType.js";
 import { UnionType } from "../Type/UnionType.js";
-import { derefAnnotatedType, derefType } from "../Utils/derefType.js";
+import { derefAnnotatedType, derefType, isDeepLiteralUnion } from "../Utils/derefType.js";
 import { getKey } from "../Utils/nodeKey.js";
 import { preserveAnnotation } from "../Utils/preserveAnnotation.js";
 import { removeUndefined } from "../Utils/removeUndefined.js";
@@ -158,6 +158,10 @@ export class MappedTypeNodeParser implements SubNodeParser {
         keyListType: UnionType,
         context: Context,
     ): BaseType | boolean {
+        if (isDeepLiteralUnion(keyListType)) {
+            return this.additionalProperties;
+        }
+
         const key = keyListType.getTypes().filter((type) => !(derefType(type) instanceof LiteralType))[0];
 
         if (key) {

--- a/src/Utils/derefType.ts
+++ b/src/Utils/derefType.ts
@@ -3,8 +3,10 @@ import { AnnotatedType } from "../Type/AnnotatedType.js";
 import type { BaseType } from "../Type/BaseType.js";
 import { DefinitionType } from "../Type/DefinitionType.js";
 import { HiddenType } from "../Type/HiddenType.js";
+import { LiteralType } from "../Type/LiteralType.js";
 import { NeverType } from "../Type/NeverType.js";
 import { ReferenceType } from "../Type/ReferenceType.js";
+import { UnionType } from "../Type/UnionType.js";
 
 /**
  * Dereference the type as far as possible.
@@ -33,6 +35,23 @@ export function isHiddenType(type: BaseType): boolean {
         return true;
     } else if (type instanceof DefinitionType || type instanceof AliasType || type instanceof AnnotatedType) {
         return isHiddenType(type.getType());
+    }
+
+    return false;
+}
+
+/**
+ * Recursively checks whether the given type is a union composed entirely of literal types.
+ */
+export function isDeepLiteralUnion(type: BaseType): boolean {
+    const resolved = derefType(type);
+
+    if (resolved instanceof LiteralType) {
+        return true;
+    }
+
+    if (resolved instanceof UnionType) {
+        return resolved.getTypes().every((t) => isDeepLiteralUnion(t));
     }
 
     return false;

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -89,6 +89,7 @@ describe("valid-data-type", () => {
     it("type-keyof-object", assertValidSchema("type-keyof-object", "MyType"));
     it("type-keyof-object-function", assertValidSchema("type-keyof-object-function", "MyType"));
     it("type-mapped-pick-union-alias", assertValidSchema("type-mapped-pick-union-alias", "PickAliasedLiteralUnion"));
+    it("type-mapped-exported-aliases", assertValidSchema("type-mapped-exported-aliases", "*"));
     it("type-mapped-simple", assertValidSchema("type-mapped-simple", "MyObject"));
     it("type-mapped-index", assertValidSchema("type-mapped-index", "MyObject"));
     it("type-mapped-index-as", assertValidSchema("type-mapped-index-as", "MyObject"));

--- a/test/valid-data/type-mapped-exported-aliases/main.ts
+++ b/test/valid-data/type-mapped-exported-aliases/main.ts
@@ -1,0 +1,19 @@
+interface SomeInterface {
+    a: number;
+    b: string;
+    c: boolean;
+    d: string[];
+    e: null;
+}
+
+type A = "a";
+type B = "b";
+type C = "c";
+type D = "d";
+
+// Export the aliases individually to verify they're handled correctly
+export type AB = A | B;
+export type ABC = AB | C;
+export type ABCD = ABC | D;
+
+export type ABCDE = Pick<SomeInterface, ABCD | "e">;

--- a/test/valid-data/type-mapped-exported-aliases/schema.json
+++ b/test/valid-data/type-mapped-exported-aliases/schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "AB": {
+      "enum": [
+        "a",
+        "b"
+      ],
+      "type": "string"
+    },
+    "ABC": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/AB"
+        },
+        {
+          "const": "c",
+          "type": "string"
+        }
+      ]
+    },
+    "ABCD": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ABC"
+        },
+        {
+          "const": "d",
+          "type": "string"
+        }
+      ]
+    },
+    "ABCDE": {
+      "additionalProperties": false,
+      "properties": {
+        "a": {
+          "type": "number"
+        },
+        "b": {
+          "type": "string"
+        },
+        "c": {
+          "type": "boolean"
+        },
+        "d": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "e": {
+          "type": "null"
+        }
+      },
+      "required": [
+        "a",
+        "b",
+        "c",
+        "d",
+        "e"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/test/valid-data/type-mapped-pick-union-alias/main.ts
+++ b/test/valid-data/type-mapped-pick-union-alias/main.ts
@@ -1,9 +1,19 @@
 interface SomeInterface {
-    foo: string;
-    bar: number;
+    a: number;
+    b: string;
+    c: boolean;
+    d: string[];
+    e: null;
 }
 
-type KeyFoo = "foo";
-type KeyBar = "bar";
+type A = "a";
+type B = "b";
+type C = "c";
+type D = "d";
+type E = "e";
 
-export type PickAliasedLiteralUnion = Pick<SomeInterface, KeyFoo | KeyBar>;
+type AB = A | B;
+type ABC = AB | C;
+type ABCD = ABC | D;
+
+export type PickAliasedLiteralUnion = Pick<SomeInterface, ABCD | E>;

--- a/test/valid-data/type-mapped-pick-union-alias/schema.json
+++ b/test/valid-data/type-mapped-pick-union-alias/schema.json
@@ -5,16 +5,31 @@
     "PickAliasedLiteralUnion": {
       "additionalProperties": false,
       "properties": {
-        "bar": {
+        "a": {
           "type": "number"
         },
-        "foo": {
+        "b": {
           "type": "string"
+        },
+        "c": {
+          "type": "boolean"
+        },
+        "d": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "e": {
+          "type": "null"
         }
       },
       "required": [
-        "foo",
-        "bar"
+        "a",
+        "b",
+        "c",
+        "d",
+        "e"
       ],
       "type": "object"
     }

--- a/test/valid-data/type-mapped-union-union/schema.json
+++ b/test/valid-data/type-mapped-union-union/schema.json
@@ -3,9 +3,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "MyType": {
-      "additionalProperties": {
-        "type": "string"
-      },
+      "additionalProperties": false,
       "properties": {
         "s1": {
           "type": "string"


### PR DESCRIPTION
Closes #2231
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.4.1-next.1`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Alex ([@alexchexes](https://github.com/alexchexes)), for all your work!
  
  #### 🐛 Bug Fix
  
  - fix: fully unwrap union aliases in mapped keys to avoid generating incorrect additionalProperties [#2232](https://github.com/vega/ts-json-schema-generator/pull/2232) ([@alexchexes](https://github.com/alexchexes))
  - fix: avoid incorrect additionalProperties for Pick<..., AliasLiteralUnion> [#2230](https://github.com/vega/ts-json-schema-generator/pull/2230) ([@alexchexes](https://github.com/alexchexes))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump eslint-config-prettier from 10.1.2 to 10.1.5 [#2249](https://github.com/vega/ts-json-schema-generator/pull/2249) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.31.0 to 8.32.0 [#2250](https://github.com/vega/ts-json-schema-generator/pull/2250) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.19.3 to 4.19.4 [#2251](https://github.com/vega/ts-json-schema-generator/pull/2251) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.25.1 to 9.26.0 [#2252](https://github.com/vega/ts-json-schema-generator/pull/2252) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.2.6 to 5.4.0 [#2253](https://github.com/vega/ts-json-schema-generator/pull/2253) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.27.0 to 7.27.1 [#2244](https://github.com/vega/ts-json-schema-generator/pull/2244) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.25.1 to 9.26.0 [#2245](https://github.com/vega/ts-json-schema-generator/pull/2245) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.26.9 to 7.27.1 [#2246](https://github.com/vega/ts-json-schema-generator/pull/2246) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.26.10 to 7.27.1 [#2247](https://github.com/vega/ts-json-schema-generator/pull/2247) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.2 to 22.15.3 [#2248](https://github.com/vega/ts-json-schema-generator/pull/2248) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.14.1 to 22.15.2 [#2239](https://github.com/vega/ts-json-schema-generator/pull/2239) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump glob from 11.0.1 to 11.0.2 [#2240](https://github.com/vega/ts-json-schema-generator/pull/2240) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.25.0 to 9.25.1 [#2242](https://github.com/vega/ts-json-schema-generator/pull/2242) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.30.1 to 8.31.0 [#2243](https://github.com/vega/ts-json-schema-generator/pull/2243) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.29.1 to 8.30.1 [#2235](https://github.com/vega/ts-json-schema-generator/pull/2235) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.24.0 to 9.25.0 [#2236](https://github.com/vega/ts-json-schema-generator/pull/2236) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.24.0 to 9.25.0 [#2237](https://github.com/vega/ts-json-schema-generator/pull/2237) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.14.0 to 22.14.1 [#2225](https://github.com/vega/ts-json-schema-generator/pull/2225) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.29.0 to 8.29.1 [#2226](https://github.com/vega/ts-json-schema-generator/pull/2226) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 10.1.1 to 10.1.2 [#2227](https://github.com/vega/ts-json-schema-generator/pull/2227) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.23.0 to 9.24.0 [#2228](https://github.com/vega/ts-json-schema-generator/pull/2228) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 2
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Alex ([@alexchexes](https://github.com/alexchexes))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
