### PR TITLE
fix: array ref used as rest item

### DIFF
--- a/src/TypeFormatter/TupleTypeFormatter.ts
+++ b/src/TypeFormatter/TupleTypeFormatter.ts
@@ -6,8 +6,25 @@ import { OptionalType } from "../Type/OptionalType.js";
 import { RestType } from "../Type/RestType.js";
 import { TupleType } from "../Type/TupleType.js";
 import type { TypeFormatter } from "../TypeFormatter.js";
+import { derefType } from "../Utils/derefType.js";
 import { notNever } from "../Utils/notNever.js";
 import { uniqueArray } from "../Utils/uniqueArray.js";
+
+function getRestAdditionalItems(
+    restType: RestType,
+    childTypeFormatter: TypeFormatter,
+): Definition["items"] | undefined {
+    const items = childTypeFormatter.getDefinition(restType).items;
+    if (items !== undefined) {
+        return items;
+    }
+    const resolvedType = derefType(restType.getType());
+    if (!(resolvedType instanceof ArrayType)) {
+        return undefined;
+    }
+    const resolvedDef = childTypeFormatter.getDefinition(resolvedType);
+    return resolvedDef.items;
+}
 
 function uniformRestType(type: RestType, check_type: BaseType): boolean {
     const inner = type.getType();
@@ -64,7 +81,8 @@ export class TupleTypeFormatter implements SubTypeFormatter {
         const requiredDefinitions = requiredElements.map((item) => this.childTypeFormatter.getDefinition(item));
         const optionalDefinitions = optionalElements.map((item) => this.childTypeFormatter.getDefinition(item));
         const itemsTotal = requiredDefinitions.length + optionalDefinitions.length;
-        const additionalItems = restType ? this.childTypeFormatter.getDefinition(restType).items : undefined;
+        const additionalItems =
+            restType !== undefined ? getRestAdditionalItems(restType, this.childTypeFormatter) : undefined;
 
         return {
             type: "array",

--- a/test/valid-data/type-aliases-tuple-rest-array-ref/index.test.ts
+++ b/test/valid-data/type-aliases-tuple-rest-array-ref/index.test.ts
@@ -1,0 +1,6 @@
+import { test } from "node:test";
+import { assertValidSchema } from "../../utils";
+
+const testDir = "type-aliases-tuple-rest-array-ref";
+
+test(`valid-data - ${testDir}`, assertValidSchema(testDir, "TupleWithRestRef"));

--- a/test/valid-data/type-aliases-tuple-rest-array-ref/main.ts
+++ b/test/valid-data/type-aliases-tuple-rest-array-ref/main.ts
@@ -1,0 +1,2 @@
+export type RestItems = string[];
+export type TupleWithRestRef = [number, ...RestItems];

--- a/test/valid-data/type-aliases-tuple-rest-array-ref/schema.json
+++ b/test/valid-data/type-aliases-tuple-rest-array-ref/schema.json
@@ -1,0 +1,18 @@
+{
+  "$ref": "#/definitions/TupleWithRestRef",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "TupleWithRestRef": {
+      "additionalItems": {
+        "type": "string"
+      },
+      "items": [
+        {
+          "type": "number"
+        }
+      ],
+      "minItems": 1,
+      "type": "array"
+    }
+  }
+}


### PR DESCRIPTION
## Fix tuple schema when rest element is a type reference so `additionalItems` is emitted and `maxItems` is omitted.

### Problem

For types like `[number, ...RestItems]` with `RestItems = string[]`, the generator produced `maxItems: 1` and no `additionalItems`, so the rest element was not described.

### Solution

In `TupleTypeFormatter`, when the rest type’s definition has no `items` (e.g. it’s a `$ref` from a type alias), the rest’s inner type is resolved with `derefType()`. If the resolved type is an `ArrayType`, its `items` schema is used as `additionalItems`.

**Files:** `src/TypeFormatter/TupleTypeFormatter.ts`

### Tests

- **type-aliases-tuple-rest-array-ref:** `TupleWithRestRef = [number, ...RestItems]` with `RestItems = string[]` → schema with `additionalProperties` and no `maxItems`