### PR TITLE
fix: keep additionalProperties: false when merging with undefined

### DIFF
--- a/src/Utils/allOfDefinition.ts
+++ b/src/Utils/allOfDefinition.ts
@@ -84,10 +84,7 @@ export function getAllOfDefinitionReducer(childTypeFormatter: TypeFormatter) {
             definition.required = uniqueArray((definition.required || []).concat(other.required)).sort();
         }
 
-        if (
-            (other.additionalProperties || other.additionalProperties === undefined) &&
-            definition.additionalProperties == false
-        ) {
+        if (other.additionalProperties === true && definition.additionalProperties === false) {
             delete definition.additionalProperties;
         }
 

--- a/test/unit/allOfDefinition.test.ts
+++ b/test/unit/allOfDefinition.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import type { BaseType } from "../../src/Type/BaseType.js";
+import type { TypeFormatter } from "../../src/TypeFormatter.js";
+import { getAllOfDefinitionReducer } from "../../src/Utils/allOfDefinition.js";
+
+describe("getAllOfDefinitionReducer - additionalProperties fix", () => {
+    it("does not delete additionalProperties: false when other has additionalProperties undefined", () => {
+        const mockFormatter: TypeFormatter = {
+            getDefinition: () => ({
+                type: "object",
+                properties: {},
+                // no additionalProperties key (undefined) - e.g. from [key: string]: any
+            }),
+            getChildren: () => [],
+        };
+
+        const reduce = getAllOfDefinitionReducer(mockFormatter);
+        const definition = {
+            type: "object" as const,
+            properties: { name: { type: "string" as const } },
+            required: ["name"],
+            additionalProperties: false,
+        };
+        const baseType = {} as BaseType;
+        const result = reduce(definition, baseType);
+
+        assert.strictEqual(
+            result.additionalProperties,
+            false,
+            "Must keep additionalProperties: false when other has undefined",
+        );
+    });
+
+    it("deletes additionalProperties when other explicitly has additionalProperties: true", () => {
+        const mockFormatter: TypeFormatter = {
+            getDefinition: () => ({
+                type: "object",
+                properties: {},
+                additionalProperties: true,
+            }),
+            getChildren: () => [],
+        };
+
+        const reduce = getAllOfDefinitionReducer(mockFormatter);
+        const definition = {
+            type: "object" as const,
+            properties: { name: { type: "string" as const } },
+            required: ["name"],
+            additionalProperties: false,
+        };
+        const baseType = {} as BaseType;
+        const result = reduce(definition, baseType);
+
+        assert.strictEqual(
+            result.additionalProperties,
+            undefined,
+            "Must remove additionalProperties when other explicitly allows (true)",
+        );
+    });
+});


### PR DESCRIPTION
## Fix: keep `additionalProperties: false` when merging with undefined

### Problem

When merging object definitions in `getAllOfDefinitionReducer` (used for intersections and extended interfaces), the code was removing `additionalProperties: false` from the current definition whenever the *other* definition had `additionalProperties` truthy **or** undefined.

### Solution

Only remove `additionalProperties` when the other definition **explicitly** allows additional properties (`other.additionalProperties === true`).
 If the other has `additionalProperties === undefined`, we keep `additionalProperties: false` on the merged definition.

### Changes

- **`src/Utils/allOfDefinition.ts`** – Tightened the condition so we only delete `definition.additionalProperties` when the other side explicitly has `additionalProperties: true`.
- **`test/unit/allOfDefinition.test.ts`** – New unit tests:
  - Do **not** delete `additionalProperties: false` when the other has `additionalProperties` undefined.
  - Still delete when the other has `additionalProperties: true`.