### PR TITLE
fix: remove `removeComments` from `tsconfig.json`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,6 @@
     "suppressImplicitAnyIndexErrors": false,
     "strictNullChecks": true,
     "preserveConstEnums": true,
-    "removeComments": true,
     "resolveJsonModule": true,
     "noLib": false,
     "sourceMap": true,


### PR DESCRIPTION
# **This PR**:

- [X] Helpful JSDoc comments added in #2392 were not being emitted in the generated declaration files due to the [**`removeComments`**](https://www.typescriptlang.org/tsconfig/#removeComments) option. This PR removes that option from **`tsconfig.json`** so the JSDocs are included in the output.