### PR TITLE
fix: correctly handled mapped union types

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "debug": "tsx --inspect-brk ts-json-schema-generator.ts",
     "format": "eslint --fix",
     "lint": "eslint",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "release": "npm run build && auto shipit",
     "run": "tsx ts-json-schema-generator.ts",

--- a/src/NodeParser/MappedTypeNodeParser.ts
+++ b/src/NodeParser/MappedTypeNodeParser.ts
@@ -34,23 +34,22 @@ export class MappedTypeNodeParser implements SubNodeParser {
     }
 
     public createType(node: ts.MappedTypeNode, context: Context): BaseType {
-        const constraintType = this.childNodeParser.createType(node.typeParameter.constraint!, context);
-        const keyListType = derefType(constraintType);
-        const id = `indexed-type-${getKey(node, context)}`;
-
-        if (keyListType instanceof UnionType) {
-            // Key type resolves to a set of known properties
-            return new ObjectType(
-                id,
-                [],
-                this.getProperties(node, keyListType, context),
-                this.getAdditionalProperties(node, keyListType, context),
-            );
+        // Check if the constraint is `keyof T` where T resolves to a union type.
+        // In TypeScript, mapped types distribute over unions, so `{ [P in keyof (A | B)]: ... }`
+        // is equivalent to `{ [P in keyof A]: ... } | { [P in keyof B]: ... }`.
+        const distributedType = this.tryDistributeUnion(node, context);
+        if (distributedType) {
+            return distributedType;
         }
 
-        if (keyListType instanceof LiteralType) {
-            // Key type resolves to single known property
-            return new ObjectType(id, [], this.getProperties(node, new UnionType([keyListType]), context), false);
+        const constraintType = this.childNodeParser.createType(node.typeParameter.constraint!, context);
+        const keyListType = derefType(constraintType);
+
+        const id = `indexed-type-${getKey(node, context)}`;
+
+        const objectType = this.createObjectFromKeyList(node, keyListType, id, context);
+        if (objectType) {
+            return objectType;
         }
 
         const maybeUnionType = this.childNodeParser.createType(
@@ -121,6 +120,31 @@ export class MappedTypeNodeParser implements SubNodeParser {
             return true; // -? removes optional → output property is always required
         }
         return false;
+    }
+
+    // Attempts to create an ObjectType from a resolved key list type.
+    // Handles UnionType (set of known property keys) and LiteralType (single known property key).
+    // Returns undefined if the key list type is not one of these.
+    protected createObjectFromKeyList(
+        node: ts.MappedTypeNode,
+        keyListType: BaseType,
+        id: string,
+        context: Context,
+    ): ObjectType | undefined {
+        if (keyListType instanceof UnionType) {
+            return new ObjectType(
+                id,
+                [],
+                this.getProperties(node, keyListType, context),
+                this.getAdditionalProperties(node, keyListType, context),
+            );
+        }
+
+        if (keyListType instanceof LiteralType) {
+            return new ObjectType(id, [], this.getProperties(node, new UnionType([keyListType]), context), false);
+        }
+
+        return undefined;
     }
 
     protected mapKey(node: ts.MappedTypeNode, rawKey: LiteralType, context: Context): BaseType {
@@ -211,5 +235,76 @@ export class MappedTypeNodeParser implements SubNodeParser {
         subContext.pushArgument(key);
 
         return subContext;
+    }
+
+    // Checks if the mapped type's constraint is `keyof T` where `T` is a type parameter
+    // that resolves to a union type in the current context.
+    // If so, distributes the mapped type over each union member (like TypeScript does),
+    // returning a UnionType of the individually mapped types.
+    //
+    // TypeScript distributes mapped types over union type parameters:
+    // `{ [P in keyof T]: X }` where `T = A | B` becomes `{ [P in keyof A]: X } | { [P in keyof B]: X }`
+    protected tryDistributeUnion(node: ts.MappedTypeNode, context: Context): BaseType | undefined {
+        const { constraint } = node.typeParameter;
+        if (!constraint) {
+            return undefined;
+        }
+
+        // Check if constraint is `keyof X`
+        if (!ts.isTypeOperatorNode(constraint) || constraint.operator !== ts.SyntaxKind.KeyOfKeyword) {
+            return undefined;
+        }
+
+        // Resolve the operand type (X in `keyof X`)
+        const operandType = this.childNodeParser.createType(constraint.type, context);
+        const derefedOperand = derefType(operandType);
+
+        if (!(derefedOperand instanceof UnionType)) {
+            return undefined;
+        }
+
+        const unionMembers = derefedOperand.getTypes();
+
+        // Only distribute if the union contains object-like types (not a union of literals/primitives)
+        const hasObjectTypes = unionMembers.some((member) => {
+            const derefed = derefType(member);
+            return derefed instanceof ObjectType;
+        });
+
+        if (!hasObjectTypes) {
+            return undefined;
+        }
+
+        // Distribute the mapping for each union type individually
+        const mappedTypes = unionMembers.map((member) => {
+            // Create a new context where the operand type parameter is bound to this union member
+            const subContext = new Context(node);
+
+            for (const parentParameter of context.getParameters()) {
+                const arg = context.getArgument(parentParameter);
+                // If this argument is the union we're distributing over, replace it with the member
+                if (arg === operandType || derefType(arg) === derefedOperand) {
+                    subContext.pushParameter(parentParameter);
+                    subContext.pushArgument(member);
+                } else {
+                    subContext.pushParameter(parentParameter);
+                    subContext.pushArgument(arg);
+                }
+            }
+
+            // Now resolve the constraint (keyof member) and create the mapped type for this member
+            const memberConstraintType = this.childNodeParser.createType(constraint, subContext);
+            const memberKeyListType = derefType(memberConstraintType);
+            const memberId = `indexed-type-${getKey(node, subContext)}`;
+
+            return this.createObjectFromKeyList(node, memberKeyListType, memberId, subContext)
+                ?? this.createType(node, subContext);
+        });
+
+        const result = new UnionType(mappedTypes).normalize();
+
+        // Preserve annotations (e.g., @discriminator) from the original operand type
+        // onto the resulting union, since the distribution creates a brand new UnionType.
+        return preserveAnnotation(operandType, result);
     }
 }

--- a/src/TypeFormatter/AnnotatedTypeFormatter.ts
+++ b/src/TypeFormatter/AnnotatedTypeFormatter.ts
@@ -54,12 +54,16 @@ export class AnnotatedTypeFormatter implements SubTypeFormatter {
     }
     public getDefinition(type: AnnotatedType): Definition {
         const annotations = type.getAnnotations();
+        // Copy annotations to avoid mutating the original object, which may be shared
+        // with other AnnotatedType instances (e.g., via preserveAnnotation).
+        let restAnnotations = annotations;
 
         if ("discriminator" in annotations) {
             const deref = derefType(type.getType());
             if (deref instanceof UnionType) {
                 deref.setDiscriminator(annotations.discriminator as string);
-                delete annotations.discriminator;
+                const { discriminator: _, ...rest } = annotations;
+                restAnnotations = rest;
             } else {
                 throw new JsonTypeError(
                     `Cannot assign discriminator tag to type: ${deref.getName()}. This tag can only be assigned to union types.`,
@@ -70,7 +74,7 @@ export class AnnotatedTypeFormatter implements SubTypeFormatter {
 
         const def: Definition = {
             ...this.childTypeFormatter.getDefinition(type.getType()),
-            ...type.getAnnotations(),
+            ...restAnnotations,
         };
 
         if ("$ref" in def && "type" in def) {

--- a/src/Utils/isAssignableTo.ts
+++ b/src/Utils/isAssignableTo.ts
@@ -95,6 +95,9 @@ export function isAssignableTo(
     inferMap: Map<string, BaseType> = new Map(),
     insideTypes: Set<BaseType> = new Set(),
 ): boolean {
+    // Keep original source for infer map so annotations (e.g. @discriminator) are preserved
+    const originalSource = source;
+
     // Dereference source and target
     source = derefType(source);
     target = derefType(target);
@@ -115,9 +118,9 @@ export function isAssignableTo(
         const infer = inferMap.get(key);
 
         if (infer === undefined) {
-            inferMap.set(key, source);
+            inferMap.set(key, originalSource);
         } else {
-            inferMap.set(key, new UnionType([infer, source]));
+            inferMap.set(key, new UnionType([infer, originalSource]));
         }
 
         return true;

--- a/src/Utils/narrowType.ts
+++ b/src/Utils/narrowType.ts
@@ -3,6 +3,7 @@ import { EnumType } from "../Type/EnumType.js";
 import { NeverType } from "../Type/NeverType.js";
 import { UnionType } from "../Type/UnionType.js";
 import { derefType } from "./derefType.js";
+import { preserveAnnotation } from "./preserveAnnotation.js";
 
 /**
  * Narrows the given type by passing all variants to the given predicate function. So when type is a union type then
@@ -46,7 +47,7 @@ export function narrowType(type: BaseType, predicate: (type: BaseType) => boolea
             } else if (types.length === 1) {
                 return types[0];
             } else {
-                return new UnionType(types);
+                return preserveAnnotation(type, new UnionType(types));
             }
         }
         return type;

--- a/src/Utils/preserveAnnotation.ts
+++ b/src/Utils/preserveAnnotation.ts
@@ -1,15 +1,24 @@
 import type { BaseType } from "../Type/BaseType.js";
 import { AnnotatedType } from "../Type/AnnotatedType.js";
+import { AliasType } from "../Type/AliasType.js";
+import { DefinitionType } from "../Type/DefinitionType.js";
+import { ReferenceType } from "../Type/ReferenceType.js";
 
 /**
  * Return the new type wrapped in an annotated type with the same annotations as the original type.
- * @param originalType The original type. If this is an annotated type,
- *      then the returned type will be wrapped with the same annotations.
+ * @param originalType The original type. If this is an annotated type (possibly wrapped in AliasType,
+ *      DefinitionType, or ReferenceType), then the returned type will be wrapped with the same annotations.
  * @param newType The type to be wrapped.
  */
 export function preserveAnnotation(originalType: BaseType, newType: BaseType): BaseType {
     if (originalType instanceof AnnotatedType) {
         return new AnnotatedType(newType, originalType.getAnnotations(), originalType.isNullable());
+    }
+    if (originalType instanceof AliasType || originalType instanceof DefinitionType) {
+        return preserveAnnotation(originalType.getType(), newType);
+    }
+    if (originalType instanceof ReferenceType && originalType.hasType()) {
+        return preserveAnnotation(originalType.getType(), newType);
     }
     return newType;
 }

--- a/test/valid-data/type-mapped-union-discriminator-shared-annotation/index.test.ts
+++ b/test/valid-data/type-mapped-union-discriminator-shared-annotation/index.test.ts
@@ -1,0 +1,7 @@
+import { assertValidSchema } from "../../utils";
+import { test } from "node:test";
+
+test(
+    "valid-data - type-mapped-union-discriminator-shared-annotation",
+    assertValidSchema("type-mapped-union-discriminator-shared-annotation", "*", { jsDoc: "basic", discriminatorType: "open-api" }),
+);

--- a/test/valid-data/type-mapped-union-discriminator-shared-annotation/main.ts
+++ b/test/valid-data/type-mapped-union-discriminator-shared-annotation/main.ts
@@ -1,0 +1,34 @@
+/**
+ * Regression test: when a @discriminator-annotated union goes through a
+ * mapped type and is referenced from TWO different exported types, the
+ * annotations object produced by preserveAnnotation is shared between
+ * the resulting AnnotatedType instances.
+ *
+ * Before the fix, `delete annotations.discriminator` in
+ * AnnotatedTypeFormatter mutated the shared object, so whichever type
+ * was processed first would steal the discriminator from the second.
+ */
+
+type Fish = {
+    animal_type: "fish";
+    found_in: "ocean" | "river";
+};
+
+type Bird = {
+    animal_type: "bird";
+    can_fly: boolean;
+};
+
+/** @discriminator animal_type */
+type Animal = Fish | Bird;
+
+// A simple recursive mapped type that preserves structure but forces
+// the union through tryDistributeUnion → preserveAnnotation.
+type DeepMapped<T extends object> = {
+    [P in keyof T]: T[P] extends object ? DeepMapped<T[P]> : T[P];
+};
+
+// Two distinct exported types that both embed the same discriminated union
+// through the same mapped type. They will share the annotations object.
+export type First = DeepMapped<{ pet: Animal; label: string }>;
+export type Second = DeepMapped<{ pet: Animal; tag: number }>;

--- a/test/valid-data/type-mapped-union-discriminator-shared-annotation/schema.json
+++ b/test/valid-data/type-mapped-union-discriminator-shared-annotation/schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "First": {
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "type": "string"
+        },
+        "pet": {
+          "discriminator": {
+            "propertyName": "animal_type"
+          },
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "animal_type": {
+                  "const": "fish",
+                  "type": "string"
+                },
+                "found_in": {
+                  "enum": [
+                    "ocean",
+                    "river"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "animal_type",
+                "found_in"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "animal_type": {
+                  "const": "bird",
+                  "type": "string"
+                },
+                "can_fly": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "animal_type",
+                "can_fly"
+              ],
+              "type": "object"
+            }
+          ],
+          "required": [
+            "animal_type"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "pet",
+        "label"
+      ],
+      "type": "object"
+    },
+    "Second": {
+      "additionalProperties": false,
+      "properties": {
+        "pet": {
+          "discriminator": {
+            "propertyName": "animal_type"
+          },
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "animal_type": {
+                  "const": "fish",
+                  "type": "string"
+                },
+                "found_in": {
+                  "enum": [
+                    "ocean",
+                    "river"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "animal_type",
+                "found_in"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "animal_type": {
+                  "const": "bird",
+                  "type": "string"
+                },
+                "can_fly": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "animal_type",
+                "can_fly"
+              ],
+              "type": "object"
+            }
+          ],
+          "required": [
+            "animal_type"
+          ],
+          "type": "object"
+        },
+        "tag": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "pet",
+        "tag"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/test/valid-data/type-mapped-union-discriminator/index.test.ts
+++ b/test/valid-data/type-mapped-union-discriminator/index.test.ts
@@ -1,0 +1,7 @@
+import { assertValidSchema } from "../../utils";
+import { test } from "node:test";
+
+test(
+    "valid-data - type-mapped-union-discriminator",
+    assertValidSchema("type-mapped-union-discriminator", "MyObject", { jsDoc: "basic", discriminatorType: "open-api" }),
+);

--- a/test/valid-data/type-mapped-union-discriminator/main.ts
+++ b/test/valid-data/type-mapped-union-discriminator/main.ts
@@ -1,0 +1,28 @@
+type Fish = {
+    animal_type: "fish";
+    found_in: "ocean" | "river";
+    map_to_string: number;
+};
+
+type Bird = {
+    animal_type: "bird";
+    can_fly: boolean;
+    map_to_string: boolean;
+};
+
+/**
+ * @discriminator animal_type
+ */
+type Animal = Fish | Bird;
+
+// Recursively maps object fields: specifically turns `map_to_string` into string.
+// When it encounters an object field, it recurses into it.
+type DeepMapped<T extends object> = {
+    [P in keyof T]: P extends "map_to_string"
+        ? string
+        : T[P] extends object
+            ? DeepMapped<T[P]>
+            : T[P];
+};
+
+export type MyObject = DeepMapped<{ pet: Animal; name: string }>;

--- a/test/valid-data/type-mapped-union-discriminator/schema.json
+++ b/test/valid-data/type-mapped-union-discriminator/schema.json
@@ -1,0 +1,76 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "pet": {
+          "discriminator": {
+            "propertyName": "animal_type"
+          },
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "animal_type": {
+                  "const": "fish",
+                  "type": "string"
+                },
+                "found_in": {
+                  "enum": [
+                    "ocean",
+                    "river"
+                  ],
+                  "type": "string"
+                },
+                "map_to_string": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "animal_type",
+                "found_in",
+                "map_to_string"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "animal_type": {
+                  "const": "bird",
+                  "type": "string"
+                },
+                "can_fly": {
+                  "type": "boolean"
+                },
+                "map_to_string": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "animal_type",
+                "can_fly",
+                "map_to_string"
+              ],
+              "type": "object"
+            }
+          ],
+          "required": [
+            "animal_type"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "pet",
+        "name"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/test/valid-data/type-mapped-union-keyof/index.test.ts
+++ b/test/valid-data/type-mapped-union-keyof/index.test.ts
@@ -1,0 +1,4 @@
+import { assertValidSchema } from "../../utils";
+import { test } from "node:test";
+
+test("valid-data - type-mapped-union-keyof", assertValidSchema("type-mapped-union-keyof", "MyObject"));

--- a/test/valid-data/type-mapped-union-keyof/main.ts
+++ b/test/valid-data/type-mapped-union-keyof/main.ts
@@ -1,0 +1,13 @@
+type A = {
+    a: string;
+};
+
+type B = {
+    b: number;
+};
+
+type MappedUnion<T extends object> = {
+    [P in keyof T]: number;
+};
+
+export type MyObject = MappedUnion<A | B>;

--- a/test/valid-data/type-mapped-union-keyof/schema.json
+++ b/test/valid-data/type-mapped-union-keyof/schema.json
@@ -1,25 +1,31 @@
 {
-  "$ref": "#/definitions/MyType",
+  "$ref": "#/definitions/MyObject",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "MyType": {
+    "MyObject": {
       "anyOf": [
         {
           "additionalProperties": false,
           "properties": {
-            "foo": {
+            "a": {
               "type": "number"
             }
           },
+          "required": [
+            "a"
+          ],
           "type": "object"
         },
         {
           "additionalProperties": false,
           "properties": {
-            "foo": {
-              "type": "boolean"
+            "b": {
+              "type": "number"
             }
           },
+          "required": [
+            "b"
+          ],
           "type": "object"
         }
       ]

--- a/test/vega-lite/schema.json
+++ b/test/vega-lite/schema.json
@@ -27082,110 +27082,140 @@
           "type": "object"
         },
         "xError": {
-          "additionalProperties": false,
-          "properties": {
-            "aggregate": {
-              "$ref": "#/definitions/Aggregate",
-              "description": "Aggregation function for the field (e.g., `\"mean\"`, `\"sum\"`, `\"median\"`, `\"min\"`, `\"max\"`, `\"count\"`).\n\n__Default value:__ `undefined` (None)\n\n__See also:__ [`aggregate`](https://vega.github.io/vega-lite/docs/aggregate.html) documentation."
-            },
-            "bandPosition": {
-              "description": "Relative position on a band of a stacked, binned, time unit, or band scale. For example, the marks will be positioned at the beginning of the band if set to `0`, and at the middle of the band if set to `0.5`.",
-              "maximum": 1,
-              "minimum": 0,
-              "type": "number"
-            },
-            "bin": {
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
-              "type": "null"
-            },
-            "field": {
-              "$ref": "#/definitions/Field",
-              "description": "__Required.__ A string defining the name of the field from which to pull a data value or an object defining iterated values from the [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.\n\n__See also:__ [`field`](https://vega.github.io/vega-lite/docs/field.html) documentation.\n\n__Notes:__ 1)  Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., `\"field\": \"foo.bar\"` and `\"field\": \"foo['bar']\"`). If field names contain dots or brackets but are not nested, you can use `\\\\` to escape dots and brackets (e.g., `\"a\\\\.b\"` and `\"a\\\\[0\\\\]\"`). See more details about escaping in the [field documentation](https://vega.github.io/vega-lite/docs/field.html). 2) `field` is not required if `aggregate` is `count`."
-            },
-            "timeUnit": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/TimeUnit"
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "aggregate": {
+                  "$ref": "#/definitions/Aggregate",
+                  "description": "Aggregation function for the field (e.g., `\"mean\"`, `\"sum\"`, `\"median\"`, `\"min\"`, `\"max\"`, `\"count\"`).\n\n__Default value:__ `undefined` (None)\n\n__See also:__ [`aggregate`](https://vega.github.io/vega-lite/docs/aggregate.html) documentation."
                 },
-                {
-                  "$ref": "#/definitions/BinnedTimeUnit"
+                "bandPosition": {
+                  "description": "Relative position on a band of a stacked, binned, time unit, or band scale. For example, the marks will be positioned at the beginning of the band if set to `0`, and at the middle of the band if set to `0.5`.",
+                  "maximum": 1,
+                  "minimum": 0,
+                  "type": "number"
                 },
-                {
-                  "$ref": "#/definitions/TimeUnitParams"
-                }
-              ],
-              "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)\n\n__See also:__ [`timeUnit`](https://vega.github.io/vega-lite/docs/timeunit.html) documentation."
-            },
-            "title": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/Text"
-                },
-                {
+                "bin": {
+                  "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
                   "type": "null"
+                },
+                "field": {
+                  "$ref": "#/definitions/Field",
+                  "description": "__Required.__ A string defining the name of the field from which to pull a data value or an object defining iterated values from the [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.\n\n__See also:__ [`field`](https://vega.github.io/vega-lite/docs/field.html) documentation.\n\n__Notes:__ 1)  Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., `\"field\": \"foo.bar\"` and `\"field\": \"foo['bar']\"`). If field names contain dots or brackets but are not nested, you can use `\\\\` to escape dots and brackets (e.g., `\"a\\\\.b\"` and `\"a\\\\[0\\\\]\"`). See more details about escaping in the [field documentation](https://vega.github.io/vega-lite/docs/field.html). 2) `field` is not required if `aggregate` is `count`."
+                },
+                "timeUnit": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/TimeUnit"
+                    },
+                    {
+                      "$ref": "#/definitions/BinnedTimeUnit"
+                    },
+                    {
+                      "$ref": "#/definitions/TimeUnitParams"
+                    }
+                  ],
+                  "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)\n\n__See also:__ [`timeUnit`](https://vega.github.io/vega-lite/docs/timeunit.html) documentation."
+                },
+                "title": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Text"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`). If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`). Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/usage/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
                 }
-              ],
-              "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`). If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`). Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/usage/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
+              },
+              "type": "object"
             },
-            "value": {
-              "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity).",
-              "type": "number"
+            {
+              "additionalProperties": false,
+              "properties": {
+                "value": {
+                  "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity).",
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "type": "object"
             }
-          },
-          "type": "object"
+          ],
+          "description": "Error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
         },
         "xError2": {
-          "additionalProperties": false,
-          "properties": {
-            "aggregate": {
-              "$ref": "#/definitions/Aggregate",
-              "description": "Aggregation function for the field (e.g., `\"mean\"`, `\"sum\"`, `\"median\"`, `\"min\"`, `\"max\"`, `\"count\"`).\n\n__Default value:__ `undefined` (None)\n\n__See also:__ [`aggregate`](https://vega.github.io/vega-lite/docs/aggregate.html) documentation."
-            },
-            "bandPosition": {
-              "description": "Relative position on a band of a stacked, binned, time unit, or band scale. For example, the marks will be positioned at the beginning of the band if set to `0`, and at the middle of the band if set to `0.5`.",
-              "maximum": 1,
-              "minimum": 0,
-              "type": "number"
-            },
-            "bin": {
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
-              "type": "null"
-            },
-            "field": {
-              "$ref": "#/definitions/Field",
-              "description": "__Required.__ A string defining the name of the field from which to pull a data value or an object defining iterated values from the [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.\n\n__See also:__ [`field`](https://vega.github.io/vega-lite/docs/field.html) documentation.\n\n__Notes:__ 1)  Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., `\"field\": \"foo.bar\"` and `\"field\": \"foo['bar']\"`). If field names contain dots or brackets but are not nested, you can use `\\\\` to escape dots and brackets (e.g., `\"a\\\\.b\"` and `\"a\\\\[0\\\\]\"`). See more details about escaping in the [field documentation](https://vega.github.io/vega-lite/docs/field.html). 2) `field` is not required if `aggregate` is `count`."
-            },
-            "timeUnit": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/TimeUnit"
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "aggregate": {
+                  "$ref": "#/definitions/Aggregate",
+                  "description": "Aggregation function for the field (e.g., `\"mean\"`, `\"sum\"`, `\"median\"`, `\"min\"`, `\"max\"`, `\"count\"`).\n\n__Default value:__ `undefined` (None)\n\n__See also:__ [`aggregate`](https://vega.github.io/vega-lite/docs/aggregate.html) documentation."
                 },
-                {
-                  "$ref": "#/definitions/BinnedTimeUnit"
+                "bandPosition": {
+                  "description": "Relative position on a band of a stacked, binned, time unit, or band scale. For example, the marks will be positioned at the beginning of the band if set to `0`, and at the middle of the band if set to `0.5`.",
+                  "maximum": 1,
+                  "minimum": 0,
+                  "type": "number"
                 },
-                {
-                  "$ref": "#/definitions/TimeUnitParams"
-                }
-              ],
-              "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)\n\n__See also:__ [`timeUnit`](https://vega.github.io/vega-lite/docs/timeunit.html) documentation."
-            },
-            "title": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/Text"
-                },
-                {
+                "bin": {
+                  "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
                   "type": "null"
+                },
+                "field": {
+                  "$ref": "#/definitions/Field",
+                  "description": "__Required.__ A string defining the name of the field from which to pull a data value or an object defining iterated values from the [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.\n\n__See also:__ [`field`](https://vega.github.io/vega-lite/docs/field.html) documentation.\n\n__Notes:__ 1)  Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., `\"field\": \"foo.bar\"` and `\"field\": \"foo['bar']\"`). If field names contain dots or brackets but are not nested, you can use `\\\\` to escape dots and brackets (e.g., `\"a\\\\.b\"` and `\"a\\\\[0\\\\]\"`). See more details about escaping in the [field documentation](https://vega.github.io/vega-lite/docs/field.html). 2) `field` is not required if `aggregate` is `count`."
+                },
+                "timeUnit": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/TimeUnit"
+                    },
+                    {
+                      "$ref": "#/definitions/BinnedTimeUnit"
+                    },
+                    {
+                      "$ref": "#/definitions/TimeUnitParams"
+                    }
+                  ],
+                  "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)\n\n__See also:__ [`timeUnit`](https://vega.github.io/vega-lite/docs/timeunit.html) documentation."
+                },
+                "title": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Text"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`). If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`). Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/usage/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
                 }
-              ],
-              "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`). If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`). Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/usage/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
+              },
+              "type": "object"
             },
-            "value": {
-              "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity).",
-              "type": "number"
+            {
+              "additionalProperties": false,
+              "properties": {
+                "value": {
+                  "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity).",
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "type": "object"
             }
-          },
-          "type": "object"
+          ],
+          "description": "Secondary error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
         },
         "xOffset": {
           "additionalProperties": false,
@@ -27548,110 +27578,140 @@
           "type": "object"
         },
         "yError": {
-          "additionalProperties": false,
-          "properties": {
-            "aggregate": {
-              "$ref": "#/definitions/Aggregate",
-              "description": "Aggregation function for the field (e.g., `\"mean\"`, `\"sum\"`, `\"median\"`, `\"min\"`, `\"max\"`, `\"count\"`).\n\n__Default value:__ `undefined` (None)\n\n__See also:__ [`aggregate`](https://vega.github.io/vega-lite/docs/aggregate.html) documentation."
-            },
-            "bandPosition": {
-              "description": "Relative position on a band of a stacked, binned, time unit, or band scale. For example, the marks will be positioned at the beginning of the band if set to `0`, and at the middle of the band if set to `0.5`.",
-              "maximum": 1,
-              "minimum": 0,
-              "type": "number"
-            },
-            "bin": {
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
-              "type": "null"
-            },
-            "field": {
-              "$ref": "#/definitions/Field",
-              "description": "__Required.__ A string defining the name of the field from which to pull a data value or an object defining iterated values from the [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.\n\n__See also:__ [`field`](https://vega.github.io/vega-lite/docs/field.html) documentation.\n\n__Notes:__ 1)  Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., `\"field\": \"foo.bar\"` and `\"field\": \"foo['bar']\"`). If field names contain dots or brackets but are not nested, you can use `\\\\` to escape dots and brackets (e.g., `\"a\\\\.b\"` and `\"a\\\\[0\\\\]\"`). See more details about escaping in the [field documentation](https://vega.github.io/vega-lite/docs/field.html). 2) `field` is not required if `aggregate` is `count`."
-            },
-            "timeUnit": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/TimeUnit"
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "aggregate": {
+                  "$ref": "#/definitions/Aggregate",
+                  "description": "Aggregation function for the field (e.g., `\"mean\"`, `\"sum\"`, `\"median\"`, `\"min\"`, `\"max\"`, `\"count\"`).\n\n__Default value:__ `undefined` (None)\n\n__See also:__ [`aggregate`](https://vega.github.io/vega-lite/docs/aggregate.html) documentation."
                 },
-                {
-                  "$ref": "#/definitions/BinnedTimeUnit"
+                "bandPosition": {
+                  "description": "Relative position on a band of a stacked, binned, time unit, or band scale. For example, the marks will be positioned at the beginning of the band if set to `0`, and at the middle of the band if set to `0.5`.",
+                  "maximum": 1,
+                  "minimum": 0,
+                  "type": "number"
                 },
-                {
-                  "$ref": "#/definitions/TimeUnitParams"
-                }
-              ],
-              "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)\n\n__See also:__ [`timeUnit`](https://vega.github.io/vega-lite/docs/timeunit.html) documentation."
-            },
-            "title": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/Text"
-                },
-                {
+                "bin": {
+                  "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
                   "type": "null"
+                },
+                "field": {
+                  "$ref": "#/definitions/Field",
+                  "description": "__Required.__ A string defining the name of the field from which to pull a data value or an object defining iterated values from the [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.\n\n__See also:__ [`field`](https://vega.github.io/vega-lite/docs/field.html) documentation.\n\n__Notes:__ 1)  Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., `\"field\": \"foo.bar\"` and `\"field\": \"foo['bar']\"`). If field names contain dots or brackets but are not nested, you can use `\\\\` to escape dots and brackets (e.g., `\"a\\\\.b\"` and `\"a\\\\[0\\\\]\"`). See more details about escaping in the [field documentation](https://vega.github.io/vega-lite/docs/field.html). 2) `field` is not required if `aggregate` is `count`."
+                },
+                "timeUnit": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/TimeUnit"
+                    },
+                    {
+                      "$ref": "#/definitions/BinnedTimeUnit"
+                    },
+                    {
+                      "$ref": "#/definitions/TimeUnitParams"
+                    }
+                  ],
+                  "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)\n\n__See also:__ [`timeUnit`](https://vega.github.io/vega-lite/docs/timeunit.html) documentation."
+                },
+                "title": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Text"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`). If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`). Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/usage/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
                 }
