### PR TITLE
feat: simplify parsing variadic arg (and support -t X Y and -t X -t Y patterns)

### DIFF
--- a/ts-json-schema-generator.ts
+++ b/ts-json-schema-generator.ts
@@ -11,23 +11,14 @@ import pkg from "./package.json";
 
 const args = new Command()
     .option("-p, --path <path>", "Source file path")
-    .option(
-        "-t, --type <name>",
-        "Type name (can be passed multiple times)",
-        (value: string, previous: string[] | undefined) => {
-            if (previous) {
-                return previous.concat(value);
-            }
-            return [value];
-        },
-    )
+    .option("-t, --type <name...>", "Type name(s)")
     .option("-i, --id <name>", "$id for generated schema")
     .option("-f, --tsconfig <path>", "Custom tsconfig.json path")
     .addOption(
         new Option("-e, --expose <expose>", "Type exposing").choices(["all", "none", "export"]).default("export"),
     )
     .addOption(
-        new Option("-j, --jsDoc <extended>", "Read JsDoc annotations")
+        new Option("-j, --jsDoc <extended>", "Read JSDoc annotations")
             .choices(["none", "basic", "extended"])
             .default("extended"),
     )


### PR DESCRIPTION
Follow up for https://github.com/vega/ts-json-schema-generator/pull/2410
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.5.0-next.9`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: Sam Sudar ([@srsudar](https://github.com/srsudar))
  
  :heart: Orta Therox ([@orta](https://github.com/orta))
  
  :heart: James Vaughan ([@jamesbvaughan](https://github.com/jamesbvaughan))
  
  :heart: Alex ([@alexchexes](https://github.com/alexchexes))
  
  :heart: Cal ([@CalLavicka](https://github.com/CalLavicka))
  
  :heart: Valentyne Stigloher ([@pixunil](https://github.com/pixunil))
  
  #### 🚀 Enhancement
  
  - feat: simplify parsing variadic arg (and support -t X Y and -t X -t Y patterns) [#2416](https://github.com/vega/ts-json-schema-generator/pull/2416) ([@domoritz](https://github.com/domoritz))
  - feat: add `NewExpression` parser [#2346](https://github.com/vega/ts-json-schema-generator/pull/2346) ([@jamesbvaughan](https://github.com/jamesbvaughan))
  - feat: Add --full-description option to include full comment in schema [#2224](https://github.com/vega/ts-json-schema-generator/pull/2224) ([@alexchexes](https://github.com/alexchexes))
  - feat(parser): support SpreadElement in array literals [#2269](https://github.com/vega/ts-json-schema-generator/pull/2269) ([@alexchexes](https://github.com/alexchexes))
  
  #### 🐛 Bug Fix
  
  - add support for a types array [#2410](https://github.com/vega/ts-json-schema-generator/pull/2410) ([@srsudar](https://github.com/srsudar) [@domoritz](https://github.com/domoritz))
  - Allow node VFS based programmatic usage [#2392](https://github.com/vega/ts-json-schema-generator/pull/2392) ([@orta](https://github.com/orta))
  - chore: update deps [#2306](https://github.com/vega/ts-json-schema-generator/pull/2306) ([@domoritz](https://github.com/domoritz))
  - Fix: crashes and incomplete schema generation when mapped/intersection helpers are used with `--additional-properties` option [#2305](https://github.com/vega/ts-json-schema-generator/pull/2305) ([@alexchexes](https://github.com/alexchexes))
  - Fix promise with generic type arguments [#2291](https://github.com/vega/ts-json-schema-generator/pull/2291) ([@CalLavicka](https://github.com/CalLavicka))
  - Fix: prune unreachable definitions when `--type "*"` is used with multiple exports [#2284](https://github.com/vega/ts-json-schema-generator/pull/2284) ([@alexchexes](https://github.com/alexchexes) [@arthurfiorette](https://github.com/arthurfiorette))
  - Fix: crash when a union includes `symbol` [#2282](https://github.com/vega/ts-json-schema-generator/pull/2282) ([@alexchexes](https://github.com/alexchexes))
  - fix: correctly generate anyOf on unions with string and boolean constant [#2208](https://github.com/vega/ts-json-schema-generator/pull/2208) ([@pixunil](https://github.com/pixunil))
  - fix: fully unwrap union aliases in mapped keys to avoid generating incorrect additionalProperties [#2232](https://github.com/vega/ts-json-schema-generator/pull/2232) ([@alexchexes](https://github.com/alexchexes))
  - fix: avoid incorrect additionalProperties for Pick<..., AliasLiteralUnion> [#2230](https://github.com/vega/ts-json-schema-generator/pull/2230) ([@alexchexes](https://github.com/alexchexes))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump prettier from 3.6.2 to 3.7.3 [#2414](https://github.com/vega/ts-json-schema-generator/pull/2414) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump glob from 11.1.0 to 13.0.0 [#2407](https://github.com/vega/ts-json-schema-generator/pull/2407) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/first-time-contributor from 11.3.0 to 11.3.6 [#2408](https://github.com/vega/ts-json-schema-generator/pull/2408) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.46.4 to 8.47.0 [#2409](https://github.com/vega/ts-json-schema-generator/pull/2409) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/checkout from 5 to 6 [#2406](https://github.com/vega/ts-json-schema-generator/pull/2406) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump js-yaml from 3.14.1 to 3.14.2 [#2405](https://github.com/vega/ts-json-schema-generator/pull/2405) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump glob [#2404](https://github.com/vega/ts-json-schema-generator/pull/2404) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.10.0 to 24.10.1 [#2398](https://github.com/vega/ts-json-schema-generator/pull/2398) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @auto-it/conventional-commits from 11.3.0 to 11.3.6 [#2399](https://github.com/vega/ts-json-schema-generator/pull/2399) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump auto from 11.3.0 to 11.3.6 [#2400](https://github.com/vega/ts-json-schema-generator/pull/2400) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.46.3 to 8.46.4 [#2401](https://github.com/vega/ts-json-schema-generator/pull/2401) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump chai from 6.2.0 to 6.2.1 [#2402](https://github.com/vega/ts-json-schema-generator/pull/2402) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.39.0 to 9.39.1 [#2394](https://github.com/vega/ts-json-schema-generator/pull/2394) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.39.0 to 9.39.1 [#2395](https://github.com/vega/ts-json-schema-generator/pull/2395) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.9.2 to 24.10.0 [#2396](https://github.com/vega/ts-json-schema-generator/pull/2396) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.46.2 to 8.46.3 [#2393](https://github.com/vega/ts-json-schema-generator/pull/2393) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.38.0 to 9.39.0 [#2387](https://github.com/vega/ts-json-schema-generator/pull/2387) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.28.3 to 7.28.5 [#2388](https://github.com/vega/ts-json-schema-generator/pull/2388) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.9.1 to 24.9.2 [#2389](https://github.com/vega/ts-json-schema-generator/pull/2389) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump globals from 16.4.0 to 16.5.0 [#2390](https://github.com/vega/ts-json-schema-generator/pull/2390) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.38.0 to 9.39.0 [#2391](https://github.com/vega/ts-json-schema-generator/pull/2391) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.27.1 to 7.28.5 [#2382](https://github.com/vega/ts-json-schema-generator/pull/2382) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 14.0.1 to 14.0.2 [#2383](https://github.com/vega/ts-json-schema-generator/pull/2383) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.8.1 to 24.9.1 [#2384](https://github.com/vega/ts-json-schema-generator/pull/2384) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.46.1 to 8.46.2 [#2385](https://github.com/vega/ts-json-schema-generator/pull/2385) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.28.4 to 7.28.5 [#2386](https://github.com/vega/ts-json-schema-generator/pull/2386) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.7.2 to 24.8.1 [#2378](https://github.com/vega/ts-json-schema-generator/pull/2378) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.37.0 to 9.38.0 [#2379](https://github.com/vega/ts-json-schema-generator/pull/2379) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.46.0 to 8.46.1 [#2381](https://github.com/vega/ts-json-schema-generator/pull/2381) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/setup-node from 5 to 6 [#2377](https://github.com/vega/ts-json-schema-generator/pull/2377) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.45.0 to 8.46.0 [#2373](https://github.com/vega/ts-json-schema-generator/pull/2373) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 5.9.2 to 5.9.3 [#2374](https://github.com/vega/ts-json-schema-generator/pull/2374) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.6.2 to 24.7.2 [#2375](https://github.com/vega/ts-json-schema-generator/pull/2375) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.36.0 to 9.37.0 [#2376](https://github.com/vega/ts-json-schema-generator/pull/2376) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.44.1 to 8.45.0 [#2368](https://github.com/vega/ts-json-schema-generator/pull/2368) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 30.1.3 to 30.2.0 [#2369](https://github.com/vega/ts-json-schema-generator/pull/2369) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.36.0 to 9.37.0 [#2370](https://github.com/vega/ts-json-schema-generator/pull/2370) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump cross-env from 10.0.0 to 10.1.0 [#2371](https://github.com/vega/ts-json-schema-generator/pull/2371) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.5.2 to 24.6.2 [#2372](https://github.com/vega/ts-json-schema-generator/pull/2372) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.44.0 to 8.44.1 [#2363](https://github.com/vega/ts-json-schema-generator/pull/2363) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.3.3 to 24.5.2 [#2364](https://github.com/vega/ts-json-schema-generator/pull/2364) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega-lite from 6.4.0 to 6.4.1 [#2365](https://github.com/vega/ts-json-schema-generator/pull/2365) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump chai from 6.0.1 to 6.2.0 [#2366](https://github.com/vega/ts-json-schema-generator/pull/2366) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.20.5 to 4.20.6 [#2367](https://github.com/vega/ts-json-schema-generator/pull/2367) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega-lite from 6.3.1 to 6.4.0 [#2358](https://github.com/vega/ts-json-schema-generator/pull/2358) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.35.0 to 9.36.0 [#2359](https://github.com/vega/ts-json-schema-generator/pull/2359) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega from 6.1.2 to 6.2.0 [#2360](https://github.com/vega/ts-json-schema-generator/pull/2360) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.43.0 to 8.44.0 [#2361](https://github.com/vega/ts-json-schema-generator/pull/2361) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.35.0 to 9.36.0 [#2362](https://github.com/vega/ts-json-schema-generator/pull/2362) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.3.0 to 24.3.3 [#2353](https://github.com/vega/ts-json-schema-generator/pull/2353) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump globals from 16.3.0 to 16.4.0 [#2354](https://github.com/vega/ts-json-schema-generator/pull/2354) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega-lite from 6.3.0 to 6.3.1 [#2355](https://github.com/vega/ts-json-schema-generator/pull/2355) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.41.0 to 8.43.0 [#2356](https://github.com/vega/ts-json-schema-generator/pull/2356) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 14.0.0 to 14.0.1 [#2357](https://github.com/vega/ts-json-schema-generator/pull/2357) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.28.3 to 7.28.4 [#2347](https://github.com/vega/ts-json-schema-generator/pull/2347) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega-lite from 6.2.0 to 6.3.0 [#2348](https://github.com/vega/ts-json-schema-generator/pull/2348) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.34.0 to 9.35.0 [#2349](https://github.com/vega/ts-json-schema-generator/pull/2349) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 30.1.1 to 30.1.3 [#2350](https://github.com/vega/ts-json-schema-generator/pull/2350) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.34.0 to 9.35.0 [#2351](https://github.com/vega/ts-json-schema-generator/pull/2351) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/setup-node from 4 to 5 [#2345](https://github.com/vega/ts-json-schema-generator/pull/2345) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 30.0.5 to 30.1.1 [#2343](https://github.com/vega/ts-json-schema-generator/pull/2343) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.40.0 to 8.41.0 [#2344](https://github.com/vega/ts-json-schema-generator/pull/2344) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump chai from 5.2.1 to 6.0.1 [#2341](https://github.com/vega/ts-json-schema-generator/pull/2341) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.33.0 to 9.34.0 [#2337](https://github.com/vega/ts-json-schema-generator/pull/2337) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.33.0 to 9.34.0 [#2338](https://github.com/vega/ts-json-schema-generator/pull/2338) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.20.4 to 4.20.5 [#2339](https://github.com/vega/ts-json-schema-generator/pull/2339) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.39.1 to 8.40.0 [#2340](https://github.com/vega/ts-json-schema-generator/pull/2340) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.28.0 to 7.28.3 [#2331](https://github.com/vega/ts-json-schema-generator/pull/2331) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.2.1 to 24.3.0 [#2332](https://github.com/vega/ts-json-schema-generator/pull/2332) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.39.0 to 8.39.1 [#2333](https://github.com/vega/ts-json-schema-generator/pull/2333) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.28.0 to 7.28.3 [#2334](https://github.com/vega/ts-json-schema-generator/pull/2334) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.20.3 to 4.20.4 [#2335](https://github.com/vega/ts-json-schema-generator/pull/2335) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/checkout from 4 to 5 [#2330](https://github.com/vega/ts-json-schema-generator/pull/2330) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump typescript from 5.8.3 to 5.9.2 [#2325](https://github.com/vega/ts-json-schema-generator/pull/2325) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.38.0 to 8.39.0 [#2329](https://github.com/vega/ts-json-schema-generator/pull/2329) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.32.0 to 9.33.0 [#2326](https://github.com/vega/ts-json-schema-generator/pull/2326) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.5.3 to 5.5.4 [#2327](https://github.com/vega/ts-json-schema-generator/pull/2327) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.1.0 to 24.2.1 [#2328](https://github.com/vega/ts-json-schema-generator/pull/2328) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump cross-env from 7.0.3 to 10.0.0 [#2324](https://github.com/vega/ts-json-schema-generator/pull/2324) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.0.15 to 24.1.0 [#2318](https://github.com/vega/ts-json-schema-generator/pull/2318) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.37.0 to 8.38.0 [#2320](https://github.com/vega/ts-json-schema-generator/pull/2320) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 30.0.4 to 30.0.5 [#2321](https://github.com/vega/ts-json-schema-generator/pull/2321) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.31.0 to 9.32.0 [#2322](https://github.com/vega/ts-json-schema-generator/pull/2322) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.0.13 to 24.0.15 [#2313](https://github.com/vega/ts-json-schema-generator/pull/2313) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 10.1.5 to 10.1.8 [#2314](https://github.com/vega/ts-json-schema-generator/pull/2314) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.36.0 to 8.37.0 [#2315](https://github.com/vega/ts-json-schema-generator/pull/2315) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.5.1 to 5.5.3 [#2316](https://github.com/vega/ts-json-schema-generator/pull/2316) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump chai from 5.2.0 to 5.2.1 [#2308](https://github.com/vega/ts-json-schema-generator/pull/2308) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.0.10 to 24.0.13 [#2309](https://github.com/vega/ts-json-schema-generator/pull/2309) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.35.1 to 8.36.0 [#2310](https://github.com/vega/ts-json-schema-generator/pull/2310) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.30.1 to 9.31.0 [#2311](https://github.com/vega/ts-json-schema-generator/pull/2311) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.0.7 to 24.0.10 [#2301](https://github.com/vega/ts-json-schema-generator/pull/2301) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.27.4 to 7.28.0 [#2302](https://github.com/vega/ts-json-schema-generator/pull/2302) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.5.0 to 5.5.1 [#2304](https://github.com/vega/ts-json-schema-generator/pull/2304) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.30.0 to 9.30.1 [#2300](https://github.com/vega/ts-json-schema-generator/pull/2300) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.30 to 24.0.7 [#2296](https://github.com/vega/ts-json-schema-generator/pull/2296) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump vega-lite from 6.1.0 to 6.2.0 [#2295](https://github.com/vega/ts-json-schema-generator/pull/2295) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump prettier from 3.5.3 to 3.6.2 [#2297](https://github.com/vega/ts-json-schema-generator/pull/2297) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest from 30.0.2 to 30.0.3 [#2298](https://github.com/vega/ts-json-schema-generator/pull/2298) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.29.0 to 9.30.0 [#2299](https://github.com/vega/ts-json-schema-generator/pull/2299) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump jest and @types/jest [#2287](https://github.com/vega/ts-json-schema-generator/pull/2287) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.33.1 to 8.34.1 [#2289](https://github.com/vega/ts-json-schema-generator/pull/2289) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.4.1 to 5.5.0 [#2290](https://github.com/vega/ts-json-schema-generator/pull/2290) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.19.4 to 4.20.3 [#2276](https://github.com/vega/ts-json-schema-generator/pull/2276) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.28.0 to 9.29.0 [#2277](https://github.com/vega/ts-json-schema-generator/pull/2277) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump glob from 11.0.2 to 11.0.3 [#2279](https://github.com/vega/ts-json-schema-generator/pull/2279) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.28.0 to 9.29.0 [#2280](https://github.com/vega/ts-json-schema-generator/pull/2280) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump brace-expansion [#2274](https://github.com/vega/ts-json-schema-generator/pull/2274) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.32.1 to 8.33.1 [#2270](https://github.com/vega/ts-json-schema-generator/pull/2270) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.29 to 22.15.30 [#2271](https://github.com/vega/ts-json-schema-generator/pull/2271) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.27.0 to 9.28.0 [#2264](https://github.com/vega/ts-json-schema-generator/pull/2264) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.27.1 to 7.27.4 [#2265](https://github.com/vega/ts-json-schema-generator/pull/2265) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.27.0 to 9.28.0 [#2266](https://github.com/vega/ts-json-schema-generator/pull/2266) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.4.0 to 5.4.1 [#2267](https://github.com/vega/ts-json-schema-generator/pull/2267) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.21 to 22.15.29 [#2268](https://github.com/vega/ts-json-schema-generator/pull/2268) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.18 to 22.15.21 [#2262](https://github.com/vega/ts-json-schema-generator/pull/2262) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.27.1 to 7.27.2 [#2263](https://github.com/vega/ts-json-schema-generator/pull/2263) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump commander from 13.1.0 to 14.0.0 [#2255](https://github.com/vega/ts-json-schema-generator/pull/2255) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.32.0 to 8.32.1 [#2254](https://github.com/vega/ts-json-schema-generator/pull/2254) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.26.0 to 9.27.0 [#2256](https://github.com/vega/ts-json-schema-generator/pull/2256) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.26.0 to 9.27.0 [#2257](https://github.com/vega/ts-json-schema-generator/pull/2257) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.3 to 22.15.18 [#2258](https://github.com/vega/ts-json-schema-generator/pull/2258) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 10.1.2 to 10.1.5 [#2249](https://github.com/vega/ts-json-schema-generator/pull/2249) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.31.0 to 8.32.0 [#2250](https://github.com/vega/ts-json-schema-generator/pull/2250) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump tsx from 4.19.3 to 4.19.4 [#2251](https://github.com/vega/ts-json-schema-generator/pull/2251) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.25.1 to 9.26.0 [#2252](https://github.com/vega/ts-json-schema-generator/pull/2252) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.2.6 to 5.4.0 [#2253](https://github.com/vega/ts-json-schema-generator/pull/2253) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-typescript from 7.27.0 to 7.27.1 [#2244](https://github.com/vega/ts-json-schema-generator/pull/2244) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.25.1 to 9.26.0 [#2245](https://github.com/vega/ts-json-schema-generator/pull/2245) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/preset-env from 7.26.9 to 7.27.1 [#2246](https://github.com/vega/ts-json-schema-generator/pull/2246) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @babel/core from 7.26.10 to 7.27.1 [#2247](https://github.com/vega/ts-json-schema-generator/pull/2247) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.15.2 to 22.15.3 [#2248](https://github.com/vega/ts-json-schema-generator/pull/2248) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.14.1 to 22.15.2 [#2239](https://github.com/vega/ts-json-schema-generator/pull/2239) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump glob from 11.0.1 to 11.0.2 [#2240](https://github.com/vega/ts-json-schema-generator/pull/2240) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.25.0 to 9.25.1 [#2242](https://github.com/vega/ts-json-schema-generator/pull/2242) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.30.1 to 8.31.0 [#2243](https://github.com/vega/ts-json-schema-generator/pull/2243) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.29.1 to 8.30.1 [#2235](https://github.com/vega/ts-json-schema-generator/pull/2235) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @eslint/js from 9.24.0 to 9.25.0 [#2236](https://github.com/vega/ts-json-schema-generator/pull/2236) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.24.0 to 9.25.0 [#2237](https://github.com/vega/ts-json-schema-generator/pull/2237) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 22.14.0 to 22.14.1 [#2225](https://github.com/vega/ts-json-schema-generator/pull/2225) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.29.0 to 8.29.1 [#2226](https://github.com/vega/ts-json-schema-generator/pull/2226) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-config-prettier from 10.1.1 to 10.1.2 [#2227](https://github.com/vega/ts-json-schema-generator/pull/2227) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.23.0 to 9.24.0 [#2228](https://github.com/vega/ts-json-schema-generator/pull/2228) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 9
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Alex ([@alexchexes](https://github.com/alexchexes))
  - Arthur Fiorette ([@arthurfiorette](https://github.com/arthurfiorette))
  - Cal ([@CalLavicka](https://github.com/CalLavicka))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
  - James Vaughan ([@jamesbvaughan](https://github.com/jamesbvaughan))
  - Orta Therox ([@orta](https://github.com/orta))
  - Sam Sudar ([@srsudar](https://github.com/srsudar))
  - Valentyne Stigloher ([@pixunil](https://github.com/pixunil))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
