### PR TITLE
feat: add `NewExpression` parser

### DIFF
--- a/factory/parser.ts
+++ b/factory/parser.ts
@@ -16,6 +16,7 @@ import { BooleanLiteralNodeParser } from "../src/NodeParser/BooleanLiteralNodePa
 import { BooleanTypeNodeParser } from "../src/NodeParser/BooleanTypeNodeParser.js";
 import { CallExpressionParser } from "../src/NodeParser/CallExpressionParser.js";
 import { ConditionalTypeNodeParser } from "../src/NodeParser/ConditionalTypeNodeParser.js";
+import { NewExpressionParser } from "../src/NodeParser/NewExpressionParser.js";
 import { ConstructorNodeParser } from "../src/NodeParser/ConstructorNodeParser.js";
 import { EnumNodeParser } from "../src/NodeParser/EnumNodeParser.js";
 import { ExpressionWithTypeArgumentsNodeParser } from "../src/NodeParser/ExpressionWithTypeArgumentsNodeParser.js";
@@ -149,6 +150,7 @@ export function createParser(program: ts.Program, config: CompletedConfig, augme
         .addNodeParser(new SpreadElementNodeParser(chainNodeParser))
 
         .addNodeParser(new CallExpressionParser(typeChecker, chainNodeParser))
+        .addNodeParser(new NewExpressionParser(typeChecker, chainNodeParser))
         .addNodeParser(new PropertyAccessExpressionParser(typeChecker, chainNodeParser))
 
         .addNodeParser(withCircular(withExpose(withJsDoc(new TypeAliasNodeParser(typeChecker, chainNodeParser)))))

--- a/src/NodeParser/NewExpressionParser.ts
+++ b/src/NodeParser/NewExpressionParser.ts
@@ -1,0 +1,46 @@
+import ts from "typescript";
+import type { NodeParser } from "../NodeParser.js";
+import { Context } from "../NodeParser.js";
+import type { SubNodeParser } from "../SubNodeParser.js";
+import type { BaseType } from "../Type/BaseType.js";
+import { UnknownNodeError } from "../Error/Errors.js";
+
+export class NewExpressionParser implements SubNodeParser {
+    public constructor(
+        protected typeChecker: ts.TypeChecker,
+        protected childNodeParser: NodeParser,
+    ) {}
+
+    public supportsNode(node: ts.NewExpression): boolean {
+        return node.kind === ts.SyntaxKind.NewExpression;
+    }
+
+    public createType(node: ts.NewExpression, context: Context): BaseType {
+        const type = this.typeChecker.getTypeAtLocation(node);
+        
+        const symbol = type.symbol || type.aliasSymbol;
+        
+        const decl =
+            this.typeChecker.typeToTypeNode(type, node, ts.NodeBuilderFlags.IgnoreErrors) ||
+            symbol?.valueDeclaration ||
+            symbol?.declarations?.[0];
+
+        if (!decl) {
+            throw new UnknownNodeError(node);
+        }
+
+        return this.childNodeParser.createType(decl, this.createSubContext(node, context));
+    }
+
+    protected createSubContext(node: ts.NewExpression, parentContext: Context): Context {
+        const subContext = new Context(node);
+
+        if (node.arguments) {
+            for (const arg of node.arguments) {
+                const type = this.childNodeParser.createType(arg, parentContext);
+                subContext.pushArgument(type);
+            }
+        }
+        return subContext;
+    }
+}

--- a/src/NodeParser/NewExpressionParser.ts
+++ b/src/NodeParser/NewExpressionParser.ts
@@ -17,9 +17,9 @@ export class NewExpressionParser implements SubNodeParser {
 
     public createType(node: ts.NewExpression, context: Context): BaseType {
         const type = this.typeChecker.getTypeAtLocation(node);
-        
+
         const symbol = type.symbol || type.aliasSymbol;
-        
+
         const decl =
             this.typeChecker.typeToTypeNode(type, node, ts.NodeBuilderFlags.IgnoreErrors) ||
             symbol?.valueDeclaration ||

--- a/test/valid-data-struct.test.ts
+++ b/test/valid-data-struct.test.ts
@@ -31,6 +31,7 @@ describe("valid-data-struct", () => {
     it("class-inheritance", assertValidSchema("class-inheritance", "MyObject"));
     it("class-generics", assertValidSchema("class-generics", "MyObject"));
     it("class-jsdoc", assertValidSchema("class-jsdoc", "MyObject"));
+    it("class-new-expression", assertValidSchema("class-new-expression", "MyType"));
 
     it("structure-private", assertValidSchema("structure-private", "MyObject"));
     it("structure-anonymous", assertValidSchema("structure-anonymous", "MyObject"));

--- a/test/valid-data/class-new-expression/main.ts
+++ b/test/valid-data/class-new-expression/main.ts
@@ -1,0 +1,50 @@
+class MyObject {
+    // Static properties must be ignored
+    public static staticProp: number;
+
+    public propA: number;
+    // Test that types can be inferred
+    public propB = 42;
+
+    // Properties without type must be ignored
+    public noType;
+
+    // Protected properties must be ignored
+    protected protectedProp: string;
+
+    // Protected properties must be ignored
+    private privateProp: boolean;
+
+    readonly readonlyProp: string;
+
+    // Constructors must be ignored
+    public constructor(
+        protected a: number,
+        private b: number,
+        c: number,
+        // Test that types can be inferred
+        public propC = 42,
+        public propD?: string,
+    ) {
+        this.privateProp = false;
+    }
+
+    // Normal method must be ignored
+    public getPrivateProp() {
+        return this.privateProp;
+    }
+
+    // Getter methods must be ignored
+    public get getterSetter(): number {
+        return this.propA;
+    }
+
+    // Setter methods must be ignored
+    public set getterSetter(value: number) {
+        this.propA = value;
+    }
+}
+
+const obj = new MyObject(1, 2, 3);
+
+export type MyType = typeof obj;

--- a/test/valid-data/class-new-expression/main.ts
+++ b/test/valid-data/class-new-expression/main.ts
@@ -1,50 +1,5 @@
-class MyObject {
-    // Static properties must be ignored
-    public static staticProp: number;
+class MyObject {}
 
-    public propA: number;
-    // Test that types can be inferred
-    public propB = 42;
-
-    // Properties without type must be ignored
-    public noType;
-
-    // Protected properties must be ignored
-    protected protectedProp: string;
-
-    // Protected properties must be ignored
-    private privateProp: boolean;
-
-    readonly readonlyProp: string;
-
-    // Constructors must be ignored
-    public constructor(
-        protected a: number,
-        private b: number,
-        c: number,
-        // Test that types can be inferred
-        public propC = 42,
-        public propD?: string,
-    ) {
-        this.privateProp = false;
-    }
-
-    // Normal method must be ignored
-    public getPrivateProp() {
-        return this.privateProp;
-    }
-
-    // Getter methods must be ignored
-    public get getterSetter(): number {
-        return this.propA;
-    }
-
-    // Setter methods must be ignored
-    public set getterSetter(value: number) {
-        this.propA = value;
-    }
-}
-
-const obj = new MyObject(1, 2, 3);
+const obj = new MyObject();
 
 export type MyType = typeof obj;

--- a/test/valid-data/class-new-expression/schema.json
+++ b/test/valid-data/class-new-expression/schema.json
@@ -1,0 +1,33 @@
+{
+  "$ref": "#/definitions/MyType",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyType": {
+      "additionalProperties": false,
+      "properties": {
+        "propA": {
+          "type": "number"
+        },
+        "propB": {
+          "type": "number"
+        },
+        "propC": {
+          "type": "number"
+        },
+        "propD": {
+          "type": "string"
+        },
+        "readonlyProp": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "propA",
+        "propB",
+        "readonlyProp",
+        "propC"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/test/valid-data/class-new-expression/schema.json
+++ b/test/valid-data/class-new-expression/schema.json
@@ -4,29 +4,6 @@
   "definitions": {
     "MyType": {
       "additionalProperties": false,
-      "properties": {
-        "propA": {
-          "type": "number"
-        },
-        "propB": {
-          "type": "number"
-        },
-        "propC": {
-          "type": "number"
-        },
-        "propD": {
-          "type": "string"
-        },
-        "readonlyProp": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "propA",
-        "propB",
-        "readonlyProp",
-        "propC"
-      ],
       "type": "object"
     }
   }


### PR DESCRIPTION
This adds support for types that depend on the ability to parse `NewExpression`s, as in:

```ts
const foo = new Foo()
type FooType = typeof foo
```

This should close https://github.com/vega/ts-json-schema-generator/issues/2054
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.5.0-next.6`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: James Vaughan ([@jamesbvaughan](https://github.com/jamesbvaughan))
  
  :heart: Alex ([@alexchexes](https://github.com/alexchexes))
  
  :heart: Cal ([@CalLavicka](https://github.com/CalLavicka))
  
  :heart: Valentyne Stigloher ([@pixunil](https://github.com/pixunil))
  
  #### 🚀 Enhancement
  
  - feat: add `NewExpression` parser [#2346](https://github.com/vega/ts-json-schema-generator/pull/2346) ([@jamesbvaughan](https://github.com/jamesbvaughan))
  - feat: Add --full-description option to include full comment in schema [#2224](https://github.com/vega/ts-json-schema-generator/pull/2224) ([@alexchexes](https://github.com/alexchexes))
  - feat(parser): support SpreadElement in array literals [#2269](https://github.com/vega/ts-json-schema-generator/pull/2269) ([@alexchexes](https://github.com/alexchexes))
  
  #### 🐛 Bug Fix
  
  - chore: update deps [#2306](https://github.com/vega/ts-json-schema-generator/pull/2306) ([@domoritz](https://github.com/domoritz))
  - Fix: crashes and incomplete schema generation when mapped/intersection helpers are used with `--additional-properties` option [#2305](https://github.com/vega/ts-json-schema-generator/pull/2305) ([@alexchexes](https://github.com/alexchexes))
  - Fix promise with generic type arguments [#2291](https://github.com/vega/ts-json-schema-generator/pull/2291) ([@CalLavicka](https://github.com/CalLavicka))
  - Fix: prune unreachable definitions when `--type "*"` is used with multiple exports [#2284](https://github.com/vega/ts-json-schema-generator/pull/2284) ([@alexchexes](https://github.com/alexchexes) [@arthurfiorette](https://github.com/arthurfiorette))
  - Fix: crash when a union includes `symbol` [#2282](https://github.com/vega/ts-json-schema-generator/pull/2282) ([@alexchexes](https://github.com/alexchexes))
  - fix: correctly generate anyOf on unions with string and boolean constant [#2208](https://github.com/vega/ts-json-schema-generator/pull/2208) ([@pixunil](https://github.com/pixunil))
  - fix: fully unwrap union aliases in mapped keys to avoid generating incorrect additionalProperties [#2232](https://github.com/vega/ts-json-schema-generator/pull/2232) ([@alexchexes](https://github.com/alexchexes))
  - fix: avoid incorrect additionalProperties for Pick<..., AliasLiteralUnion> [#2230](https://github.com/vega/ts-json-schema-generator/pull/2230) ([@alexchexes](https://github.com/alexchexes))
  
  #### 🔩 Dependency Updates
  
  - chore(deps): bump actions/setup-node from 4 to 5 [#2345](https://github.com/vega/ts-json-schema-generator/pull/2345) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 30.0.5 to 30.1.1 [#2343](https://github.com/vega/ts-json-schema-generator/pull/2343) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.40.0 to 8.41.0 [#2344](https://github.com/vega/ts-json-schema-generator/pull/2344) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump chai from 5.2.1 to 6.0.1 [#2341](https://github.com/vega/ts-json-schema-generator/pull/2341) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.33.0 to 9.34.0 [#2337](https://github.com/vega/ts-json-schema-generator/pull/2337) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.33.0 to 9.34.0 [#2338](https://github.com/vega/ts-json-schema-generator/pull/2338) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.20.4 to 4.20.5 [#2339](https://github.com/vega/ts-json-schema-generator/pull/2339) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.39.1 to 8.40.0 [#2340](https://github.com/vega/ts-json-schema-generator/pull/2340) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.28.0 to 7.28.3 [#2331](https://github.com/vega/ts-json-schema-generator/pull/2331) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.2.1 to 24.3.0 [#2332](https://github.com/vega/ts-json-schema-generator/pull/2332) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.39.0 to 8.39.1 [#2333](https://github.com/vega/ts-json-schema-generator/pull/2333) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.28.0 to 7.28.3 [#2334](https://github.com/vega/ts-json-schema-generator/pull/2334) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.20.3 to 4.20.4 [#2335](https://github.com/vega/ts-json-schema-generator/pull/2335) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/checkout from 4 to 5 [#2330](https://github.com/vega/ts-json-schema-generator/pull/2330) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 5.8.3 to 5.9.2 [#2325](https://github.com/vega/ts-json-schema-generator/pull/2325) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.38.0 to 8.39.0 [#2329](https://github.com/vega/ts-json-schema-generator/pull/2329) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.32.0 to 9.33.0 [#2326](https://github.com/vega/ts-json-schema-generator/pull/2326) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.5.3 to 5.5.4 [#2327](https://github.com/vega/ts-json-schema-generator/pull/2327) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.1.0 to 24.2.1 [#2328](https://github.com/vega/ts-json-schema-generator/pull/2328) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump cross-env from 7.0.3 to 10.0.0 [#2324](https://github.com/vega/ts-json-schema-generator/pull/2324) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.0.15 to 24.1.0 [#2318](https://github.com/vega/ts-json-schema-generator/pull/2318) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.37.0 to 8.38.0 [#2320](https://github.com/vega/ts-json-schema-generator/pull/2320) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 30.0.4 to 30.0.5 [#2321](https://github.com/vega/ts-json-schema-generator/pull/2321) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.31.0 to 9.32.0 [#2322](https://github.com/vega/ts-json-schema-generator/pull/2322) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.0.13 to 24.0.15 [#2313](https://github.com/vega/ts-json-schema-generator/pull/2313) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 10.1.5 to 10.1.8 [#2314](https://github.com/vega/ts-json-schema-generator/pull/2314) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.36.0 to 8.37.0 [#2315](https://github.com/vega/ts-json-schema-generator/pull/2315) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.5.1 to 5.5.3 [#2316](https://github.com/vega/ts-json-schema-generator/pull/2316) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump chai from 5.2.0 to 5.2.1 [#2308](https://github.com/vega/ts-json-schema-generator/pull/2308) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.0.10 to 24.0.13 [#2309](https://github.com/vega/ts-json-schema-generator/pull/2309) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.35.1 to 8.36.0 [#2310](https://github.com/vega/ts-json-schema-generator/pull/2310) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.30.1 to 9.31.0 [#2311](https://github.com/vega/ts-json-schema-generator/pull/2311) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.0.7 to 24.0.10 [#2301](https://github.com/vega/ts-json-schema-generator/pull/2301) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.27.4 to 7.28.0 [#2302](https://github.com/vega/ts-json-schema-generator/pull/2302) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.5.0 to 5.5.1 [#2304](https://github.com/vega/ts-json-schema-generator/pull/2304) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.30.0 to 9.30.1 [#2300](https://github.com/vega/ts-json-schema-generator/pull/2300) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.30 to 24.0.7 [#2296](https://github.com/vega/ts-json-schema-generator/pull/2296) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega-lite from 6.1.0 to 6.2.0 [#2295](https://github.com/vega/ts-json-schema-generator/pull/2295) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 3.5.3 to 3.6.2 [#2297](https://github.com/vega/ts-json-schema-generator/pull/2297) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 30.0.2 to 30.0.3 [#2298](https://github.com/vega/ts-json-schema-generator/pull/2298) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.29.0 to 9.30.0 [#2299](https://github.com/vega/ts-json-schema-generator/pull/2299) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest and @types/jest [#2287](https://github.com/vega/ts-json-schema-generator/pull/2287) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.33.1 to 8.34.1 [#2289](https://github.com/vega/ts-json-schema-generator/pull/2289) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.4.1 to 5.5.0 [#2290](https://github.com/vega/ts-json-schema-generator/pull/2290) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.19.4 to 4.20.3 [#2276](https://github.com/vega/ts-json-schema-generator/pull/2276) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.28.0 to 9.29.0 [#2277](https://github.com/vega/ts-json-schema-generator/pull/2277) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump glob from 11.0.2 to 11.0.3 [#2279](https://github.com/vega/ts-json-schema-generator/pull/2279) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.28.0 to 9.29.0 [#2280](https://github.com/vega/ts-json-schema-generator/pull/2280) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump brace-expansion [#2274](https://github.com/vega/ts-json-schema-generator/pull/2274) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.32.1 to 8.33.1 [#2270](https://github.com/vega/ts-json-schema-generator/pull/2270) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.29 to 22.15.30 [#2271](https://github.com/vega/ts-json-schema-generator/pull/2271) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.27.0 to 9.28.0 [#2264](https://github.com/vega/ts-json-schema-generator/pull/2264) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.27.1 to 7.27.4 [#2265](https://github.com/vega/ts-json-schema-generator/pull/2265) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.27.0 to 9.28.0 [#2266](https://github.com/vega/ts-json-schema-generator/pull/2266) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.4.0 to 5.4.1 [#2267](https://github.com/vega/ts-json-schema-generator/pull/2267) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.21 to 22.15.29 [#2268](https://github.com/vega/ts-json-schema-generator/pull/2268) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.18 to 22.15.21 [#2262](https://github.com/vega/ts-json-schema-generator/pull/2262) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.27.1 to 7.27.2 [#2263](https://github.com/vega/ts-json-schema-generator/pull/2263) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 13.1.0 to 14.0.0 [#2255](https://github.com/vega/ts-json-schema-generator/pull/2255) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.32.0 to 8.32.1 [#2254](https://github.com/vega/ts-json-schema-generator/pull/2254) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.26.0 to 9.27.0 [#2256](https://github.com/vega/ts-json-schema-generator/pull/2256) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.26.0 to 9.27.0 [#2257](https://github.com/vega/ts-json-schema-generator/pull/2257) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.3 to 22.15.18 [#2258](https://github.com/vega/ts-json-schema-generator/pull/2258) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 10.1.2 to 10.1.5 [#2249](https://github.com/vega/ts-json-schema-generator/pull/2249) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.31.0 to 8.32.0 [#2250](https://github.com/vega/ts-json-schema-generator/pull/2250) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.19.3 to 4.19.4 [#2251](https://github.com/vega/ts-json-schema-generator/pull/2251) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.25.1 to 9.26.0 [#2252](https://github.com/vega/ts-json-schema-generator/pull/2252) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.2.6 to 5.4.0 [#2253](https://github.com/vega/ts-json-schema-generator/pull/2253) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.27.0 to 7.27.1 [#2244](https://github.com/vega/ts-json-schema-generator/pull/2244) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.25.1 to 9.26.0 [#2245](https://github.com/vega/ts-json-schema-generator/pull/2245) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.26.9 to 7.27.1 [#2246](https://github.com/vega/ts-json-schema-generator/pull/2246) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.26.10 to 7.27.1 [#2247](https://github.com/vega/ts-json-schema-generator/pull/2247) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.2 to 22.15.3 [#2248](https://github.com/vega/ts-json-schema-generator/pull/2248) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.14.1 to 22.15.2 [#2239](https://github.com/vega/ts-json-schema-generator/pull/2239) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump glob from 11.0.1 to 11.0.2 [#2240](https://github.com/vega/ts-json-schema-generator/pull/2240) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.25.0 to 9.25.1 [#2242](https://github.com/vega/ts-json-schema-generator/pull/2242) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.30.1 to 8.31.0 [#2243](https://github.com/vega/ts-json-schema-generator/pull/2243) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.29.1 to 8.30.1 [#2235](https://github.com/vega/ts-json-schema-generator/pull/2235) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.24.0 to 9.25.0 [#2236](https://github.com/vega/ts-json-schema-generator/pull/2236) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.24.0 to 9.25.0 [#2237](https://github.com/vega/ts-json-schema-generator/pull/2237) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.14.0 to 22.14.1 [#2225](https://github.com/vega/ts-json-schema-generator/pull/2225) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.29.0 to 8.29.1 [#2226](https://github.com/vega/ts-json-schema-generator/pull/2226) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 10.1.1 to 10.1.2 [#2227](https://github.com/vega/ts-json-schema-generator/pull/2227) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.23.0 to 9.24.0 [#2228](https://github.com/vega/ts-json-schema-generator/pull/2228) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 7
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Alex ([@alexchexes](https://github.com/alexchexes))
  - Arthur Fiorette ([@arthurfiorette](https://github.com/arthurfiorette))
  - Cal ([@CalLavicka](https://github.com/CalLavicka))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
  - James Vaughan ([@jamesbvaughan](https://github.com/jamesbvaughan))
  - Valentyne Stigloher ([@pixunil](https://github.com/pixunil))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
