### PR TITLE
fix: missing properties alias type circular reference

### DIFF
--- a/src/ChainTypeFormatter.ts
+++ b/src/ChainTypeFormatter.ts
@@ -3,6 +3,7 @@ import type { MutableTypeFormatter } from "./MutableTypeFormatter.js";
 import type { Definition } from "./Schema/Definition.js";
 import type { SubTypeFormatter } from "./SubTypeFormatter.js";
 import type { BaseType } from "./Type/BaseType.js";
+import type { GetDefinitionOptions } from "./TypeFormatter.js";
 
 export class ChainTypeFormatter implements SubTypeFormatter, MutableTypeFormatter {
     public constructor(protected typeFormatters: SubTypeFormatter[]) {}
@@ -15,8 +16,8 @@ export class ChainTypeFormatter implements SubTypeFormatter, MutableTypeFormatte
     public supportsType(type: BaseType): boolean {
         return this.typeFormatters.some((typeFormatter) => typeFormatter.supportsType(type));
     }
-    public getDefinition(type: BaseType): Definition {
-        return this.getTypeFormatter(type).getDefinition(type);
+    public getDefinition(type: BaseType, options?: GetDefinitionOptions): Definition {
+        return this.getTypeFormatter(type).getDefinition(type, options);
     }
     public getChildren(type: BaseType): BaseType[] {
         return this.getTypeFormatter(type).getChildren(type);

--- a/src/CircularReferenceTypeFormatter.ts
+++ b/src/CircularReferenceTypeFormatter.ts
@@ -1,7 +1,20 @@
+import type { JSONSchema7 } from "json-schema";
 import type { Definition } from "./Schema/Definition.js";
 import type { SubTypeFormatter } from "./SubTypeFormatter.js";
 import type { BaseType } from "./Type/BaseType.js";
+import type { GetDefinitionOptions } from "./TypeFormatter.js";
 import { uniqueArray } from "./Utils/uniqueArray.js";
+
+function safeStringify(obj: JSONSchema7): string {
+    const seen = new WeakSet<object>();
+    return JSON.stringify(obj, (_key, value: unknown) => {
+        if (typeof value === "object" && value !== null) {
+            if (seen.has(value)) return "[Circular]";
+            seen.add(value);
+        }
+        return value;
+    });
+}
 
 export class CircularReferenceTypeFormatter implements SubTypeFormatter {
     protected definition: Map<BaseType, Definition> = new Map();
@@ -12,14 +25,14 @@ export class CircularReferenceTypeFormatter implements SubTypeFormatter {
     public supportsType(type: BaseType): boolean {
         return this.childTypeFormatter.supportsType(type);
     }
-    public getDefinition(type: BaseType): Definition {
+    public getDefinition(type: BaseType, options?: GetDefinitionOptions): Definition {
         if (this.definition.has(type)) {
             return this.definition.get(type)!;
         }
 
         const definition: Definition = {};
         this.definition.set(type, definition);
-        Object.assign(definition, this.childTypeFormatter.getDefinition(type));
+        Object.assign(definition, this.childTypeFormatter.getDefinition(type, options));
         return definition;
     }
     public getChildren(type: BaseType): BaseType[] {
@@ -31,5 +44,41 @@ export class CircularReferenceTypeFormatter implements SubTypeFormatter {
         this.children.set(type, children);
         children.push(...this.childTypeFormatter.getChildren(type));
         return uniqueArray(children);
+    }
+
+    /**
+     * Recompute all cached definitions that may contain stale data from circular-reference placeholders.
+     *
+     * During initial processing, when a recursive type (e.g. a class with `children: Node[]`) is being processed, the cache returns {} for it.
+     * All definitions computed during that window embed the incomplete placeholder.
+     * This method recomputes every cached entry using now-complete member caches.
+     *
+     * Every entry is checked for convergence because wrapper types (AliasType, AnnotatedType, etc.) may sit between the stale source and the consuming definition,
+     * and their cache entries must also propagate the fix before the loop can exit.
+     */
+    public recomputeCachedDefinitions(options?: GetDefinitionOptions): void {
+        const entries = Array.from(this.definition.entries());
+        if (entries.length === 0) return;
+
+        // Safety limit for deeply wrapped types
+        const MAX_ITERATIONS = 10;
+        for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
+            let changed = false;
+
+            for (const [type, definition] of entries) {
+                const oldJson = safeStringify(definition);
+
+                for (const key of Object.keys(definition)) {
+                    delete (definition as Record<string, unknown>)[key];
+                }
+                Object.assign(definition, this.childTypeFormatter.getDefinition(type, options));
+
+                if (safeStringify(definition) !== oldJson) {
+                    changed = true;
+                }
+            }
+
+            if (!changed) break;
+        }
     }
 }

--- a/src/Interfaces/TypeFormatter.ts
+++ b/src/Interfaces/TypeFormatter.ts
@@ -1,7 +1,8 @@
 import type { Definition } from "../Schema/Definition.js";
 import type { BaseType } from "../Type/BaseType.js";
+import type { GetDefinitionOptions } from "../TypeFormatter.js";
 
 export interface TypeFormatter {
-    getDefinition(type: BaseType): Definition;
+    getDefinition(type: BaseType, options?: GetDefinitionOptions): Definition;
     getChildren(type: BaseType): BaseType[];
 }

--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -1,4 +1,5 @@
 import ts from "typescript";
+import { CircularReferenceTypeFormatter } from "./CircularReferenceTypeFormatter.js";
 import type { Config } from "./Config.js";
 import { MultipleDefinitionsError, RootlessError, UnhandledError } from "./Error/Errors.js";
 import { Context, type NodeParser } from "./NodeParser.js";
@@ -11,6 +12,7 @@ import type { StringMap } from "./Utils/StringMap.js";
 import { AnnotatedType } from "./Type/AnnotatedType.js";
 import { hasJsDocTag } from "./Utils/hasJsDocTag.js";
 import { removeUnreachable } from "./Utils/removeUnreachable.js";
+import { buildNameMaps, deepCloneDefinition, replaceCircularRefs } from "./Utils/replaceCircularRefs.js";
 import { castArray } from "./Utils/castArray.js";
 import { symbolAtNode } from "./Utils/symbolAtNode.js";
 
@@ -33,10 +35,7 @@ export class SchemaGenerator {
             rootType: this.nodeParser.createType(rootNode, new Context()),
         }));
 
-        const rootTypeDefinitions = roots.map((root) => this.getRootTypeDefinition(root.rootType, root.rootNode));
-        const rootTypeDefinition = rootTypeDefinitions.length === 1 ? rootTypeDefinitions[0] : undefined;
         const definitions: StringMap<Definition> = {};
-
         for (const root of roots) {
             try {
                 this.appendRootChildDefinitions(root.rootType, definitions);
@@ -49,16 +48,35 @@ export class SchemaGenerator {
             }
         }
 
+        if (this.typeFormatter instanceof CircularReferenceTypeFormatter) {
+            this.typeFormatter.recomputeCachedDefinitions({ definitions });
+        }
+
+        const rootTypeDefinitions = roots.map((root) =>
+            this.getRootTypeDefinition(root.rootType, root.rootNode, definitions),
+        );
+
+        replaceCircularRefs(definitions, rootTypeDefinitions);
+
+        const rootTypeDefinition = rootTypeDefinitions.length === 1 ? rootTypeDefinitions[0] : undefined;
+
         const reachableDefinitions = rootTypeDefinitions.reduce<StringMap<Definition>>(
             (acc, def) => Object.assign(acc, removeUnreachable(def, definitions)),
             {},
         );
 
+        const { objToName, arrayToName } = buildNameMaps(reachableDefinitions);
+
+        const clonedDefinitions: StringMap<Definition> = {};
+        for (const [key, def] of Object.entries(reachableDefinitions)) {
+            clonedDefinitions[key] = deepCloneDefinition(def, objToName, arrayToName);
+        }
+
         return {
             ...(this.config?.schemaId ? { $id: this.config.schemaId } : {}),
             $schema: "http://json-schema.org/draft-07/schema#",
-            ...(rootTypeDefinition ?? {}),
-            definitions: reachableDefinitions,
+            ...(rootTypeDefinition ? deepCloneDefinition(rootTypeDefinition, objToName, arrayToName) : {}),
+            definitions: clonedDefinitions,
         };
     }
 
@@ -102,9 +120,13 @@ export class SchemaGenerator {
         throw new RootlessError(fullName);
     }
 
-    protected getRootTypeDefinition(rootType: BaseType, rootNode: ts.Node): Definition {
+    protected getRootTypeDefinition(
+        rootType: BaseType,
+        rootNode: ts.Node,
+        definitions?: StringMap<Definition>,
+    ): Definition {
         try {
-            return this.typeFormatter.getDefinition(rootType);
+            return this.typeFormatter.getDefinition(rootType, { definitions });
         } catch (error) {
             throw UnhandledError.from("Unhandled error while creating Root Type Definition.", rootNode, error);
         }

--- a/src/TypeFormatter.ts
+++ b/src/TypeFormatter.ts
@@ -1,7 +1,12 @@
 import type { Definition } from "./Schema/Definition.js";
 import type { BaseType } from "./Type/BaseType.js";
+import type { StringMap } from "./Utils/StringMap.js";
+
+export interface GetDefinitionOptions {
+    definitions?: StringMap<Definition>;
+}
 
 export interface TypeFormatter {
-    getDefinition(type: BaseType): Definition;
+    getDefinition(type: BaseType, options?: GetDefinitionOptions): Definition;
     getChildren(type: BaseType): BaseType[];
 }

--- a/src/TypeFormatter/AliasTypeFormatter.ts
+++ b/src/TypeFormatter/AliasTypeFormatter.ts
@@ -2,6 +2,7 @@ import type { Definition } from "../Schema/Definition.js";
 import type { SubTypeFormatter } from "../SubTypeFormatter.js";
 import { AliasType } from "../Type/AliasType.js";
 import type { BaseType } from "../Type/BaseType.js";
+import type { GetDefinitionOptions } from "../TypeFormatter.js";
 import type { TypeFormatter } from "../TypeFormatter.js";
 
 export class AliasTypeFormatter implements SubTypeFormatter {
@@ -10,8 +11,8 @@ export class AliasTypeFormatter implements SubTypeFormatter {
     public supportsType(type: BaseType): boolean {
         return type instanceof AliasType;
     }
-    public getDefinition(type: AliasType): Definition {
-        return this.childTypeFormatter.getDefinition(type.getType());
+    public getDefinition(type: AliasType, options?: GetDefinitionOptions): Definition {
+        return this.childTypeFormatter.getDefinition(type.getType(), options);
     }
     public getChildren(type: AliasType): BaseType[] {
         return this.childTypeFormatter.getChildren(type.getType());

--- a/src/TypeFormatter/AnnotatedTypeFormatter.ts
+++ b/src/TypeFormatter/AnnotatedTypeFormatter.ts
@@ -4,6 +4,7 @@ import type { SubTypeFormatter } from "../SubTypeFormatter.js";
 import { AnnotatedType } from "../Type/AnnotatedType.js";
 import type { BaseType } from "../Type/BaseType.js";
 import { UnionType } from "../Type/UnionType.js";
+import type { GetDefinitionOptions } from "../TypeFormatter.js";
 import type { TypeFormatter } from "../TypeFormatter.js";
 import { derefType } from "../Utils/derefType.js";
 
@@ -52,7 +53,7 @@ export class AnnotatedTypeFormatter implements SubTypeFormatter {
     public supportsType(type: BaseType): boolean {
         return type instanceof AnnotatedType;
     }
-    public getDefinition(type: AnnotatedType): Definition {
+    public getDefinition(type: AnnotatedType, options?: GetDefinitionOptions): Definition {
         const annotations = type.getAnnotations();
 
         if ("discriminator" in annotations) {
@@ -69,7 +70,7 @@ export class AnnotatedTypeFormatter implements SubTypeFormatter {
         }
 
         const def: Definition = {
-            ...this.childTypeFormatter.getDefinition(type.getType()),
+            ...this.childTypeFormatter.getDefinition(type.getType(), options),
             ...type.getAnnotations(),
         };
 

--- a/src/TypeFormatter/ArrayTypeFormatter.ts
+++ b/src/TypeFormatter/ArrayTypeFormatter.ts
@@ -2,6 +2,7 @@ import type { Definition } from "../Schema/Definition.js";
 import type { SubTypeFormatter } from "../SubTypeFormatter.js";
 import { ArrayType } from "../Type/ArrayType.js";
 import type { BaseType } from "../Type/BaseType.js";
+import type { GetDefinitionOptions } from "../TypeFormatter.js";
 import type { TypeFormatter } from "../TypeFormatter.js";
 
 export class ArrayTypeFormatter implements SubTypeFormatter {
@@ -10,10 +11,10 @@ export class ArrayTypeFormatter implements SubTypeFormatter {
     public supportsType(type: BaseType): boolean {
         return type instanceof ArrayType;
     }
-    public getDefinition(type: ArrayType): Definition {
+    public getDefinition(type: ArrayType, options?: GetDefinitionOptions): Definition {
         return {
             type: "array",
-            items: this.childTypeFormatter.getDefinition(type.getItem()),
+            items: this.childTypeFormatter.getDefinition(type.getItem(), options),
         };
     }
     public getChildren(type: ArrayType): BaseType[] {

--- a/src/TypeFormatter/FunctionTypeFormatter.ts
+++ b/src/TypeFormatter/FunctionTypeFormatter.ts
@@ -3,6 +3,7 @@ import type { Definition } from "../Schema/Definition.js";
 import type { SubTypeFormatter } from "../SubTypeFormatter.js";
 import type { BaseType } from "../Type/BaseType.js";
 import { FunctionType } from "../Type/FunctionType.js";
+import type { GetDefinitionOptions } from "../TypeFormatter.js";
 import type { TypeFormatter } from "../TypeFormatter.js";
 
 export class FunctionTypeFormatter implements SubTypeFormatter {
@@ -15,14 +16,14 @@ export class FunctionTypeFormatter implements SubTypeFormatter {
         return type instanceof FunctionType;
     }
 
-    public getDefinition(type: FunctionType): Definition {
+    public getDefinition(type: FunctionType, options?: GetDefinitionOptions): Definition {
         const namedArgs = type.getNamedArguments();
         if (namedArgs) {
             return {
                 $comment: type.getComment(),
                 type: "object",
                 properties: {
-                    namedArgs: this.childTypeFormatter.getDefinition(namedArgs),
+                    namedArgs: this.childTypeFormatter.getDefinition(namedArgs, options),
                 },
             };
         }

--- a/src/TypeFormatter/IntersectionTypeFormatter.ts
+++ b/src/TypeFormatter/IntersectionTypeFormatter.ts
@@ -4,9 +4,31 @@ import { ArrayType } from "../Type/ArrayType.js";
 import type { BaseType } from "../Type/BaseType.js";
 import { IntersectionType } from "../Type/IntersectionType.js";
 import { TupleType } from "../Type/TupleType.js";
+import { UnionType } from "../Type/UnionType.js";
+import type { GetDefinitionOptions } from "../TypeFormatter.js";
 import type { TypeFormatter } from "../TypeFormatter.js";
-import { getAllOfDefinitionReducer } from "../Utils/allOfDefinition.js";
+import { getAllOfDefinitionReducer, refResolverFromDefinitions } from "../Utils/allOfDefinition.js";
+import { derefType } from "../Utils/derefType.js";
 import { uniqueArray } from "../Utils/uniqueArray.js";
+
+/**
+ * Recursively flatten nested IntersectionType members so each leaf type is
+ * reduced individually. This prevents CircularReferenceTypeFormatter from
+ * caching incomplete intermediate IntersectionType definitions when one of the
+ * members triggers a circular reference (e.g. a type with recursive fields).
+ */
+function flattenIntersectionMembers(types: readonly BaseType[]): BaseType[] {
+    const result: BaseType[] = [];
+    for (const t of types) {
+        const derefed = derefType(t);
+        if (derefed instanceof IntersectionType) {
+            result.push(...flattenIntersectionMembers(derefed.getTypes()));
+        } else {
+            result.push(t);
+        }
+    }
+    return result;
+}
 
 export class IntersectionTypeFormatter implements SubTypeFormatter {
     public constructor(protected childTypeFormatter: TypeFormatter) {}
@@ -15,15 +37,19 @@ export class IntersectionTypeFormatter implements SubTypeFormatter {
         return type instanceof IntersectionType;
     }
 
-    public getDefinition(type: IntersectionType): Definition {
+    public getDefinition(type: IntersectionType, options?: GetDefinitionOptions): Definition {
+        const refResolver = refResolverFromDefinitions(options?.definitions);
+        const reducer = getAllOfDefinitionReducer(this.childTypeFormatter, refResolver, options);
         const dependencies: Definition[] = [];
         const nonArrayLikeTypes: BaseType[] = [];
 
-        for (const t of type.getTypes()) {
+        const flatMembers = flattenIntersectionMembers(type.getTypes());
+
+        for (const t of flatMembers) {
             // Filter out Array like definitions that cannot be
             // easily mergeable into a single json-schema object
             if (t instanceof ArrayType || t instanceof TupleType) {
-                dependencies.push(this.childTypeFormatter.getDefinition(t));
+                dependencies.push(this.childTypeFormatter.getDefinition(t, options));
             } else {
                 nonArrayLikeTypes.push(t);
             }
@@ -31,12 +57,30 @@ export class IntersectionTypeFormatter implements SubTypeFormatter {
 
         if (nonArrayLikeTypes.length) {
             // There are non array (mergeable requirements)
-            dependencies.push(
-                nonArrayLikeTypes.reduce(getAllOfDefinitionReducer(this.childTypeFormatter), {
-                    type: "object",
-                    additionalProperties: false,
-                }),
-            );
+            const unionTypes = nonArrayLikeTypes
+                .map((t) => derefType(t))
+                .filter((t): t is UnionType => t instanceof UnionType);
+            const unionMember = unionTypes[0];
+            const nonUnionMembers = nonArrayLikeTypes.filter((t) => !(derefType(t) instanceof UnionType));
+
+            if (!unionMember) {
+                dependencies.push(
+                    nonArrayLikeTypes.reduce(reducer, {
+                        type: "object",
+                        additionalProperties: false,
+                    }),
+                );
+            } else {
+                const base = nonUnionMembers.reduce(reducer, { type: "object", additionalProperties: false });
+                const branchDefs = unionMember.getTypes().flatMap((branchType) => {
+                    const derefed = derefType(branchType);
+                    if (derefed instanceof UnionType) {
+                        return derefed.getTypes().map((innerType) => [innerType].reduce(reducer, { ...base }));
+                    }
+                    return [[branchType].reduce(reducer, { ...base })];
+                });
+                dependencies.push(branchDefs.length === 1 ? branchDefs[0] : { anyOf: branchDefs });
+            }
         }
 
         return dependencies.length === 1 ? dependencies[0] : { allOf: dependencies };

--- a/src/TypeFormatter/ObjectTypeFormatter.ts
+++ b/src/TypeFormatter/ObjectTypeFormatter.ts
@@ -6,8 +6,10 @@ import { BaseType } from "../Type/BaseType.js";
 import { ObjectProperty, ObjectType } from "../Type/ObjectType.js";
 import { UndefinedType } from "../Type/UndefinedType.js";
 import { UnionType } from "../Type/UnionType.js";
+import type { GetDefinitionOptions } from "../TypeFormatter.js";
 import type { TypeFormatter } from "../TypeFormatter.js";
-import { getAllOfDefinitionReducer } from "../Utils/allOfDefinition.js";
+
+import { getAllOfDefinitionReducer, refResolverFromDefinitions } from "../Utils/allOfDefinition.js";
 import { derefType } from "../Utils/derefType.js";
 import { preserveAnnotation } from "../Utils/preserveAnnotation.js";
 import { removeUndefined } from "../Utils/removeUndefined.js";
@@ -22,13 +24,15 @@ export class ObjectTypeFormatter implements SubTypeFormatter {
         return type instanceof ObjectType;
     }
 
-    public getDefinition(type: ObjectType): Definition {
+    public getDefinition(type: ObjectType, options?: GetDefinitionOptions): Definition {
         const types = type.getBaseTypes();
         if (types.length === 0) {
-            return this.getObjectDefinition(type);
+            return this.getObjectDefinition(type, options);
         }
 
-        return types.reduce(getAllOfDefinitionReducer(this.childTypeFormatter), this.getObjectDefinition(type));
+        const refResolver = refResolverFromDefinitions(options?.definitions);
+        const reducer = getAllOfDefinitionReducer(this.childTypeFormatter, refResolver, options);
+        return types.reduce(reducer, this.getObjectDefinition(type, options));
     }
 
     public getChildren(type: ObjectType): BaseType[] {
@@ -59,7 +63,7 @@ export class ObjectTypeFormatter implements SubTypeFormatter {
         return uniqueArray(children);
     }
 
-    protected getObjectDefinition(type: ObjectType): Definition {
+    protected getObjectDefinition(type: ObjectType, options?: GetDefinitionOptions): Definition {
         let objectProperties = type.getProperties();
         const additionalProperties: BaseType | boolean = type.getAdditionalProperties();
 
@@ -76,7 +80,7 @@ export class ObjectTypeFormatter implements SubTypeFormatter {
             .map((property) => property.getName());
 
         const properties = preparedProperties.reduce((result: StringMap<Definition>, property) => {
-            result[property.getName()] = this.childTypeFormatter.getDefinition(property.getType());
+            result[property.getName()] = this.childTypeFormatter.getDefinition(property.getType(), options);
             return result;
         }, {});
 
@@ -91,7 +95,7 @@ export class ObjectTypeFormatter implements SubTypeFormatter {
                 : {
                       additionalProperties:
                           additionalProperties instanceof BaseType
-                              ? this.childTypeFormatter.getDefinition(additionalProperties)
+                              ? this.childTypeFormatter.getDefinition(additionalProperties, options)
                               : additionalProperties,
                   }),
         };

--- a/src/TypeFormatter/OptionalTypeFormatter.ts
+++ b/src/TypeFormatter/OptionalTypeFormatter.ts
@@ -2,6 +2,7 @@ import type { Definition } from "../Schema/Definition.js";
 import type { SubTypeFormatter } from "../SubTypeFormatter.js";
 import type { BaseType } from "../Type/BaseType.js";
 import { OptionalType } from "../Type/OptionalType.js";
+import type { GetDefinitionOptions } from "../TypeFormatter.js";
 import type { TypeFormatter } from "../TypeFormatter.js";
 
 export class OptionalTypeFormatter implements SubTypeFormatter {
@@ -10,8 +11,8 @@ export class OptionalTypeFormatter implements SubTypeFormatter {
     public supportsType(type: BaseType): boolean {
         return type instanceof OptionalType;
     }
-    public getDefinition(type: OptionalType): Definition {
-        return this.childTypeFormatter.getDefinition(type.getType());
+    public getDefinition(type: OptionalType, options?: GetDefinitionOptions): Definition {
+        return this.childTypeFormatter.getDefinition(type.getType(), options);
     }
     public getChildren(type: OptionalType): BaseType[] {
         return this.childTypeFormatter.getChildren(type.getType());

--- a/src/TypeFormatter/RestTypeFormatter.ts
+++ b/src/TypeFormatter/RestTypeFormatter.ts
@@ -2,6 +2,7 @@ import type { Definition } from "../Schema/Definition.js";
 import type { SubTypeFormatter } from "../SubTypeFormatter.js";
 import type { BaseType } from "../Type/BaseType.js";
 import { RestType } from "../Type/RestType.js";
+import type { GetDefinitionOptions } from "../TypeFormatter.js";
 import type { TypeFormatter } from "../TypeFormatter.js";
 
 export class RestTypeFormatter implements SubTypeFormatter {
@@ -11,8 +12,8 @@ export class RestTypeFormatter implements SubTypeFormatter {
         return type instanceof RestType;
     }
 
-    public getDefinition(type: RestType): Definition {
-        const definition = this.childTypeFormatter.getDefinition(type.getType());
+    public getDefinition(type: RestType, options?: GetDefinitionOptions): Definition {
+        const definition = this.childTypeFormatter.getDefinition(type.getType(), options);
         const title = type.getTitle();
 
         if (title !== null && typeof definition.items === "object") {

--- a/src/TypeFormatter/TupleTypeFormatter.ts
+++ b/src/TypeFormatter/TupleTypeFormatter.ts
@@ -5,6 +5,7 @@ import type { BaseType } from "../Type/BaseType.js";
 import { OptionalType } from "../Type/OptionalType.js";
 import { RestType } from "../Type/RestType.js";
 import { TupleType } from "../Type/TupleType.js";
+import type { GetDefinitionOptions } from "../TypeFormatter.js";
 import type { TypeFormatter } from "../TypeFormatter.js";
 import { derefType } from "../Utils/derefType.js";
 import { notNever } from "../Utils/notNever.js";
@@ -13,8 +14,9 @@ import { uniqueArray } from "../Utils/uniqueArray.js";
 function getRestAdditionalItems(
     restType: RestType,
     childTypeFormatter: TypeFormatter,
+    options?: GetDefinitionOptions,
 ): Definition["items"] | undefined {
-    const items = childTypeFormatter.getDefinition(restType).items;
+    const items = childTypeFormatter.getDefinition(restType, options).items;
     if (items !== undefined) {
         return items;
     }
@@ -22,7 +24,7 @@ function getRestAdditionalItems(
     if (!(resolvedType instanceof ArrayType)) {
         return undefined;
     }
-    const resolvedDef = childTypeFormatter.getDefinition(resolvedType);
+    const resolvedDef = childTypeFormatter.getDefinition(resolvedType, options);
     return resolvedDef.items;
 }
 
@@ -48,7 +50,7 @@ export class TupleTypeFormatter implements SubTypeFormatter {
         return type instanceof TupleType;
     }
 
-    public getDefinition(type: TupleType): Definition {
+    public getDefinition(type: TupleType, options?: GetDefinitionOptions): Definition {
         const subTypes = type.getTypes().filter(notNever);
 
         const requiredElements = subTypes.filter((t) => !(t instanceof OptionalType) && !(t instanceof RestType));
@@ -72,17 +74,21 @@ export class TupleTypeFormatter implements SubTypeFormatter {
         if (isUniformArray) {
             return {
                 type: "array",
-                items: this.childTypeFormatter.getDefinition(firstItemType),
+                items: this.childTypeFormatter.getDefinition(firstItemType, options),
                 minItems: requiredElements.length,
                 ...(restType ? {} : { maxItems: requiredElements.length + optionalElements.length }),
             };
         }
 
-        const requiredDefinitions = requiredElements.map((item) => this.childTypeFormatter.getDefinition(item));
-        const optionalDefinitions = optionalElements.map((item) => this.childTypeFormatter.getDefinition(item));
+        const requiredDefinitions = requiredElements.map((item) =>
+            this.childTypeFormatter.getDefinition(item, options),
+        );
+        const optionalDefinitions = optionalElements.map((item) =>
+            this.childTypeFormatter.getDefinition(item, options),
+        );
         const itemsTotal = requiredDefinitions.length + optionalDefinitions.length;
         const additionalItems =
-            restType !== undefined ? getRestAdditionalItems(restType, this.childTypeFormatter) : undefined;
+            restType !== undefined ? getRestAdditionalItems(restType, this.childTypeFormatter, options) : undefined;
 
         return {
             type: "array",

--- a/src/TypeFormatter/UnionTypeFormatter.ts
+++ b/src/TypeFormatter/UnionTypeFormatter.ts
@@ -5,6 +5,7 @@ import type { BaseType } from "../Type/BaseType.js";
 import { LiteralType } from "../Type/LiteralType.js";
 import { NeverType } from "../Type/NeverType.js";
 import { UnionType } from "../Type/UnionType.js";
+import type { GetDefinitionOptions } from "../TypeFormatter.js";
 import type { TypeFormatter } from "../TypeFormatter.js";
 import { derefType } from "../Utils/derefType.js";
 import { getTypeByKey } from "../Utils/typeKeys.js";
@@ -22,15 +23,15 @@ export class UnionTypeFormatter implements SubTypeFormatter {
     public supportsType(type: BaseType): boolean {
         return type instanceof UnionType;
     }
-    private getTypeDefinitions(type: UnionType) {
+    private getTypeDefinitions(type: UnionType, options?: GetDefinitionOptions) {
         return type
             .getTypes()
             .filter((item) => !(derefType(item) instanceof NeverType))
-            .map((item) => this.childTypeFormatter.getDefinition(item));
+            .map((item) => this.childTypeFormatter.getDefinition(item, options));
     }
 
-    private getJsonSchemaDiscriminatorDefinition(type: UnionType): Definition {
-        const definitions = this.getTypeDefinitions(type);
+    private getJsonSchemaDiscriminatorDefinition(type: UnionType, options?: GetDefinitionOptions): Definition {
+        const definitions = this.getTypeDefinitions(type, options);
         const discriminator = type.getDiscriminator();
 
         if (!discriminator) {
@@ -51,7 +52,9 @@ export class UnionTypeFormatter implements SubTypeFormatter {
             );
         }
 
-        const kindDefinitions = kindTypes.map((item) => this.childTypeFormatter.getDefinition(item as BaseType));
+        const kindDefinitions = kindTypes.map((item) =>
+            this.childTypeFormatter.getDefinition(item as BaseType, options),
+        );
 
         const allOf = [];
 
@@ -84,8 +87,8 @@ export class UnionTypeFormatter implements SubTypeFormatter {
 
         return { type: "object", properties, required: [discriminator], allOf };
     }
-    private getOpenApiDiscriminatorDefinition(type: UnionType): Definition {
-        const oneOf = this.getTypeDefinitions(type);
+    private getOpenApiDiscriminatorDefinition(type: UnionType, options?: GetDefinitionOptions): Definition {
+        const oneOf = this.getTypeDefinitions(type, options);
         const discriminator = type.getDiscriminator();
 
         if (!discriminator) {
@@ -99,14 +102,14 @@ export class UnionTypeFormatter implements SubTypeFormatter {
             oneOf,
         } as JSONSchema7;
     }
-    public getDefinition(type: UnionType): Definition {
+    public getDefinition(type: UnionType, options?: GetDefinitionOptions): Definition {
         const discriminator = type.getDiscriminator();
         if (discriminator !== undefined) {
-            if (this.discriminatorType === "open-api") return this.getOpenApiDiscriminatorDefinition(type);
-            return this.getJsonSchemaDiscriminatorDefinition(type);
+            if (this.discriminatorType === "open-api") return this.getOpenApiDiscriminatorDefinition(type, options);
+            return this.getJsonSchemaDiscriminatorDefinition(type, options);
         }
 
-        const definitions = this.getTypeDefinitions(type);
+        const definitions = this.getTypeDefinitions(type, options);
 
         const flattenedDefinitions: JSONSchema7[] = [];
 

--- a/src/Utils/allOfDefinition.ts
+++ b/src/Utils/allOfDefinition.ts
@@ -2,16 +2,37 @@ import type { Definition } from "../Schema/Definition.js";
 import type { RawTypeName } from "../Schema/RawType.js";
 import type { BaseType } from "../Type/BaseType.js";
 import type { TypeFormatter } from "../TypeFormatter.js";
+import type { GetDefinitionOptions } from "../TypeFormatter.js";
 import { uniqueArray } from "./uniqueArray.js";
 import { deepMerge } from "./deepMerge.js";
 import { derefType } from "./derefType.js";
 
+export type RefResolver = (ref: string) => Definition | undefined;
+
+export function refResolverFromDefinitions(definitions?: Record<string, Definition>): RefResolver | undefined {
+    if (!definitions) return undefined;
+    return (ref: string) => {
+        const key = ref.replace(/^#\/definitions\//, "");
+        return definitions[decodeURIComponent(key)];
+    };
+}
+
 // TODO: Can we do this at parse time? See heritage clause in interfaces.
 // TODO: We really only need this if the children use additionalProperties: false.
-export function getAllOfDefinitionReducer(childTypeFormatter: TypeFormatter) {
+export function getAllOfDefinitionReducer(
+    childTypeFormatter: TypeFormatter,
+    refResolver?: RefResolver,
+    options?: GetDefinitionOptions,
+) {
     // combine object instead of using allOf because allOf does not work well with additional properties
     return (definition: Definition, baseType: BaseType): Definition => {
-        const other = childTypeFormatter.getDefinition(derefType(baseType));
+        let other = childTypeFormatter.getDefinition(derefType(baseType), options);
+        if (refResolver && other.$ref && (!other.properties || Object.keys(other.properties).length === 0)) {
+            const resolved = refResolver(other.$ref);
+            if (resolved) {
+                other = resolved;
+            }
+        }
 
         definition.properties = deepMerge(other.properties || {}, definition.properties || {});
 

--- a/src/Utils/replaceCircularRefs.ts
+++ b/src/Utils/replaceCircularRefs.ts
@@ -1,0 +1,157 @@
+import type { Definition } from "../Schema/Definition.js";
+import type { StringMap } from "./StringMap.js";
+
+type AnyObj = Record<string, unknown>;
+
+/**
+ * Build lookup maps from definition objects/arrays to their definition names.
+ * An object matches a named definition if:
+ *  - it IS the definition object itself, or
+ *  - it shares the same `anyOf`/`oneOf` array reference as a named definition.
+ */
+function buildNameMaps(definitions: StringMap<Definition>): {
+    objToName: Map<object, string>;
+    arrayToName: Map<object, string>;
+} {
+    const objToName = new Map<object, string>();
+    const arrayToName = new Map<object, string>();
+
+    for (const [name, def] of Object.entries(definitions)) {
+        objToName.set(def as AnyObj, name);
+        if (def.anyOf) arrayToName.set(def.anyOf as unknown as object, name);
+        if (def.oneOf) arrayToName.set(def.oneOf as unknown as object, name);
+    }
+
+    return { objToName, arrayToName };
+}
+
+function resolveRefName(
+    val: object,
+    objToName: Map<object, string>,
+    arrayToName: Map<object, string>,
+): string | undefined {
+    const direct = objToName.get(val) ?? arrayToName.get(val);
+    if (direct) return direct;
+    const rec = val as AnyObj;
+    if (rec.anyOf && typeof rec.anyOf === "object") {
+        const name = arrayToName.get(rec.anyOf);
+        if (name) return name;
+    }
+    if (rec.oneOf && typeof rec.oneOf === "object") {
+        const name = arrayToName.get(rec.oneOf);
+        if (name) return name;
+    }
+    return undefined;
+}
+
+/**
+ * Walk the schema definitions and replace circular JS object references with JSON Schema `$ref` pointers.
+ *
+ * After recomputation with shallow copies, the cached definitions may contain circular JS object references
+ * (e.g. Node -> anyOf[0] -> children.items -> AliasType def whose anyOf IS the same array as Node.anyOf).
+ * These cycles must be replaced with `$ref` before the schema can be serialised.
+ */
+export function replaceCircularRefs(definitions: StringMap<Definition>, rootDefs?: Definition[]): void {
+    const { objToName, arrayToName } = buildNameMaps(definitions);
+
+    for (const def of Object.values(definitions)) {
+        walkAndReplace(def as AnyObj, objToName, arrayToName, new WeakSet());
+    }
+
+    if (rootDefs) {
+        for (const rd of rootDefs) {
+            walkAndReplace(rd as AnyObj, objToName, arrayToName, new WeakSet());
+        }
+    }
+}
+
+function walkAndReplace(
+    obj: AnyObj,
+    objToName: Map<object, string>,
+    arrayToName: Map<object, string>,
+    ancestors: WeakSet<object>,
+): void {
+    ancestors.add(obj);
+
+    for (const key of Object.keys(obj)) {
+        const val = obj[key];
+        if (typeof val !== "object" || val === null) continue;
+
+        if (ancestors.has(val)) {
+            const name = resolveRefName(val, objToName, arrayToName);
+            if (name) {
+                obj[key] = { $ref: `#/definitions/${name}` };
+            }
+            continue;
+        }
+
+        if (Array.isArray(val)) {
+            ancestors.add(val);
+            for (let i = 0; i < val.length; i++) {
+                const item = val[i] as unknown;
+                if (typeof item !== "object" || item === null) continue;
+
+                if (ancestors.has(item)) {
+                    const name = resolveRefName(item, objToName, arrayToName);
+                    if (name) val[i] = { $ref: `#/definitions/${name}` };
+                    continue;
+                }
+
+                walkAndReplace(item as AnyObj, objToName, arrayToName, ancestors);
+            }
+            ancestors.delete(val);
+            continue;
+        }
+
+        walkAndReplace(val as AnyObj, objToName, arrayToName, ancestors);
+    }
+
+    ancestors.delete(obj);
+}
+
+/**
+ * Deep-clone a schema definition, replacing any circular JS object references with JSON Schema `$ref` pointers.
+ * This produces an independent, acyclic copy safe for `JSON.stringify`.
+ */
+export function deepCloneDefinition(
+    def: Definition,
+    objToName: Map<object, string>,
+    arrayToName: Map<object, string>,
+): Definition {
+    return cloneValue(def, objToName, arrayToName, new WeakSet()) as Definition;
+}
+
+function cloneValue(
+    val: unknown,
+    objToName: Map<object, string>,
+    arrayToName: Map<object, string>,
+    ancestors: WeakSet<object>,
+): unknown {
+    if (typeof val !== "object" || val === null) return val;
+
+    if (ancestors.has(val)) {
+        const name = resolveRefName(val, objToName, arrayToName);
+        if (name) return { $ref: `#/definitions/${name}` };
+        // unmapped circular objects are replaced with {} in the clone
+        return {};
+    }
+
+    ancestors.add(val);
+
+    let result: unknown;
+    if (Array.isArray(val)) {
+        result = val.map((item) => cloneValue(item, objToName, arrayToName, ancestors));
+    } else {
+        const obj = val as AnyObj;
+        const clone: AnyObj = {};
+        for (const key of Object.keys(obj)) {
+            clone[key] = cloneValue(obj[key], objToName, arrayToName, ancestors);
+        }
+        result = clone;
+    }
+
+    ancestors.delete(val);
+    return result;
+}
+
+export { buildNameMaps };

--- a/test/unit/replaceCircularRefs.test.ts
+++ b/test/unit/replaceCircularRefs.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import type { Definition } from "../../src/Schema/Definition.js";
+import { buildNameMaps, deepCloneDefinition, replaceCircularRefs } from "../../src/Utils/replaceCircularRefs.js";
+
+describe("replaceCircularRefs", () => {
+    it("replaces circular references between two definitions with $ref", () => {
+        const defA: Definition = { type: "object", properties: {} };
+        const defB: Definition = { type: "object", properties: {} };
+        (defA.properties as Record<string, unknown>).child = defB;
+        (defB.properties as Record<string, unknown>).parent = defA;
+
+        const definitions: Record<string, Definition> = { A: defA, B: defB };
+        replaceCircularRefs(definitions);
+
+        assert.doesNotThrow(() => JSON.stringify(definitions));
+        const bProps = defB.properties as Record<string, unknown>;
+        assert.ok(bProps.parent && typeof bProps.parent === "object" && "$ref" in bProps.parent);
+        assert.strictEqual((bProps.parent as { $ref: string }).$ref, "#/definitions/A");
+    });
+
+    it("replaces self-reference in a definition with $ref", () => {
+        const def: Definition = { type: "object", properties: {} };
+        (def.properties as Record<string, unknown>).self = def;
+
+        const definitions: Record<string, Definition> = { Self: def };
+        replaceCircularRefs(definitions);
+
+        assert.doesNotThrow(() => JSON.stringify(definitions));
+        const selfRef = (def.properties as Record<string, unknown>).self as { $ref?: string };
+        assert.strictEqual(selfRef?.$ref, "#/definitions/Self");
+    });
+
+    it("updates rootDefs in-place when they participate in cycles", () => {
+        const defInDict: Definition = { type: "object", properties: {} };
+        const rootDef: Definition = { type: "object", properties: {} };
+        (defInDict.properties as Record<string, unknown>).root = rootDef;
+        (rootDef.properties as Record<string, unknown>).back = defInDict;
+
+        const definitions: Record<string, Definition> = { InDict: defInDict };
+        replaceCircularRefs(definitions, [rootDef]);
+
+        assert.doesNotThrow(() => JSON.stringify(definitions));
+        assert.doesNotThrow(() => JSON.stringify(rootDef));
+        const backRef = (rootDef.properties as Record<string, unknown>).back as { $ref?: string };
+        assert.strictEqual(backRef?.$ref, "#/definitions/InDict");
+    });
+});
+
+describe("buildNameMaps", () => {
+    it("maps definition objects and their anyOf/oneOf arrays to names", () => {
+        const anyOfArr = [{ type: "string" as const }, { type: "number" as const }];
+        const defWithAnyOf: Definition = { anyOf: anyOfArr };
+        const oneOfArr = [{ type: "boolean" as const }];
+        const defWithOneOf: Definition = { oneOf: oneOfArr };
+        const defPlain: Definition = { type: "object" };
+
+        const definitions: Record<string, Definition> = {
+            WithAnyOf: defWithAnyOf,
+            WithOneOf: defWithOneOf,
+            Plain: defPlain,
+        };
+        const { objToName, arrayToName } = buildNameMaps(definitions);
+
+        assert.strictEqual(objToName.get(defWithAnyOf), "WithAnyOf");
+        assert.strictEqual(objToName.get(defWithOneOf), "WithOneOf");
+        assert.strictEqual(objToName.get(defPlain), "Plain");
+        assert.strictEqual(arrayToName.get(anyOfArr), "WithAnyOf");
+        assert.strictEqual(arrayToName.get(oneOfArr), "WithOneOf");
+        assert.strictEqual(objToName.size, 3);
+        assert.strictEqual(arrayToName.size, 2);
+    });
+});
+
+describe("deepCloneDefinition", () => {
+    it("produces acyclic clone with $ref for circular references", () => {
+        const defA: Definition = { type: "object", properties: {} };
+        const defB: Definition = { type: "object", properties: {} };
+        (defA.properties as Record<string, unknown>).link = defB;
+        (defB.properties as Record<string, unknown>).link = defA;
+
+        const definitions: Record<string, Definition> = { A: defA, B: defB };
+        const { objToName, arrayToName } = buildNameMaps(definitions);
+
+        const clone = deepCloneDefinition(defA, objToName, arrayToName);
+
+        assert.doesNotThrow(() => JSON.stringify(clone));
+        assert.notStrictEqual(clone, defA);
+        const cloneProps = (clone as { properties?: Record<string, unknown> }).properties;
+        assert.ok(cloneProps);
+        const inner = cloneProps?.link as { properties?: Record<string, unknown> };
+        assert.ok(inner?.properties?.link && typeof inner.properties.link === "object");
+        assert.strictEqual((inner?.properties?.link as { $ref?: string }).$ref, "#/definitions/A");
+    });
+
+    it("replaces self-reference in clone with $ref", () => {
+        const def: Definition = { type: "object", properties: {} };
+        (def.properties as Record<string, unknown>).self = def;
+
+        const definitions: Record<string, Definition> = { Self: def };
+        const { objToName, arrayToName } = buildNameMaps(definitions);
+
+        const clone = deepCloneDefinition(def, objToName, arrayToName);
+
+        assert.doesNotThrow(() => JSON.stringify(clone));
+        const selfRef = (clone as { properties?: Record<string, unknown> }).properties?.self as { $ref?: string };
+        assert.strictEqual(selfRef?.$ref, "#/definitions/Self");
+    });
+});

--- a/test/valid-data/type-intersection-union-nested-circular/index.test.ts
+++ b/test/valid-data/type-intersection-union-nested-circular/index.test.ts
@@ -1,0 +1,6 @@
+import { assertValidSchema } from "../../utils.js";
+import { test } from "node:test";
+
+const testDir = "type-intersection-union-nested-circular";
+
+test(`valid-data - ${testDir}`, assertValidSchema(testDir, "MyObject"));

--- a/test/valid-data/type-intersection-union-nested-circular/main.ts
+++ b/test/valid-data/type-intersection-union-nested-circular/main.ts
@@ -1,0 +1,21 @@
+interface RE {
+    e: string;
+}
+
+interface RR {
+    r: string;
+}
+type Leaf = {
+    a?: string;
+}
+
+export type PlainNode = Leaf | PlainIntermediaryNode;
+export type Node = PlainNode | (PlainNode & RE) | (PlainNode & RR);
+
+export type PlainIntermediaryNode = Leaf & {
+    children: Node[];
+}
+
+export type MyObject = {
+    value: PlainNode;
+}

--- a/test/valid-data/type-intersection-union-nested-circular/schema.json
+++ b/test/valid-data/type-intersection-union-nested-circular/schema.json
@@ -1,0 +1,133 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/definitions/PlainNode"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    },
+    "Node": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PlainNode"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "a": {
+              "type": "string"
+            },
+            "e": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "e"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "a": {
+              "type": "string"
+            },
+            "children": {
+              "items": {
+                "$ref": "#/definitions/Node"
+              },
+              "type": "array"
+            },
+            "e": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "children",
+            "e"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "a": {
+              "type": "string"
+            },
+            "r": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "r"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "a": {
+              "type": "string"
+            },
+            "children": {
+              "items": {
+                "$ref": "#/definitions/Node"
+              },
+              "type": "array"
+            },
+            "r": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "children",
+            "r"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "PlainIntermediaryNode": {
+      "additionalProperties": false,
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "children": {
+          "items": {
+            "$ref": "#/definitions/Node"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "children"
+      ],
+      "type": "object"
+    },
+    "PlainNode": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "a": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/definitions/PlainIntermediaryNode"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Fix: missing properties for alias type with circular reference

## Summary

Fixes a bug where object **properties were missing** in generated JSON Schema when types combined **aliases**, **intersections**, **unions**, and **circular references** (e.g. a type like `Node` that includes `PlainIntermediaryNode` with `children: Node[]`).

The root cause was that during circular-reference handling, the formatter cache stored placeholder definitions before all members were resolved. Definitions that merged those placeholders (e.g. via `allOf` or intersection reduction) then kept incomplete data. This PR recomputes cached definitions after the definition map is complete, resolves `$ref` aliases when merging, and ensures the output schema is acyclic and serializable.

## Problem

For types such as:

- `PlainNode = Leaf | PlainIntermediaryNode`
- `Node = PlainNode | (PlainNode & RE) | (PlainNode & RR)`
- `PlainIntermediaryNode = Leaf & { children: Node[] }`

the generated schema could have **empty or missing `properties`** on some definitions because:

1. While processing a circular type, `CircularReferenceTypeFormatter` caches `{}` as a placeholder.
2. Intersection/union and alias formatters merge or delegate to that cache and get the placeholder.
3. Those merged definitions were never updated once the full definition was available.

## Solution

1. **Thread `GetDefinitionOptions` through formatters**  
   An optional `options` argument (with `definitions?: StringMap<Definition>`) is passed through the formatter chain so that merge logic can resolve `$ref` against the current definition map.

2. **Recompute cached definitions**  
   After all root child definitions are collected, `CircularReferenceTypeFormatter.recomputeCachedDefinitions(options)` is called. It clears and refills each cached definition using the child formatter, iterating until no definition changes (with a safety cap of 10 interations)  so that wrapper types (Alias, Annotated, etc.) propagate the fix.

3. **Resolve `$ref` when merging**  
   In `getAllOfDefinitionReducer`, when a base type yields a definition that is only a `$ref` (no or empty `properties`), the reducer resolves that `$ref` from the definitions map and merges the resolved properties instead of an empty object.

4. **Flatten intersection members**  
   In `IntersectionTypeFormatter`, nested `IntersectionType` members are flattened before reduction so that the circular-reference cache does not store incomplete intermediate intersection definitions.

5. **Replace circular JS references with `$ref` and clone**  
   New helpers in `replaceCircularRefs.ts`:
   - `replaceCircularRefs(definitions, rootDefs)` — replaces in-place circular object references with JSON Schema `$ref` pointers.
   - `deepCloneDefinition(def, objToName, arrayToName)` — builds an acyclic clone suitable for `JSON.stringify`.
   The schema generator uses these so the final schema is serializable and does not expose shared mutable objects.

## Changes

### Core

- **`TypeFormatter` / `SubTypeFormatter`**  
  `getDefinition(type, options?: GetDefinitionOptions)` now accepts optional `GetDefinitionOptions` (with `definitions`). 

- **`CircularReferenceTypeFormatter`**  
  - `getDefinition` forwards `options` to the child formatter.
  - New `recomputeCachedDefinitions(options?)` to recompute all cached definitions until stable.

- **`SchemaGenerator`**  
  - Builds the definition map, then calls `recomputeCachedDefinitions({ definitions })` when using `CircularReferenceTypeFormatter`.
  - Gets root type definitions with `definitions` in options, then runs `replaceCircularRefs(definitions, rootTypeDefinitions)`.
  - Uses `buildNameMaps` and `deepCloneDefinition` to produce the final schema and definitions so output is acyclic and independent of internal caches.

- **`getAllOfDefinitionReducer`**  
  Now takes an optional `RefResolver` and `GetDefinitionOptions`. When a definition is only a `$ref` (no/empty `properties`), it resolves the ref and merges the resolved properties.

- **`refResolverFromDefinitions`**  
  New helper in `allOfDefinition.ts` to build a `RefResolver` from the current definitions map. Used by `ObjectTypeFormatter` and `IntersectionTypeFormatter`.

- **`IntersectionTypeFormatter`**  
  - Uses `refResolverFromDefinitions` and the new reducer signature.
  - Flattens nested intersection members before reduction.
  - Handles union members in the intersection (first union expanded into branches; non-union members merged as base). 

- **`ObjectTypeFormatter`**  
  Uses `refResolverFromDefinitions` and passes `options` through to the reducer and child formatter.

### New utility

- **`src/Utils/replaceCircularRefs.ts`**  
  - `buildNameMaps(definitions)` — maps definition objects and their `anyOf`/`oneOf` arrays to definition names.
  - `replaceCircularRefs(definitions, rootDefs?)` — walks definitions and root defs and replaces circular JS references with `$ref`.
  - `deepCloneDefinition(def, objToName, arrayToName)` — returns an acyclic clone with cycles replaced by `$ref` (unmapped circular objects replaced with `{}`).

### Tests

- **Unit:** `test/unit/replaceCircularRefs.test.ts` — tests for `replaceCircularRefs`, `buildNameMaps`, and `deepCloneDefinition` (circular refs, self-refs, root defs).
- **Valid-data:** `test/valid-data/type-intersection-union-nested-circular` — regression case for intersection + union + nested types with a circular reference (`PlainIntermediaryNode` → `children: Node[]` → `Node`)