### PR TITLE
Allow node VFS based programmatic usage

### DIFF
--- a/factory/generator.ts
+++ b/factory/generator.ts
@@ -7,7 +7,7 @@ import { createProgram } from "./program.js";
 
 export function createGenerator(config: Config): SchemaGenerator {
     const completedConfig = { ...DEFAULT_CONFIG, ...config };
-    const program = createProgram(completedConfig);
+    const program = config.tsProgram || createProgram(completedConfig);
     const parser = createParser(program, completedConfig);
     const formatter = createFormatter(completedConfig);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.15",
+        "@typescript/vfs": "1.6.2",
         "commander": "^14.0.0",
         "glob": "^11.0.3",
         "json5": "^2.2.3",
@@ -4203,6 +4204,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript/vfs": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.6.2.tgz",
+      "integrity": "sha512-hoBwJwcbKHmvd2QVebiytN1aELvpk9B74B4L1mFm/XT1Q/VOYAWl2vQ9AWRFtQq8zmz6enTpfTV8WRc4ATjW/g==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -5944,7 +5957,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -6500,19 +6512,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/@eslint/js": {
-      "version": "9.38.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.38.0.tgz",
-      "integrity": "sha512-UZ1VpFvXf9J06YG9xQBdnzU+kthors6KjhMAl6f4gH4usHyh31rUf2DLGInT8RFYIReYXNSydgPY0V2LuWgl7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/eslint/node_modules/ajv": {
@@ -9460,7 +9459,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/napi-postinstall": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "normalize-path": "^3.0.0",
     "safe-stable-stringify": "^2.5.0",
     "tslib": "^2.8.1",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "@typescript/vfs":"1.6.2"
   },
   "devDependencies": {
     "@auto-it/conventional-commits": "^11.3.0",

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -1,29 +1,149 @@
+import type ts from "typescript";
+
 export interface Config {
+    /**
+     * Glob pattern(s) for source TypeScript files to process.
+     * If not provided, falls back to files from tsconfig.
+     */
     path?: string;
+
+    /**
+     * Name of the type/interface to generate schema for.
+     * Use "*" to generate schemas for all exported types.
+     */
     type?: string;
+
+    /**
+     * Minify the output JSON schema (no whitespace).
+     * When false, the schema is pretty-printed with 2-space indentation.
+     * @default false
+     */
     minify?: boolean;
+
+    /**
+     * Sets the `$id` property in the root of the generated schema.
+     * Used for schema identification and referencing.
+     */
     schemaId?: string;
+
+    /**
+     * Path to a custom tsconfig.json file for TypeScript compilation.
+     * If not provided, uses default TypeScript configuration.
+     */
     tsconfig?: string;
+
+    /**
+     * Controls which types are exposed as definitions in the schema.
+     * - "all": Exposes all types except type literals
+     * - "none": Exposes no types automatically
+     * - "export": Only exposes exported types (respects @internal JSDoc tag)
+     * @default "export"
+     */
     expose?: "all" | "none" | "export";
+
+    /**
+     * Wraps the root type in a `$ref` definition.
+     * When false, inlines the root type definition directly.
+     * @default true
+     */
     topRef?: boolean;
+
+    /**
+     * Controls how JSDoc comments are parsed and included in the schema.
+     * - "none": Ignores all JSDoc annotations
+     * - "basic": Parses standard JSON Schema JSDoc tags
+     * - "extended": Parses all tags plus descriptions, examples, and type overrides
+     * @default "extended"
+     */
     jsDoc?: "none" | "extended" | "basic";
+
+    /**
+     * Adds a `markdownDescription` field alongside `description` in the schema.
+     * Preserves markdown formatting including newlines.
+     * Only works with `jsDoc: "extended"`.
+     * @default false
+     */
     markdownDescription?: boolean;
+
+    /**
+     * Includes the complete raw JSDoc comment as `fullDescription` in the schema.
+     * Only works with `jsDoc: "extended"`.
+     * @default false
+     */
     fullDescription?: boolean;
+
+    /**
+     * Sorts object properties alphabetically in the output.
+     * @default true
+     */
     sortProps?: boolean;
+
+    /**
+     * Controls whether tuples allow additional items beyond their defined length.
+     * @default false
+     */
     strictTuples?: boolean;
+
+    /**
+     * Skips TypeScript type checking to improve performance.
+     * Speeds up generation but may miss type errors.
+     * @default false
+     */
     skipTypeCheck?: boolean;
+
+    /**
+     * URI-encodes `$ref` values (e.g., `#/definitions/Foo%3CBar%3E`).
+     * When false, uses raw names in reference paths.
+     * @default true
+     */
     encodeRefs?: boolean;
+
+    /**
+     * Array of additional JSDoc tag names to include in the schema.
+     * Custom tags (e.g., `@customProperty`) are parsed and included in output.
+     * Values are parsed as JSON5.
+     * @default []
+     */
     extraTags?: string[];
+
+    /**
+     * Sets default value for `additionalProperties` on objects without index signatures.
+     * When false, objects get `additionalProperties: false` by default.
+     * When true, allows additional properties on all objects.
+     * @default false
+     */
     additionalProperties?: boolean;
+
+    /**
+     * Controls discriminator style for discriminated unions.
+     * - "json-schema": Uses `if`/`then`/`allOf` with properties containing discriminator enum
+     * - "open-api": Uses OpenAPI 3.x style with `discriminator: { propertyName }` and `oneOf`
+     * @default "json-schema"
+     */
     discriminatorType?: "json-schema" | "open-api";
+
+    /**
+     * Controls how function types are handled in the schema.
+     * - "fail": Throws error when encountering function types
+     * - "comment": Generates schema with `$comment` describing the function signature
+     * - "hide": Treats functions as NeverType (excluded from schema)
+     * @default "comment"
+     */
     functions?: FunctionOptions;
+
+    /**
+     * Pre-compiled TypeScript Program instance to use.
+     * Bypasses the default setup of a TypeScript program, and so some configuration options may not be applied.
+     * Useful for programmatic usage with existing TypeScript compilation, or for vfs scenarios where you do not want file-system representation.
+     */
+    tsProgram?: ts.Program;
 }
 
 export type CompletedConfig = Config & typeof DEFAULT_CONFIG;
 
 export type FunctionOptions = "fail" | "comment" | "hide";
 
-export const DEFAULT_CONFIG: Omit<Required<Config>, "path" | "type" | "schemaId" | "tsconfig"> = {
+export const DEFAULT_CONFIG: Omit<Required<Config>, "path" | "type" | "schemaId" | "tsconfig" | "tsProgram"> = {
     expose: "export",
     topRef: true,
     jsDoc: "extended",

--- a/test/unit/programmaticCustomTSProgram.test.ts
+++ b/test/unit/programmaticCustomTSProgram.test.ts
@@ -1,0 +1,52 @@
+import ts from "typescript";
+import { createFSBackedSystem, createVirtualTypeScriptEnvironment } from "@typescript/vfs";
+import type { Config } from "../../src/Config";
+import { createGenerator } from "../../factory/generator";
+
+it("Can generate a schema from a vfs", () => {
+    const tsInterface = `
+    /**
+     * This is a sample interface
+     */
+    export interface SampleInterface {
+        /** This is a name */
+        name: string;
+    }
+    `;
+
+    const fsMap = new Map<string, string>();
+    fsMap.set("/schema.ts", tsInterface);
+
+    // The FS backed API means that it will use the node_modules for lib.d.ts lookups
+    const system = createFSBackedSystem(fsMap, __dirname, ts);
+    const env = createVirtualTypeScriptEnvironment(system, ["/schema.ts"], ts);
+    const program = env.languageService.getProgram();
+    if (!program) throw new Error("No program");
+
+    const schemaConfig: Config = { path: "/schema.ts", tsProgram: program };
+    const generator = createGenerator(schemaConfig);
+
+    const result = generator.createSchema();
+    expect(result).toMatchInlineSnapshot(`
+        {
+          "$ref": "#/definitions/SampleInterface",
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "definitions": {
+            "SampleInterface": {
+              "additionalProperties": false,
+              "description": "This is a sample interface",
+              "properties": {
+                "name": {
+                  "description": "This is a name",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "name",
+              ],
+              "type": "object",
+            },
+          },
+        }
+    `);
+});


### PR DESCRIPTION
Hey there folks, I ended up wanting to replace some code where I was making a folder in `/tmp` to run the schema generator over and thought I should see if anyone else had looked at a vfs only to find that I had the answer for myself https://github.com/vega/ts-json-schema-generator/issues/2182

So, I figured I should add support. This adds a new config variable which accepts a `ts.Program` so you can set up the TS environment however you like (e.g. for vfs support, like I have provided as a test) 

While I was there, I asked Claude Code to generate JSDoc comments for the config to make programmatic usage more useful - but if that's annoying, I can drop them. 
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.5.0-next.7`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: Orta Therox ([@orta](https://github.com/orta))
  
  :heart: James Vaughan ([@jamesbvaughan](https://github.com/jamesbvaughan))
  
  :heart: Alex ([@alexchexes](https://github.com/alexchexes))
  
  :heart: Cal ([@CalLavicka](https://github.com/CalLavicka))
  
  :heart: Valentyne Stigloher ([@pixunil](https://github.com/pixunil))
  
  #### 🚀 Enhancement
  
  - feat: add `NewExpression` parser [#2346](https://github.com/vega/ts-json-schema-generator/pull/2346) ([@jamesbvaughan](https://github.com/jamesbvaughan))
  - feat: Add --full-description option to include full comment in schema [#2224](https://github.com/vega/ts-json-schema-generator/pull/2224) ([@alexchexes](https://github.com/alexchexes))
  - feat(parser): support SpreadElement in array literals [#2269](https://github.com/vega/ts-json-schema-generator/pull/2269) ([@alexchexes](https://github.com/alexchexes))
  
  #### 🐛 Bug Fix
  
  - Allow node VFS based programmatic usage [#2392](https://github.com/vega/ts-json-schema-generator/pull/2392) ([@orta](https://github.com/orta))
  - chore: update deps [#2306](https://github.com/vega/ts-json-schema-generator/pull/2306) ([@domoritz](https://github.com/domoritz))
  - Fix: crashes and incomplete schema generation when mapped/intersection helpers are used with `--additional-properties` option [#2305](https://github.com/vega/ts-json-schema-generator/pull/2305) ([@alexchexes](https://github.com/alexchexes))
  - Fix promise with generic type arguments [#2291](https://github.com/vega/ts-json-schema-generator/pull/2291) ([@CalLavicka](https://github.com/CalLavicka))
  - Fix: prune unreachable definitions when `--type "*"` is used with multiple exports [#2284](https://github.com/vega/ts-json-schema-generator/pull/2284) ([@alexchexes](https://github.com/alexchexes) [@arthurfiorette](https://github.com/arthurfiorette))
  - Fix: crash when a union includes `symbol` [#2282](https://github.com/vega/ts-json-schema-generator/pull/2282) ([@alexchexes](https://github.com/alexchexes))
  - fix: correctly generate anyOf on unions with string and boolean constant [#2208](https://github.com/vega/ts-json-schema-generator/pull/2208) ([@pixunil](https://github.com/pixunil))
  - fix: fully unwrap union aliases in mapped keys to avoid generating incorrect additionalProperties [#2232](https://github.com/vega/ts-json-schema-generator/pull/2232) ([@alexchexes](https://github.com/alexchexes))
  - fix: avoid incorrect additionalProperties for Pick<..., AliasLiteralUnion> [#2230](https://github.com/vega/ts-json-schema-generator/pull/2230) ([@alexchexes](https://github.com/alexchexes))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump js-yaml from 3.14.1 to 3.14.2 [#2405](https://github.com/vega/ts-json-schema-generator/pull/2405) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump glob [#2404](https://github.com/vega/ts-json-schema-generator/pull/2404) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.10.0 to 24.10.1 [#2398](https://github.com/vega/ts-json-schema-generator/pull/2398) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 11.3.0 to 11.3.6 [#2399](https://github.com/vega/ts-json-schema-generator/pull/2399) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 11.3.0 to 11.3.6 [#2400](https://github.com/vega/ts-json-schema-generator/pull/2400) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.46.3 to 8.46.4 [#2401](https://github.com/vega/ts-json-schema-generator/pull/2401) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump chai from 6.2.0 to 6.2.1 [#2402](https://github.com/vega/ts-json-schema-generator/pull/2402) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.39.0 to 9.39.1 [#2394](https://github.com/vega/ts-json-schema-generator/pull/2394) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.39.0 to 9.39.1 [#2395](https://github.com/vega/ts-json-schema-generator/pull/2395) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.9.2 to 24.10.0 [#2396](https://github.com/vega/ts-json-schema-generator/pull/2396) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.46.2 to 8.46.3 [#2393](https://github.com/vega/ts-json-schema-generator/pull/2393) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.38.0 to 9.39.0 [#2387](https://github.com/vega/ts-json-schema-generator/pull/2387) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.28.3 to 7.28.5 [#2388](https://github.com/vega/ts-json-schema-generator/pull/2388) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.9.1 to 24.9.2 [#2389](https://github.com/vega/ts-json-schema-generator/pull/2389) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump globals from 16.4.0 to 16.5.0 [#2390](https://github.com/vega/ts-json-schema-generator/pull/2390) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.38.0 to 9.39.0 [#2391](https://github.com/vega/ts-json-schema-generator/pull/2391) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.27.1 to 7.28.5 [#2382](https://github.com/vega/ts-json-schema-generator/pull/2382) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 14.0.1 to 14.0.2 [#2383](https://github.com/vega/ts-json-schema-generator/pull/2383) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.8.1 to 24.9.1 [#2384](https://github.com/vega/ts-json-schema-generator/pull/2384) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.46.1 to 8.46.2 [#2385](https://github.com/vega/ts-json-schema-generator/pull/2385) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.28.4 to 7.28.5 [#2386](https://github.com/vega/ts-json-schema-generator/pull/2386) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.7.2 to 24.8.1 [#2378](https://github.com/vega/ts-json-schema-generator/pull/2378) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.37.0 to 9.38.0 [#2379](https://github.com/vega/ts-json-schema-generator/pull/2379) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.46.0 to 8.46.1 [#2381](https://github.com/vega/ts-json-schema-generator/pull/2381) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/setup-node from 5 to 6 [#2377](https://github.com/vega/ts-json-schema-generator/pull/2377) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.45.0 to 8.46.0 [#2373](https://github.com/vega/ts-json-schema-generator/pull/2373) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 5.9.2 to 5.9.3 [#2374](https://github.com/vega/ts-json-schema-generator/pull/2374) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.6.2 to 24.7.2 [#2375](https://github.com/vega/ts-json-schema-generator/pull/2375) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.36.0 to 9.37.0 [#2376](https://github.com/vega/ts-json-schema-generator/pull/2376) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.44.1 to 8.45.0 [#2368](https://github.com/vega/ts-json-schema-generator/pull/2368) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 30.1.3 to 30.2.0 [#2369](https://github.com/vega/ts-json-schema-generator/pull/2369) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.36.0 to 9.37.0 [#2370](https://github.com/vega/ts-json-schema-generator/pull/2370) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump cross-env from 10.0.0 to 10.1.0 [#2371](https://github.com/vega/ts-json-schema-generator/pull/2371) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.5.2 to 24.6.2 [#2372](https://github.com/vega/ts-json-schema-generator/pull/2372) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.44.0 to 8.44.1 [#2363](https://github.com/vega/ts-json-schema-generator/pull/2363) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.3.3 to 24.5.2 [#2364](https://github.com/vega/ts-json-schema-generator/pull/2364) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega-lite from 6.4.0 to 6.4.1 [#2365](https://github.com/vega/ts-json-schema-generator/pull/2365) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump chai from 6.0.1 to 6.2.0 [#2366](https://github.com/vega/ts-json-schema-generator/pull/2366) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.20.5 to 4.20.6 [#2367](https://github.com/vega/ts-json-schema-generator/pull/2367) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega-lite from 6.3.1 to 6.4.0 [#2358](https://github.com/vega/ts-json-schema-generator/pull/2358) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.35.0 to 9.36.0 [#2359](https://github.com/vega/ts-json-schema-generator/pull/2359) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega from 6.1.2 to 6.2.0 [#2360](https://github.com/vega/ts-json-schema-generator/pull/2360) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.43.0 to 8.44.0 [#2361](https://github.com/vega/ts-json-schema-generator/pull/2361) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.35.0 to 9.36.0 [#2362](https://github.com/vega/ts-json-schema-generator/pull/2362) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.3.0 to 24.3.3 [#2353](https://github.com/vega/ts-json-schema-generator/pull/2353) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump globals from 16.3.0 to 16.4.0 [#2354](https://github.com/vega/ts-json-schema-generator/pull/2354) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega-lite from 6.3.0 to 6.3.1 [#2355](https://github.com/vega/ts-json-schema-generator/pull/2355) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.41.0 to 8.43.0 [#2356](https://github.com/vega/ts-json-schema-generator/pull/2356) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 14.0.0 to 14.0.1 [#2357](https://github.com/vega/ts-json-schema-generator/pull/2357) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.28.3 to 7.28.4 [#2347](https://github.com/vega/ts-json-schema-generator/pull/2347) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega-lite from 6.2.0 to 6.3.0 [#2348](https://github.com/vega/ts-json-schema-generator/pull/2348) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.34.0 to 9.35.0 [#2349](https://github.com/vega/ts-json-schema-generator/pull/2349) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 30.1.1 to 30.1.3 [#2350](https://github.com/vega/ts-json-schema-generator/pull/2350) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.34.0 to 9.35.0 [#2351](https://github.com/vega/ts-json-schema-generator/pull/2351) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/setup-node from 4 to 5 [#2345](https://github.com/vega/ts-json-schema-generator/pull/2345) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 30.0.5 to 30.1.1 [#2343](https://github.com/vega/ts-json-schema-generator/pull/2343) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.40.0 to 8.41.0 [#2344](https://github.com/vega/ts-json-schema-generator/pull/2344) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump chai from 5.2.1 to 6.0.1 [#2341](https://github.com/vega/ts-json-schema-generator/pull/2341) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.33.0 to 9.34.0 [#2337](https://github.com/vega/ts-json-schema-generator/pull/2337) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.33.0 to 9.34.0 [#2338](https://github.com/vega/ts-json-schema-generator/pull/2338) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.20.4 to 4.20.5 [#2339](https://github.com/vega/ts-json-schema-generator/pull/2339) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.39.1 to 8.40.0 [#2340](https://github.com/vega/ts-json-schema-generator/pull/2340) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.28.0 to 7.28.3 [#2331](https://github.com/vega/ts-json-schema-generator/pull/2331) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.2.1 to 24.3.0 [#2332](https://github.com/vega/ts-json-schema-generator/pull/2332) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.39.0 to 8.39.1 [#2333](https://github.com/vega/ts-json-schema-generator/pull/2333) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.28.0 to 7.28.3 [#2334](https://github.com/vega/ts-json-schema-generator/pull/2334) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.20.3 to 4.20.4 [#2335](https://github.com/vega/ts-json-schema-generator/pull/2335) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/checkout from 4 to 5 [#2330](https://github.com/vega/ts-json-schema-generator/pull/2330) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 5.8.3 to 5.9.2 [#2325](https://github.com/vega/ts-json-schema-generator/pull/2325) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.38.0 to 8.39.0 [#2329](https://github.com/vega/ts-json-schema-generator/pull/2329) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.32.0 to 9.33.0 [#2326](https://github.com/vega/ts-json-schema-generator/pull/2326) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.5.3 to 5.5.4 [#2327](https://github.com/vega/ts-json-schema-generator/pull/2327) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.1.0 to 24.2.1 [#2328](https://github.com/vega/ts-json-schema-generator/pull/2328) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump cross-env from 7.0.3 to 10.0.0 [#2324](https://github.com/vega/ts-json-schema-generator/pull/2324) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.0.15 to 24.1.0 [#2318](https://github.com/vega/ts-json-schema-generator/pull/2318) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.37.0 to 8.38.0 [#2320](https://github.com/vega/ts-json-schema-generator/pull/2320) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 30.0.4 to 30.0.5 [#2321](https://github.com/vega/ts-json-schema-generator/pull/2321) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.31.0 to 9.32.0 [#2322](https://github.com/vega/ts-json-schema-generator/pull/2322) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.0.13 to 24.0.15 [#2313](https://github.com/vega/ts-json-schema-generator/pull/2313) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 10.1.5 to 10.1.8 [#2314](https://github.com/vega/ts-json-schema-generator/pull/2314) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.36.0 to 8.37.0 [#2315](https://github.com/vega/ts-json-schema-generator/pull/2315) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.5.1 to 5.5.3 [#2316](https://github.com/vega/ts-json-schema-generator/pull/2316) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump chai from 5.2.0 to 5.2.1 [#2308](https://github.com/vega/ts-json-schema-generator/pull/2308) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.0.10 to 24.0.13 [#2309](https://github.com/vega/ts-json-schema-generator/pull/2309) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.35.1 to 8.36.0 [#2310](https://github.com/vega/ts-json-schema-generator/pull/2310) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.30.1 to 9.31.0 [#2311](https://github.com/vega/ts-json-schema-generator/pull/2311) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.0.7 to 24.0.10 [#2301](https://github.com/vega/ts-json-schema-generator/pull/2301) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.27.4 to 7.28.0 [#2302](https://github.com/vega/ts-json-schema-generator/pull/2302) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.5.0 to 5.5.1 [#2304](https://github.com/vega/ts-json-schema-generator/pull/2304) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.30.0 to 9.30.1 [#2300](https://github.com/vega/ts-json-schema-generator/pull/2300) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.30 to 24.0.7 [#2296](https://github.com/vega/ts-json-schema-generator/pull/2296) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega-lite from 6.1.0 to 6.2.0 [#2295](https://github.com/vega/ts-json-schema-generator/pull/2295) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 3.5.3 to 3.6.2 [#2297](https://github.com/vega/ts-json-schema-generator/pull/2297) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 30.0.2 to 30.0.3 [#2298](https://github.com/vega/ts-json-schema-generator/pull/2298) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.29.0 to 9.30.0 [#2299](https://github.com/vega/ts-json-schema-generator/pull/2299) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest and @types/jest [#2287](https://github.com/vega/ts-json-schema-generator/pull/2287) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.33.1 to 8.34.1 [#2289](https://github.com/vega/ts-json-schema-generator/pull/2289) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.4.1 to 5.5.0 [#2290](https://github.com/vega/ts-json-schema-generator/pull/2290) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.19.4 to 4.20.3 [#2276](https://github.com/vega/ts-json-schema-generator/pull/2276) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.28.0 to 9.29.0 [#2277](https://github.com/vega/ts-json-schema-generator/pull/2277) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump glob from 11.0.2 to 11.0.3 [#2279](https://github.com/vega/ts-json-schema-generator/pull/2279) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.28.0 to 9.29.0 [#2280](https://github.com/vega/ts-json-schema-generator/pull/2280) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump brace-expansion [#2274](https://github.com/vega/ts-json-schema-generator/pull/2274) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.32.1 to 8.33.1 [#2270](https://github.com/vega/ts-json-schema-generator/pull/2270) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.29 to 22.15.30 [#2271](https://github.com/vega/ts-json-schema-generator/pull/2271) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.27.0 to 9.28.0 [#2264](https://github.com/vega/ts-json-schema-generator/pull/2264) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.27.1 to 7.27.4 [#2265](https://github.com/vega/ts-json-schema-generator/pull/2265) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.27.0 to 9.28.0 [#2266](https://github.com/vega/ts-json-schema-generator/pull/2266) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.4.0 to 5.4.1 [#2267](https://github.com/vega/ts-json-schema-generator/pull/2267) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.21 to 22.15.29 [#2268](https://github.com/vega/ts-json-schema-generator/pull/2268) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.18 to 22.15.21 [#2262](https://github.com/vega/ts-json-schema-generator/pull/2262) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.27.1 to 7.27.2 [#2263](https://github.com/vega/ts-json-schema-generator/pull/2263) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 13.1.0 to 14.0.0 [#2255](https://github.com/vega/ts-json-schema-generator/pull/2255) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.32.0 to 8.32.1 [#2254](https://github.com/vega/ts-json-schema-generator/pull/2254) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.26.0 to 9.27.0 [#2256](https://github.com/vega/ts-json-schema-generator/pull/2256) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.26.0 to 9.27.0 [#2257](https://github.com/vega/ts-json-schema-generator/pull/2257) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.3 to 22.15.18 [#2258](https://github.com/vega/ts-json-schema-generator/pull/2258) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 10.1.2 to 10.1.5 [#2249](https://github.com/vega/ts-json-schema-generator/pull/2249) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.31.0 to 8.32.0 [#2250](https://github.com/vega/ts-json-schema-generator/pull/2250) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.19.3 to 4.19.4 [#2251](https://github.com/vega/ts-json-schema-generator/pull/2251) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.25.1 to 9.26.0 [#2252](https://github.com/vega/ts-json-schema-generator/pull/2252) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.2.6 to 5.4.0 [#2253](https://github.com/vega/ts-json-schema-generator/pull/2253) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.27.0 to 7.27.1 [#2244](https://github.com/vega/ts-json-schema-generator/pull/2244) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.25.1 to 9.26.0 [#2245](https://github.com/vega/ts-json-schema-generator/pull/2245) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.26.9 to 7.27.1 [#2246](https://github.com/vega/ts-json-schema-generator/pull/2246) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.26.10 to 7.27.1 [#2247](https://github.com/vega/ts-json-schema-generator/pull/2247) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.2 to 22.15.3 [#2248](https://github.com/vega/ts-json-schema-generator/pull/2248) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.14.1 to 22.15.2 [#2239](https://github.com/vega/ts-json-schema-generator/pull/2239) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump glob from 11.0.1 to 11.0.2 [#2240](https://github.com/vega/ts-json-schema-generator/pull/2240) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.25.0 to 9.25.1 [#2242](https://github.com/vega/ts-json-schema-generator/pull/2242) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.30.1 to 8.31.0 [#2243](https://github.com/vega/ts-json-schema-generator/pull/2243) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.29.1 to 8.30.1 [#2235](https://github.com/vega/ts-json-schema-generator/pull/2235) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.24.0 to 9.25.0 [#2236](https://github.com/vega/ts-json-schema-generator/pull/2236) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.24.0 to 9.25.0 [#2237](https://github.com/vega/ts-json-schema-generator/pull/2237) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.14.0 to 22.14.1 [#2225](https://github.com/vega/ts-json-schema-generator/pull/2225) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.29.0 to 8.29.1 [#2226](https://github.com/vega/ts-json-schema-generator/pull/2226) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 10.1.1 to 10.1.2 [#2227](https://github.com/vega/ts-json-schema-generator/pull/2227) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.23.0 to 9.24.0 [#2228](https://github.com/vega/ts-json-schema-generator/pull/2228) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 8
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Alex ([@alexchexes](https://github.com/alexchexes))
  - Arthur Fiorette ([@arthurfiorette](https://github.com/arthurfiorette))
  - Cal ([@CalLavicka](https://github.com/CalLavicka))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
  - James Vaughan ([@jamesbvaughan](https://github.com/jamesbvaughan))
  - Orta Therox ([@orta](https://github.com/orta))
  - Valentyne Stigloher ([@pixunil](https://github.com/pixunil))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
