### PR TITLE
feat(parser): support SpreadElement in array literals

### DIFF
--- a/factory/parser.ts
+++ b/factory/parser.ts
@@ -59,6 +59,8 @@ import type { SubNodeParser } from "../src/SubNodeParser.js";
 import { TopRefNodeParser } from "../src/TopRefNodeParser.js";
 import { SatisfiesNodeParser } from "../src/NodeParser/SatisfiesNodeParser.js";
 import { PromiseNodeParser } from "../src/NodeParser/PromiseNodeParser.js";
+import { SpreadElementNodeParser } from "../src/NodeParser/SpreadElementNodeParser.js";
+import { IdentifierNodeParser } from "../src/NodeParser/IdentifierNodeParser.js";
 
 export type ParserAugmentor = (parser: MutableParser) => void;
 
@@ -138,6 +140,8 @@ export function createParser(program: ts.Program, config: CompletedConfig, augme
         .addNodeParser(new NamedTupleMemberNodeParser(chainNodeParser))
         .addNodeParser(new OptionalTypeNodeParser(chainNodeParser))
         .addNodeParser(new RestTypeNodeParser(chainNodeParser))
+        .addNodeParser(new IdentifierNodeParser(chainNodeParser, typeChecker))
+        .addNodeParser(new SpreadElementNodeParser(chainNodeParser))
 
         .addNodeParser(new CallExpressionParser(typeChecker, chainNodeParser))
         .addNodeParser(new PropertyAccessExpressionParser(typeChecker, chainNodeParser))

--- a/src/NodeParser/IdentifierNodeParser.ts
+++ b/src/NodeParser/IdentifierNodeParser.ts
@@ -1,0 +1,38 @@
+import ts from "typescript";
+import type { Context, NodeParser } from "../NodeParser.js";
+import type { SubNodeParser } from "../SubNodeParser.js";
+import type { BaseType } from "../Type/BaseType.js";
+import { UnknownNodeError } from "../Error/Errors.js";
+
+/**
+ * Resolves identifiers whose value is a compile-time constant
+ */
+export class IdentifierNodeParser implements SubNodeParser {
+    constructor(
+        private readonly childNodeParser: NodeParser,
+        private readonly checker: ts.TypeChecker,
+    ) {}
+
+    supportsNode(node: ts.Identifier): boolean {
+        return node.kind === ts.SyntaxKind.Identifier;
+    }
+
+    createType(node: ts.Identifier, context: Context): BaseType {
+        const symbol = this.checker.getSymbolAtLocation(node);
+        if (!symbol) {
+            throw new UnknownNodeError(node);
+        }
+
+        const decl = symbol.valueDeclaration;
+        if (
+            decl &&
+            ts.isVariableDeclaration(decl) &&
+            decl.initializer &&
+            ts.getCombinedNodeFlags(decl) & ts.NodeFlags.Const
+        ) {
+            return this.childNodeParser.createType(decl.initializer, context);
+        }
+
+        throw new UnknownNodeError(node);
+    }
+}

--- a/src/NodeParser/SpreadElementNodeParser.ts
+++ b/src/NodeParser/SpreadElementNodeParser.ts
@@ -1,0 +1,25 @@
+import ts from "typescript";
+import type { Context, NodeParser } from "../NodeParser.js";
+import type { SubNodeParser } from "../SubNodeParser.js";
+import type { ArrayType } from "../Type/ArrayType.js";
+import type { InferType } from "../Type/InferType.js";
+import type { TupleType } from "../Type/TupleType.js";
+import { RestType } from "../Type/RestType.js";
+
+/**
+ * Handles `...expr` inside an ArrayLiteralExpression.
+ * Turns it into RestType so TupleTypeFormatter can emit correct JSON-Schema.
+ */
+export class SpreadElementNodeParser implements SubNodeParser {
+    constructor(private readonly childNodeParser: NodeParser) {}
+
+    supportsNode(node: ts.SpreadElement): boolean {
+        return node.kind === ts.SyntaxKind.SpreadElement;
+    }
+
+    createType(node: ts.SpreadElement, context: Context) {
+        const inner = this.childNodeParser.createType(node.expression, context) as ArrayType | InferType | TupleType;
+
+        return new RestType(inner);
+    }
+}

--- a/test/valid-data-other.test.ts
+++ b/test/valid-data-other.test.ts
@@ -83,6 +83,8 @@ describe("valid-data-other", () => {
     it("array-min-max-items-optional", assertValidSchema("array-min-max-items-optional", "MyType"));
     it("array-function-generics", assertValidSchema("array-function-generics", "*"));
     it("array-max-items-optional", assertValidSchema("array-max-items-optional", "MyType"));
+    it("array-literal-spread", assertValidSchema("array-literal-spread", "MyType"));
+    it("array-rest-only", assertValidSchema("array-rest-only", "MyType"));
     it("shorthand-array", assertValidSchema("shorthand-array", "MyType"));
     it("function-generic", assertValidSchema("function-generic", "MyType"));
 

--- a/test/valid-data/array-literal-spread/main.ts
+++ b/test/valid-data/array-literal-spread/main.ts
@@ -1,0 +1,4 @@
+const BASE = ["foo", "bar"] as const;
+
+export const ALL = [...BASE, "baz"] as const;
+export type MyType = typeof ALL;

--- a/test/valid-data/array-literal-spread/schema.json
+++ b/test/valid-data/array-literal-spread/schema.json
@@ -1,0 +1,25 @@
+{
+  "$ref": "#/definitions/MyType",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyType": {
+      "items": [
+        {
+          "const": "foo",
+          "type": "string"
+        },
+        {
+          "const": "bar",
+          "type": "string"
+        },
+        {
+          "const": "baz",
+          "type": "string"
+        }
+      ],
+      "maxItems": 3,
+      "minItems": 3,
+      "type": "array"
+    }
+  }
+}

--- a/test/valid-data/array-rest-only/main.ts
+++ b/test/valid-data/array-rest-only/main.ts
@@ -1,0 +1,1 @@
+export type MyType = [...string[]];

--- a/test/valid-data/array-rest-only/schema.json
+++ b/test/valid-data/array-rest-only/schema.json
@@ -1,0 +1,13 @@
+{
+  "$ref": "#/definitions/MyType",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyType": {
+      "items": {
+        "type": "string"
+      },
+      "minItems": 0,
+      "type": "array"
+    }
+  }
+}


