### PR TITLE
fix: mapped types required type

### DIFF
--- a/src/NodeParser/MappedTypeNodeParser.ts
+++ b/src/NodeParser/MappedTypeNodeParser.ts
@@ -106,6 +106,23 @@ export class MappedTypeNodeParser implements SubNodeParser {
         );
     }
 
+    /**
+     * In mapped types, questionToken can be:
+     * - undefined: no optional modifier
+     * - QuestionToken (?): add optional
+     * - PlusToken (+?): add optional
+     * - MinusToken (-?): remove optional (e.g. Required<T>) → property is required
+     */
+    protected isMappedPropertyRequired(node: ts.MappedTypeNode, hasUndefinedInType: boolean): boolean {
+        if (node.questionToken === undefined) {
+            return !hasUndefinedInType;
+        }
+        if (node.questionToken.kind === ts.SyntaxKind.MinusToken) {
+            return true; // -? removes optional → output property is always required
+        }
+        return false;
+    }
+
     protected mapKey(node: ts.MappedTypeNode, rawKey: LiteralType, context: Context): BaseType {
         if (!node.nameType) {
             return rawKey;
@@ -135,7 +152,7 @@ export class MappedTypeNodeParser implements SubNodeParser {
                 const objectProperty = new ObjectProperty(
                     mappedKey.getValue().toString(),
                     preserveAnnotation(propertyType, newType),
-                    !node.questionToken && !hasUndefined,
+                    this.isMappedPropertyRequired(node, hasUndefined),
                 );
 
                 result.push(objectProperty);
@@ -153,7 +170,7 @@ export class MappedTypeNodeParser implements SubNodeParser {
                     this.createSubContext(node, new LiteralType(value!), context),
                 );
 
-                return new ObjectProperty(value!.toString(), type, !node.questionToken);
+                return new ObjectProperty(value!.toString(), type, this.isMappedPropertyRequired(node, false));
             });
     }
 

--- a/test/valid-data/type-mapped-enum-required/index.test.ts
+++ b/test/valid-data/type-mapped-enum-required/index.test.ts
@@ -1,0 +1,4 @@
+import { assertValidSchema } from "../../utils";
+import { test } from "node:test";
+
+test("valid-data - type-mapped-enum-required", assertValidSchema("type-mapped-enum-required", "MyObject"));

--- a/test/valid-data/type-mapped-enum-required/main.ts
+++ b/test/valid-data/type-mapped-enum-required/main.ts
@@ -1,0 +1,10 @@
+enum Key {
+    A = "a",
+    B = "b",
+}
+
+type WithOptionalEnumKeys = {
+    [P in Key]?: string;
+};
+
+export type MyObject = Required<WithOptionalEnumKeys>;

--- a/test/valid-data/type-mapped-enum-required/schema.json
+++ b/test/valid-data/type-mapped-enum-required/schema.json
@@ -1,0 +1,22 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "a",
+        "b"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/test/valid-data/type-mapped-required/index.test.ts
+++ b/test/valid-data/type-mapped-required/index.test.ts
@@ -1,0 +1,4 @@
+import { assertValidSchema } from "../../utils";
+import { test } from "node:test";
+
+test("valid-data - type-mapped-required", assertValidSchema("type-mapped-required", "MyObject"));

--- a/test/valid-data/type-mapped-required/main.ts
+++ b/test/valid-data/type-mapped-required/main.ts
@@ -1,0 +1,6 @@
+interface WithOptional {
+    foo?: number;
+    bar?: string;
+}
+
+export type MyObject = Required<WithOptional>;

--- a/test/valid-data/type-mapped-required/schema.json
+++ b/test/valid-data/type-mapped-required/schema.json
@@ -1,0 +1,22 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "foo": {
+          "type": "number"
+        },
+        "bar": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "foo",
+        "bar"
+      ],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
## Fix required flag for mapped types (`-?` / `Required<T>`)

### Problem

Mapped types with the `-?` modifier (e.g. TypeScript’s `Required<T>`) did not mark properties as required in the generated JSON Schema. The logic only used `!node.questionToken && !hasUndefined`, which did not treat `-?` (MinusToken) as “remove optional → required”.

### Solution

- **New `isMappedPropertyRequired(node, hasUndefinedInType)`** in `MappedTypeNodeParser` that:
  - **`questionToken === undefined`** (no modifier): property is required when the value type does not include `undefined` (`!hasUndefinedInType`).
  - **`questionToken === MinusToken` (`-?`)**: property is always required (e.g. `Required<T>`).
  - **`?` or `+?`**: property stays optional.

- **Call sites updated** to use this helper:
  - `getProperties()` (union-of-keys path): `this.isMappedPropertyRequired(node, hasUndefined)` instead of `!node.questionToken && !hasUndefined`.
  - `getValues()` (enum path): `this.isMappedPropertyRequired(node, false)` instead of `!node.questionToken`.

### Tests

- **`type-mapped-required`**: `Required<WithOptional>` on an interface with optional properties → schema has all properties in `required`.
- **`type-mapped-enum-required`**: `Required<WithOptionalEnumKeys>` on a type with optional enum keys → schema has all enum keys in `required`.