### PR TITLE
Add support for `infer` in conditionals operating on function parameters

### DIFF
--- a/src/NodeParser/FunctionNodeParser.ts
+++ b/src/NodeParser/FunctionNodeParser.ts
@@ -57,7 +57,7 @@ export function getNamedArguments(
     // Special case for when function signature is (...args: infer T)
     if (node.parameters.length === 1) {
         const parameterType = childNodeParser.createType(node.parameters[0], context);
-        if (parameterType instanceof InferType) return parameterType as typeof parameterType & ObjectType; // Is this type union ok, or do I need to rework the entire return type?
+        if (parameterType instanceof InferType) return parameterType as typeof parameterType & ObjectType;
     }
 
     const parameterTypes = node.parameters.map((parameter) => {

--- a/src/NodeParser/FunctionNodeParser.ts
+++ b/src/NodeParser/FunctionNodeParser.ts
@@ -53,6 +53,12 @@ export function getNamedArguments(
         return undefined;
     }
 
+    // Special case for when function signature is (...args: infer T)
+    if (node.parameters.length === 1) {
+        const parameterType = childNodeParser.createType(node.parameters[0], context);
+        return parameterType as typeof parameterType & ObjectType; // Is this type union ok, or do I need to rework the entire return type?
+    }
+
     const parameterTypes = node.parameters.map((parameter) => {
         return childNodeParser.createType(parameter, context);
     });

--- a/src/NodeParser/FunctionNodeParser.ts
+++ b/src/NodeParser/FunctionNodeParser.ts
@@ -8,6 +8,7 @@ import { DefinitionType } from "../Type/DefinitionType.js";
 import type { Context, NodeParser } from "../NodeParser.js";
 import { ObjectProperty, ObjectType } from "../Type/ObjectType.js";
 import { getKey } from "../Utils/nodeKey.js";
+import { InferType } from "../Type/InferType.js";
 
 export class FunctionNodeParser implements SubNodeParser {
     constructor(
@@ -56,7 +57,7 @@ export function getNamedArguments(
     // Special case for when function signature is (...args: infer T)
     if (node.parameters.length === 1) {
         const parameterType = childNodeParser.createType(node.parameters[0], context);
-        return parameterType as typeof parameterType & ObjectType; // Is this type union ok, or do I need to rework the entire return type?
+        if (parameterType instanceof InferType) return parameterType as typeof parameterType & ObjectType; // Is this type union ok, or do I need to rework the entire return type?
     }
 
     const parameterTypes = node.parameters.map((parameter) => {

--- a/src/Utils/isAssignableTo.ts
+++ b/src/Utils/isAssignableTo.ts
@@ -21,6 +21,7 @@ import { BooleanType } from "../Type/BooleanType.js";
 import { InferType } from "../Type/InferType.js";
 import { RestType } from "../Type/RestType.js";
 import { NeverType } from "../Type/NeverType.js";
+import { FunctionType } from "../Type/FunctionType.js";
 
 /**
  * Returns the combined types from the given intersection. Currently only object types are combined. Maybe more
@@ -121,6 +122,21 @@ export function isAssignableTo(
         }
 
         return true;
+    }
+
+    // Function types may need to add to inferMap
+    // TODO: Add support for comparison of function return type
+    if (target instanceof FunctionType) {
+        if (source instanceof FunctionType) {
+            return isAssignableTo(
+                target.getNamedArguments() ?? new NeverType(),
+                source.getNamedArguments() ?? new NeverType(),
+                inferMap,
+                insideTypes,
+            );
+        }
+
+        return false;
     }
 
     // Check for simple type equality

--- a/src/Utils/isAssignableTo.ts
+++ b/src/Utils/isAssignableTo.ts
@@ -125,7 +125,6 @@ export function isAssignableTo(
     }
 
     // Function types may need to add to inferMap
-    // TODO: Add support for comparison of function return type
     if (target instanceof FunctionType) {
         if (source instanceof FunctionType) {
             return isAssignableTo(

--- a/test/valid-data/type-conditional-infer-function/index.test.ts
+++ b/test/valid-data/type-conditional-infer-function/index.test.ts
@@ -1,4 +1,7 @@
 import { assertValidSchema } from "../../utils";
 import { test } from "node:test";
 
-test("valid-data - type-conditional-infer-function", assertValidSchema("type-conditional-infer-function", "FuncParams"));
+test(
+    "valid-data - type-conditional-infer-function",
+    assertValidSchema("type-conditional-infer-function", "FuncParams"),
+);

--- a/test/valid-data/type-conditional-infer-function/index.test.ts
+++ b/test/valid-data/type-conditional-infer-function/index.test.ts
@@ -1,0 +1,4 @@
+import { assertValidSchema } from "../../utils";
+import { test } from "node:test";
+
+test("valid-data - type-conditional-infer-function", assertValidSchema("type-conditional-infer-function", "FuncParams"));

--- a/test/valid-data/type-conditional-infer-function/main.ts
+++ b/test/valid-data/type-conditional-infer-function/main.ts
@@ -1,0 +1,1 @@
+export type FuncParams = Parameters<(a: string, b: number) => void>;

--- a/test/valid-data/type-conditional-infer-function/schema.json
+++ b/test/valid-data/type-conditional-infer-function/schema.json
@@ -1,0 +1,22 @@
+{
+  "$ref": "#/definitions/FuncParams",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "FuncParams": {
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "a",
+        "b"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
Adds support for types which use `infer` in the function parameters, specifically where `infer` is used on the only parameter; in short, adds support for `Parameters<T>`.

**Notes**:
- Please see [this line in FunctionNodeParser](https://github.com/ninjack-dev/ts-json-schema-generator/blob/1124d59eefe1995847f72fc45620bacfb14ad3c2/src/NodeParser/FunctionNodeParser.ts#L60); to cover the base `InferType` case when handling function parameter types, I intersect the resulting `InferType` with `ObjectType` to pass the requirements for `FunctionType`. This is a bit of a hack, but it works well enough; curious how I should go about handling this, if at all.
- Added tests are minimal, but I imagine `Parameters<T>` makes up 90% of the use cases for this functionality (or at least it does for mine); if edge cases/other uses are discovered later I'll be happy to revisit this and add more tests.