### PR TITLE
fix: Include types referenced only in `additionalItems` in schema definitions

### DIFF
--- a/src/Utils/removeUnreachable.ts
+++ b/src/Utils/removeUnreachable.ts
@@ -61,6 +61,11 @@ function addReachable(
         } else if (items) {
             addReachable(items, definitions, reachable);
         }
+
+        const additionalItems = definition.additionalItems;
+        if (additionalItems) {
+            addReachable(additionalItems, definitions, reachable);
+        }
     } else if (definition.then) {
         addReachable(definition.then, definitions, reachable);
     }

--- a/test/valid-data/type-aliases-tuple-rest-additional-only/index.test.ts
+++ b/test/valid-data/type-aliases-tuple-rest-additional-only/index.test.ts
@@ -1,0 +1,7 @@
+import { assertValidSchema } from "../../utils";
+import { test } from "node:test";
+
+test(
+    "valid-data - type-aliases-tuple-rest-additional-only",
+    assertValidSchema("type-aliases-tuple-rest-additional-only", "MyTuple"),
+);

--- a/test/valid-data/type-aliases-tuple-rest-additional-only/main.ts
+++ b/test/valid-data/type-aliases-tuple-rest-additional-only/main.ts
@@ -1,0 +1,11 @@
+export class FirstItem {
+    id: string;
+    required: true;
+}
+
+export class AdditionalItem {
+    value: number;
+    optional?: boolean;
+}
+
+export type MyTuple = [FirstItem, ...AdditionalItem[]];

--- a/test/valid-data/type-aliases-tuple-rest-additional-only/schema.json
+++ b/test/valid-data/type-aliases-tuple-rest-additional-only/schema.json
@@ -1,0 +1,50 @@
+{
+    "$ref": "#/definitions/MyTuple",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "MyTuple": {
+            "type": "array",
+            "minItems": 1,
+            "items": [
+                {
+                    "$ref": "#/definitions/FirstItem"
+                }
+            ],
+            "additionalItems": {
+                "$ref": "#/definitions/AdditionalItem"
+            }
+        },
+        "FirstItem": {
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "const": true
+                }
+            },
+            "required": [
+                "id",
+                "required"
+            ],
+            "type": "object"
+        },
+        "AdditionalItem": {
+            "additionalProperties": false,
+            "properties": {
+                "value": {
+                    "type": "number"
+                },
+                "optional": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "value"
+            ],
+            "type": "object"
+        }
+    }
+}


### PR DESCRIPTION
## Problem

When generating JSON schemas from TypeScript tuple types with rest elements, types referenced only in `additionalItems` were incorrectly filtered out as "unreachable", causing missing definitions in the generated schema.

For example, with a tuple type like:
```typescript
export type MyTuple = [FirstItem, ...AdditionalItem[]];
```

The generated schema would include `FirstItem` in the definitions (because it's in `items`), but `AdditionalItem` would be missing (because it's only referenced in `additionalItems`), causing schema validation errors.

## Root Cause

The `removeUnreachable` function in `src/Utils/removeUnreachable.ts` was checking `items` for array types but not `additionalItems`.

## Solution

Added a check for `additionalItems` in the `addReachable` function, similar to how `additionalProperties` is handled for object types. This ensures that types referenced only in `additionalItems` are marked as reachable and included in the final schema definitions.

## Changes

- **`src/Utils/removeUnreachable.ts`**: Added `additionalItems` check in the array handling section (lines 65-68)
- **`test/valid-data/type-aliases-tuple-rest-additional-only/`**: Added test case to verify the fix


