### PR TITLE
Fix promise with generic type arguments

### DIFF
--- a/src/NodeParser/TypeReferenceNodeParser.ts
+++ b/src/NodeParser/TypeReferenceNodeParser.ts
@@ -56,7 +56,7 @@ export class TypeReferenceNodeParser implements SubNodeParser {
                 return new AnyType();
             }
 
-            return this.childNodeParser.createType(node.typeArguments[0], this.createSubContext(node, context));
+            return this.childNodeParser.createType(node.typeArguments[0], context);
         }
 
         if (typeSymbol.name === "Array" || typeSymbol.name === "ReadonlyArray") {

--- a/test/valid-data-type.test.ts
+++ b/test/valid-data-type.test.ts
@@ -149,6 +149,7 @@ describe("valid-data-type", () => {
     it("keyof-typeof-x", assertValidSchema("keyof-typeof-x", "MyType"));
 
     it("promise-extensions", assertValidSchema("promise-extensions", "*"));
+    it("promise-generics", assertValidSchema("promise-generics", "*"));
 
     it("export-star", assertValidSchema("export-star", "*", undefined, { mainTsOnly: true }));
     it(

--- a/test/valid-data/promise-generics/main.ts
+++ b/test/valid-data/promise-generics/main.ts
@@ -1,0 +1,3 @@
+export type HasPromise<T> = { a: Promise<T | undefined> };
+
+export type ConcreteHasPromise = HasPromise<string>;

--- a/test/valid-data/promise-generics/schema.json
+++ b/test/valid-data/promise-generics/schema.json
@@ -1,0 +1,18 @@
+{
+  "$ref": "#/definitions/ConcreteHasPromise",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "ConcreteHasPromise": {
+      "$ref": "#/definitions/HasPromise%3Cstring%3E"
+    },
+    "HasPromise<string>": {
+      "additionalProperties": false,
+      "properties": {
+        "a": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
`Promise<T>` was parsing its type parameters with a sub context, but it should just parse its type argument with the existing type context.

## Example

```ts
export type HasPromise<T> = { a: Promise<T | undefined> };

export type ConcreteHasPromise = HasPromise<string>;
```
became
```json
{
  "$ref": "#/definitions/ConcreteHasPromise",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "definitions": {
    "ConcreteHasPromise": {
      "$ref": "#/definitions/HasPromise%3Cstring%3E"
    },
    "HasPromise<string>": {
      "additionalProperties": false,
      "properties": {
        "a": {
          "description": "Failed to correctly infer type"
        }
      },
      "type": "object"
    }
  }
}
```
but now becomes
```json
{
  "$ref": "#/definitions/ConcreteHasPromise",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "definitions": {
    "ConcreteHasPromise": {
      "$ref": "#/definitions/HasPromise%3Cstring%3E"
    },
    "HasPromise<string>": {
      "additionalProperties": false,
      "properties": {
        "a": {
          "type": "string"
        }
      },
      "type": "object"
    }
  }
}
```
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.5.0-next.5`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: null[@CalLavicka](https://github.com/CalLavicka)
  
  :heart: Alex ([@alexchexes](https://github.com/alexchexes))
  
  :heart: Valentyne Stigloher ([@pixunil](https://github.com/pixunil))
  
  #### 🚀 Enhancement
  
  - feat: Add --full-description option to include full comment in schema [#2224](https://github.com/vega/ts-json-schema-generator/pull/2224) ([@alexchexes](https://github.com/alexchexes))
  - feat(parser): support SpreadElement in array literals [#2269](https://github.com/vega/ts-json-schema-generator/pull/2269) ([@alexchexes](https://github.com/alexchexes))
  
  #### 🐛 Bug Fix
  
  - Fix promise with generic type arguments [#2291](https://github.com/vega/ts-json-schema-generator/pull/2291) ([@CalLavicka](https://github.com/CalLavicka))
  - Fix: prune unreachable definitions when `--type "*"` is used with multiple exports [#2284](https://github.com/vega/ts-json-schema-generator/pull/2284) ([@alexchexes](https://github.com/alexchexes) [@arthurfiorette](https://github.com/arthurfiorette))
  - Fix: crash when a union includes `symbol` [#2282](https://github.com/vega/ts-json-schema-generator/pull/2282) ([@alexchexes](https://github.com/alexchexes))
  - fix: correctly generate anyOf on unions with string and boolean constant [#2208](https://github.com/vega/ts-json-schema-generator/pull/2208) ([@pixunil](https://github.com/pixunil))
  - fix: fully unwrap union aliases in mapped keys to avoid generating incorrect additionalProperties [#2232](https://github.com/vega/ts-json-schema-generator/pull/2232) ([@alexchexes](https://github.com/alexchexes))
  - fix: avoid incorrect additionalProperties for Pick<..., AliasLiteralUnion> [#2230](https://github.com/vega/ts-json-schema-generator/pull/2230) ([@alexchexes](https://github.com/alexchexes))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump jest and @types/jest [#2287](https://github.com/vega/ts-json-schema-generator/pull/2287) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.33.1 to 8.34.1 [#2289](https://github.com/vega/ts-json-schema-generator/pull/2289) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.4.1 to 5.5.0 [#2290](https://github.com/vega/ts-json-schema-generator/pull/2290) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.19.4 to 4.20.3 [#2276](https://github.com/vega/ts-json-schema-generator/pull/2276) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.28.0 to 9.29.0 [#2277](https://github.com/vega/ts-json-schema-generator/pull/2277) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump glob from 11.0.2 to 11.0.3 [#2279](https://github.com/vega/ts-json-schema-generator/pull/2279) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.28.0 to 9.29.0 [#2280](https://github.com/vega/ts-json-schema-generator/pull/2280) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump brace-expansion [#2274](https://github.com/vega/ts-json-schema-generator/pull/2274) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.32.1 to 8.33.1 [#2270](https://github.com/vega/ts-json-schema-generator/pull/2270) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.29 to 22.15.30 [#2271](https://github.com/vega/ts-json-schema-generator/pull/2271) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.27.0 to 9.28.0 [#2264](https://github.com/vega/ts-json-schema-generator/pull/2264) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.27.1 to 7.27.4 [#2265](https://github.com/vega/ts-json-schema-generator/pull/2265) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.27.0 to 9.28.0 [#2266](https://github.com/vega/ts-json-schema-generator/pull/2266) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.4.0 to 5.4.1 [#2267](https://github.com/vega/ts-json-schema-generator/pull/2267) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.21 to 22.15.29 [#2268](https://github.com/vega/ts-json-schema-generator/pull/2268) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.18 to 22.15.21 [#2262](https://github.com/vega/ts-json-schema-generator/pull/2262) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.27.1 to 7.27.2 [#2263](https://github.com/vega/ts-json-schema-generator/pull/2263) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 13.1.0 to 14.0.0 [#2255](https://github.com/vega/ts-json-schema-generator/pull/2255) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.32.0 to 8.32.1 [#2254](https://github.com/vega/ts-json-schema-generator/pull/2254) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.26.0 to 9.27.0 [#2256](https://github.com/vega/ts-json-schema-generator/pull/2256) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.26.0 to 9.27.0 [#2257](https://github.com/vega/ts-json-schema-generator/pull/2257) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.3 to 22.15.18 [#2258](https://github.com/vega/ts-json-schema-generator/pull/2258) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 10.1.2 to 10.1.5 [#2249](https://github.com/vega/ts-json-schema-generator/pull/2249) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.31.0 to 8.32.0 [#2250](https://github.com/vega/ts-json-schema-generator/pull/2250) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.19.3 to 4.19.4 [#2251](https://github.com/vega/ts-json-schema-generator/pull/2251) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.25.1 to 9.26.0 [#2252](https://github.com/vega/ts-json-schema-generator/pull/2252) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.2.6 to 5.4.0 [#2253](https://github.com/vega/ts-json-schema-generator/pull/2253) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.27.0 to 7.27.1 [#2244](https://github.com/vega/ts-json-schema-generator/pull/2244) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.25.1 to 9.26.0 [#2245](https://github.com/vega/ts-json-schema-generator/pull/2245) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.26.9 to 7.27.1 [#2246](https://github.com/vega/ts-json-schema-generator/pull/2246) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.26.10 to 7.27.1 [#2247](https://github.com/vega/ts-json-schema-generator/pull/2247) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.2 to 22.15.3 [#2248](https://github.com/vega/ts-json-schema-generator/pull/2248) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.14.1 to 22.15.2 [#2239](https://github.com/vega/ts-json-schema-generator/pull/2239) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump glob from 11.0.1 to 11.0.2 [#2240](https://github.com/vega/ts-json-schema-generator/pull/2240) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.25.0 to 9.25.1 [#2242](https://github.com/vega/ts-json-schema-generator/pull/2242) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.30.1 to 8.31.0 [#2243](https://github.com/vega/ts-json-schema-generator/pull/2243) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.29.1 to 8.30.1 [#2235](https://github.com/vega/ts-json-schema-generator/pull/2235) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.24.0 to 9.25.0 [#2236](https://github.com/vega/ts-json-schema-generator/pull/2236) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.24.0 to 9.25.0 [#2237](https://github.com/vega/ts-json-schema-generator/pull/2237) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.14.0 to 22.14.1 [#2225](https://github.com/vega/ts-json-schema-generator/pull/2225) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.29.0 to 8.29.1 [#2226](https://github.com/vega/ts-json-schema-generator/pull/2226) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 10.1.1 to 10.1.2 [#2227](https://github.com/vega/ts-json-schema-generator/pull/2227) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.23.0 to 9.24.0 [#2228](https://github.com/vega/ts-json-schema-generator/pull/2228) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 5
  
  - [@CalLavicka](https://github.com/CalLavicka)
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Alex ([@alexchexes](https://github.com/alexchexes))
  - Arthur Fiorette ([@arthurfiorette](https://github.com/arthurfiorette))
  - Valentyne Stigloher ([@pixunil](https://github.com/pixunil))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
