### PR TITLE
Fix: crashes and incomplete schema generation when mapped/intersection helpers are used with `--additional-properties` option

### DIFF
--- a/src/NodeParser/MappedTypeNodeParser.ts
+++ b/src/NodeParser/MappedTypeNodeParser.ts
@@ -10,6 +10,7 @@ import { DefinitionType } from "../Type/DefinitionType.js";
 import type { EnumValue } from "../Type/EnumType.js";
 import { EnumType } from "../Type/EnumType.js";
 import { LiteralType } from "../Type/LiteralType.js";
+import { AnyType } from "../Type/AnyType.js";
 import { NeverType } from "../Type/NeverType.js";
 import { NumberType } from "../Type/NumberType.js";
 import { ObjectProperty, ObjectType } from "../Type/ObjectType.js";
@@ -65,7 +66,7 @@ export class MappedTypeNodeParser implements SubNodeParser {
                 return type instanceof NeverType ? new NeverType() : new ArrayType(type);
             }
             // Key type widens to `string`
-            const type = this.childNodeParser.createType(node.type!, context);
+            const type = this.childNodeParser.createType(node.type!, this.createSubContext(node, keyListType, context));
             // const resultType = type instanceof NeverType ? new NeverType() : new ObjectType(id, [], [], type);
             const resultType = new ObjectType(id, [], [], type);
             if (resultType) {
@@ -162,13 +163,20 @@ export class MappedTypeNodeParser implements SubNodeParser {
             return this.additionalProperties;
         }
 
-        const key = keyListType.getTypes().filter((type) => !(derefType(type) instanceof LiteralType))[0];
+        const types = keyListType.getTypes();
+        const literalKeys = types.filter((t) => derefType(t) instanceof LiteralType);
+        const nonLiteral = types.filter((type) => !(derefType(type) instanceof LiteralType))[0];
 
-        if (key) {
-            return (
-                this.childNodeParser.createType(node.type!, this.createSubContext(node, key, context)) ??
-                this.additionalProperties
-            );
+        if (nonLiteral) {
+            const additional =
+                this.childNodeParser.createType(node.type!, this.createSubContext(node, nonLiteral, context)) ??
+                this.additionalProperties;
+
+            if (literalKeys.length > 0 && additional instanceof AnyType && this.additionalProperties === true) {
+                return false;
+            }
+
+            return additional;
         }
 
         return this.additionalProperties;

--- a/src/NodeParser/MappedTypeNodeParser.ts
+++ b/src/NodeParser/MappedTypeNodeParser.ts
@@ -10,7 +10,6 @@ import { DefinitionType } from "../Type/DefinitionType.js";
 import type { EnumValue } from "../Type/EnumType.js";
 import { EnumType } from "../Type/EnumType.js";
 import { LiteralType } from "../Type/LiteralType.js";
-import { AnyType } from "../Type/AnyType.js";
 import { NeverType } from "../Type/NeverType.js";
 import { NumberType } from "../Type/NumberType.js";
 import { ObjectProperty, ObjectType } from "../Type/ObjectType.js";
@@ -163,20 +162,13 @@ export class MappedTypeNodeParser implements SubNodeParser {
             return this.additionalProperties;
         }
 
-        const types = keyListType.getTypes();
-        const literalKeys = types.filter((t) => derefType(t) instanceof LiteralType);
-        const nonLiteral = types.filter((type) => !(derefType(type) instanceof LiteralType))[0];
+        const key = keyListType.getTypes().filter((type) => !(derefType(type) instanceof LiteralType))[0];
 
-        if (nonLiteral) {
-            const additional =
-                this.childNodeParser.createType(node.type!, this.createSubContext(node, nonLiteral, context)) ??
-                this.additionalProperties;
-
-            if (literalKeys.length > 0 && additional instanceof AnyType && this.additionalProperties === true) {
-                return false;
-            }
-
-            return additional;
+        if (key) {
+            return (
+                this.childNodeParser.createType(node.type!, this.createSubContext(node, key, context)) ??
+                this.additionalProperties
+            );
         }
 
         return this.additionalProperties;

--- a/src/NodeParser/TypeOperatorNodeParser.ts
+++ b/src/NodeParser/TypeOperatorNodeParser.ts
@@ -2,7 +2,7 @@ import ts from "typescript";
 import type { Context, NodeParser } from "../NodeParser.js";
 import type { SubNodeParser } from "../SubNodeParser.js";
 import { ArrayType } from "../Type/ArrayType.js";
-import type { BaseType } from "../Type/BaseType.js";
+import { BaseType } from "../Type/BaseType.js";
 import { NumberType } from "../Type/NumberType.js";
 import { ObjectType } from "../Type/ObjectType.js";
 import { StringType } from "../Type/StringType.js";
@@ -28,7 +28,7 @@ export class TypeOperatorNodeParser implements SubNodeParser {
             return new NumberType();
         }
         const keys = getTypeKeys(type);
-        if (derefed instanceof ObjectType && derefed.getAdditionalProperties()) {
+        if (derefed instanceof ObjectType && derefed.getAdditionalProperties() instanceof BaseType) {
             return new UnionType([...keys, new StringType()]);
         }
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -391,6 +391,22 @@ describe("config", () => {
     );
 
     it(
+        "mapped-intersection",
+        assertSchema("mapped-intersection", {
+            type: "MyObject",
+            additionalProperties: true,
+        }),
+    );
+
+    it(
+        "mapped-intersection-complex",
+        assertSchema("mapped-intersection-complex", {
+            type: "MyObject",
+            additionalProperties: true,
+        }),
+    );
+
+    it(
         "arrow-function-parameters",
         assertSchema("arrow-function-parameters", {
             type: "myFunction",

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -407,6 +407,22 @@ describe("config", () => {
     );
 
     it(
+        "mapped-intersection-index",
+        assertSchema("mapped-intersection-index", {
+            type: "MyObject",
+            additionalProperties: true,
+        }),
+    );
+
+    it(
+        "mapped-index-any",
+        assertSchema("mapped-index-any", {
+            type: "*",
+            additionalProperties: true,
+        }),
+    );
+
+    it(
         "arrow-function-parameters",
         assertSchema("arrow-function-parameters", {
             type: "myFunction",

--- a/test/config/mapped-index-any/main.ts
+++ b/test/config/mapped-index-any/main.ts
@@ -1,0 +1,15 @@
+interface BaseA {
+    foo: string;
+    [key: string]: any;
+}
+
+type Keep<B> = { [K in keyof B]: B[K] };
+
+export type MyObjectA = Keep<BaseA>;
+
+interface BaseB {
+    foo: string;
+    [key: string]: unknown;
+}
+
+export type MyObjectB = { [K in keyof BaseB]: any };

--- a/test/config/mapped-index-any/schema.json
+++ b/test/config/mapped-index-any/schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObjectA": {
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "foo"
+      ],
+      "type": "object"
+    },
+    "MyObjectB": {
+      "properties": {
+        "foo": {}
+      },
+      "required": [
+        "foo"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/test/config/mapped-intersection-complex/main.ts
+++ b/test/config/mapped-intersection-complex/main.ts
@@ -1,0 +1,20 @@
+type OptionalKeys<TBase> = {
+    [K in keyof TBase]-?: {} extends Pick<TBase, K> ? K : never;
+}[keyof TBase];
+
+type Override<TBase, TOverride extends { [K in keyof TOverride]: K extends keyof TBase ? unknown : never }> = {
+    [K in keyof TBase as K extends keyof TOverride ? never : K]: TBase[K]; // keep everything except overrides
+} & {
+    [K in keyof TOverride]: K extends keyof TBase
+        ? K extends OptionalKeys<TBase> // preserve optionality
+            ? TOverride[K] | undefined
+            : TOverride[K]
+        : never;
+};
+
+interface Base {
+    foo: string;
+    bar: null;
+}
+
+export type MyObject = Override<Base, { bar: number }>;

--- a/test/config/mapped-intersection-complex/schema.json
+++ b/test/config/mapped-intersection-complex/schema.json
@@ -1,0 +1,21 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "properties": {
+        "bar": {
+          "type": "number"
+        },
+        "foo": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "bar",
+        "foo"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/test/config/mapped-intersection-index/main.ts
+++ b/test/config/mapped-intersection-index/main.ts
@@ -1,0 +1,11 @@
+interface Base {
+    foo: string;
+    bar: null;
+    [key: string]: any;
+}
+
+type Keep<B, K> = { [P in Exclude<keyof B, K>]: B[P] };
+
+type Override<B, O extends Partial<Record<keyof B, any>>> = Keep<B, keyof O> & O;
+
+export type MyObject = Override<Base, { bar: number }>;

--- a/test/config/mapped-intersection-index/schema.json
+++ b/test/config/mapped-intersection-index/schema.json
@@ -1,0 +1,21 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "properties": {
+        "bar": {
+          "type": "number"
+        },
+        "foo": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "bar",
+        "foo"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/test/config/mapped-intersection/main.ts
+++ b/test/config/mapped-intersection/main.ts
@@ -1,0 +1,8 @@
+interface Base {
+    foo: string;
+    bar: null;
+}
+
+type Keep<B, K extends keyof B> = { [P in Exclude<keyof B, K>]: B[P] };
+
+export type MyObject = Keep<Base, "bar"> & { bar: number };

--- a/test/config/mapped-intersection/schema.json
+++ b/test/config/mapped-intersection/schema.json
@@ -1,0 +1,21 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "properties": {
+        "bar": {
+          "type": "number"
+        },
+        "foo": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "bar",
+        "foo"
+      ],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
Closes #2273