### PR DESCRIPTION
closes #2055 

---

* add IdentifierNodeParser to resolve const-bound identifiers
* add SpreadElementNodeParser to translate `...expr` to RestType
* register both parsers in factory chain
* add tests: array-literal-spread, array-rest-only
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.5.0-next.0`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Alex ([@alexchexes](https://github.com/alexchexes)), for all your work!
  
  #### 🚀 Enhancement
  
  - feat(parser): support SpreadElement in array literals [#2269](https://github.com/vega/ts-json-schema-generator/pull/2269) ([@alexchexes](https://github.com/alexchexes))
  
  #### 🐛 Bug Fix
  
  - fix: fully unwrap union aliases in mapped keys to avoid generating incorrect additionalProperties [#2232](https://github.com/vega/ts-json-schema-generator/pull/2232) ([@alexchexes](https://github.com/alexchexes))
  - fix: avoid incorrect additionalProperties for Pick<..., AliasLiteralUnion> [#2230](https://github.com/vega/ts-json-schema-generator/pull/2230) ([@alexchexes](https://github.com/alexchexes))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump typescript-eslint from 8.32.1 to 8.33.1 [#2270](https://github.com/vega/ts-json-schema-generator/pull/2270) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.29 to 22.15.30 [#2271](https://github.com/vega/ts-json-schema-generator/pull/2271) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.27.0 to 9.28.0 [#2264](https://github.com/vega/ts-json-schema-generator/pull/2264) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.27.1 to 7.27.4 [#2265](https://github.com/vega/ts-json-schema-generator/pull/2265) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.27.0 to 9.28.0 [#2266](https://github.com/vega/ts-json-schema-generator/pull/2266) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.4.0 to 5.4.1 [#2267](https://github.com/vega/ts-json-schema-generator/pull/2267) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.21 to 22.15.29 [#2268](https://github.com/vega/ts-json-schema-generator/pull/2268) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.18 to 22.15.21 [#2262](https://github.com/vega/ts-json-schema-generator/pull/2262) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.27.1 to 7.27.2 [#2263](https://github.com/vega/ts-json-schema-generator/pull/2263) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 13.1.0 to 14.0.0 [#2255](https://github.com/vega/ts-json-schema-generator/pull/2255) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.32.0 to 8.32.1 [#2254](https://github.com/vega/ts-json-schema-generator/pull/2254) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.26.0 to 9.27.0 [#2256](https://github.com/vega/ts-json-schema-generator/pull/2256) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.26.0 to 9.27.0 [#2257](https://github.com/vega/ts-json-schema-generator/pull/2257) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.3 to 22.15.18 [#2258](https://github.com/vega/ts-json-schema-generator/pull/2258) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 10.1.2 to 10.1.5 [#2249](https://github.com/vega/ts-json-schema-generator/pull/2249) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.31.0 to 8.32.0 [#2250](https://github.com/vega/ts-json-schema-generator/pull/2250) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.19.3 to 4.19.4 [#2251](https://github.com/vega/ts-json-schema-generator/pull/2251) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.25.1 to 9.26.0 [#2252](https://github.com/vega/ts-json-schema-generator/pull/2252) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.2.6 to 5.4.0 [#2253](https://github.com/vega/ts-json-schema-generator/pull/2253) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.27.0 to 7.27.1 [#2244](https://github.com/vega/ts-json-schema-generator/pull/2244) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.25.1 to 9.26.0 [#2245](https://github.com/vega/ts-json-schema-generator/pull/2245) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.26.9 to 7.27.1 [#2246](https://github.com/vega/ts-json-schema-generator/pull/2246) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.26.10 to 7.27.1 [#2247](https://github.com/vega/ts-json-schema-generator/pull/2247) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.2 to 22.15.3 [#2248](https://github.com/vega/ts-json-schema-generator/pull/2248) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.14.1 to 22.15.2 [#2239](https://github.com/vega/ts-json-schema-generator/pull/2239) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump glob from 11.0.1 to 11.0.2 [#2240](https://github.com/vega/ts-json-schema-generator/pull/2240) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.25.0 to 9.25.1 [#2242](https://github.com/vega/ts-json-schema-generator/pull/2242) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.30.1 to 8.31.0 [#2243](https://github.com/vega/ts-json-schema-generator/pull/2243) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.29.1 to 8.30.1 [#2235](https://github.com/vega/ts-json-schema-generator/pull/2235) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.24.0 to 9.25.0 [#2236](https://github.com/vega/ts-json-schema-generator/pull/2236) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.24.0 to 9.25.0 [#2237](https://github.com/vega/ts-json-schema-generator/pull/2237) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.14.0 to 22.14.1 [#2225](https://github.com/vega/ts-json-schema-generator/pull/2225) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.29.0 to 8.29.1 [#2226](https://github.com/vega/ts-json-schema-generator/pull/2226) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 10.1.1 to 10.1.2 [#2227](https://github.com/vega/ts-json-schema-generator/pull/2227) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.23.0 to 9.24.0 [#2228](https://github.com/vega/ts-json-schema-generator/pull/2228) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 2
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Alex ([@alexchexes](https://github.com/alexchexes))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