-              ],
-              "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`). If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`). Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/usage/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
+              },
+              "type": "object"
             },
-            "value": {
-              "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity).",
-              "type": "number"
+            {
+              "additionalProperties": false,
+              "properties": {
+                "value": {
+                  "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity).",
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "type": "object"
             }
-          },
-          "type": "object"
+          ],
+          "description": "Error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
         },
         "yError2": {
-          "additionalProperties": false,
-          "properties": {
-            "aggregate": {
-              "$ref": "#/definitions/Aggregate",
-              "description": "Aggregation function for the field (e.g., `\"mean\"`, `\"sum\"`, `\"median\"`, `\"min\"`, `\"max\"`, `\"count\"`).\n\n__Default value:__ `undefined` (None)\n\n__See also:__ [`aggregate`](https://vega.github.io/vega-lite/docs/aggregate.html) documentation."
-            },
-            "bandPosition": {
-              "description": "Relative position on a band of a stacked, binned, time unit, or band scale. For example, the marks will be positioned at the beginning of the band if set to `0`, and at the middle of the band if set to `0.5`.",
-              "maximum": 1,
-              "minimum": 0,
-              "type": "number"
-            },
-            "bin": {
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
-              "type": "null"
-            },
-            "field": {
-              "$ref": "#/definitions/Field",
-              "description": "__Required.__ A string defining the name of the field from which to pull a data value or an object defining iterated values from the [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.\n\n__See also:__ [`field`](https://vega.github.io/vega-lite/docs/field.html) documentation.\n\n__Notes:__ 1)  Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., `\"field\": \"foo.bar\"` and `\"field\": \"foo['bar']\"`). If field names contain dots or brackets but are not nested, you can use `\\\\` to escape dots and brackets (e.g., `\"a\\\\.b\"` and `\"a\\\\[0\\\\]\"`). See more details about escaping in the [field documentation](https://vega.github.io/vega-lite/docs/field.html). 2) `field` is not required if `aggregate` is `count`."
-            },
-            "timeUnit": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/TimeUnit"
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "aggregate": {
+                  "$ref": "#/definitions/Aggregate",
+                  "description": "Aggregation function for the field (e.g., `\"mean\"`, `\"sum\"`, `\"median\"`, `\"min\"`, `\"max\"`, `\"count\"`).\n\n__Default value:__ `undefined` (None)\n\n__See also:__ [`aggregate`](https://vega.github.io/vega-lite/docs/aggregate.html) documentation."
                 },
-                {
-                  "$ref": "#/definitions/BinnedTimeUnit"
+                "bandPosition": {
+                  "description": "Relative position on a band of a stacked, binned, time unit, or band scale. For example, the marks will be positioned at the beginning of the band if set to `0`, and at the middle of the band if set to `0.5`.",
+                  "maximum": 1,
+                  "minimum": 0,
+                  "type": "number"
                 },
-                {
-                  "$ref": "#/definitions/TimeUnitParams"
-                }
-              ],
-              "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)\n\n__See also:__ [`timeUnit`](https://vega.github.io/vega-lite/docs/timeunit.html) documentation."
-            },
-            "title": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/Text"
-                },
-                {
+                "bin": {
+                  "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
                   "type": "null"
+                },
+                "field": {
+                  "$ref": "#/definitions/Field",
+                  "description": "__Required.__ A string defining the name of the field from which to pull a data value or an object defining iterated values from the [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.\n\n__See also:__ [`field`](https://vega.github.io/vega-lite/docs/field.html) documentation.\n\n__Notes:__ 1)  Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., `\"field\": \"foo.bar\"` and `\"field\": \"foo['bar']\"`). If field names contain dots or brackets but are not nested, you can use `\\\\` to escape dots and brackets (e.g., `\"a\\\\.b\"` and `\"a\\\\[0\\\\]\"`). See more details about escaping in the [field documentation](https://vega.github.io/vega-lite/docs/field.html). 2) `field` is not required if `aggregate` is `count`."
+                },
+                "timeUnit": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/TimeUnit"
+                    },
+                    {
+                      "$ref": "#/definitions/BinnedTimeUnit"
+                    },
+                    {
+                      "$ref": "#/definitions/TimeUnitParams"
+                    }
+                  ],
+                  "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)\n\n__See also:__ [`timeUnit`](https://vega.github.io/vega-lite/docs/timeunit.html) documentation."
+                },
+                "title": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Text"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`). If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`). Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/usage/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
                 }
-              ],
-              "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`). If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`). Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/usage/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
+              },
+              "type": "object"
             },
-            "value": {
-              "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity).",
-              "type": "number"
+            {
+              "additionalProperties": false,
+              "properties": {
+                "value": {
+                  "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity).",
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "type": "object"
             }
-          },
-          "type": "object"
+          ],
+          "description": "Secondary error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
         },
         "yOffset": {
           "additionalProperties": false,


### PR DESCRIPTION
Mapped types may take Unions as "parameters", and, in that case, they
must distribute over each Union individually. This was wrong before, it
was creating an intersection.

This implementation handles discriminated unions as well and preserves
the potential `@discriminator` annotation. Non-OpenAPI `discriminator`
were not tested (they generate `if`/`then` schemas).

Closes #2106