### PR TITLE
fix: preserve mapped indexed access annotations

### DIFF
--- a/factory/parser.ts
+++ b/factory/parser.ts
@@ -139,7 +139,7 @@ export function createParser(program: ts.Program, config: CompletedConfig, augme
         .addNodeParser(new PromiseNodeParser(typeChecker, chainNodeParser))
         .addNodeParser(new TypeReferenceNodeParser(typeChecker, chainNodeParser))
         .addNodeParser(new ExpressionWithTypeArgumentsNodeParser(typeChecker, chainNodeParser))
-        .addNodeParser(new IndexedAccessTypeNodeParser(typeChecker, chainNodeParser))
+        .addNodeParser(new IndexedAccessTypeNodeParser(typeChecker, withJsDoc(chainNodeParser)))
         .addNodeParser(new InferTypeNodeParser(typeChecker, chainNodeParser))
         .addNodeParser(new TypeofNodeParser(typeChecker, chainNodeParser))
         .addNodeParser(new MappedTypeNodeParser(chainNodeParser, config.additionalProperties))

--- a/test/valid-data/type-mapped-indexed-access-annotation/index.test.ts
+++ b/test/valid-data/type-mapped-indexed-access-annotation/index.test.ts
@@ -1,0 +1,7 @@
+import { assertValidSchema } from "../../utils";
+import { test } from "node:test";
+
+test(
+    "valid-data - type-mapped-indexed-access-annotation",
+    assertValidSchema("type-mapped-indexed-access-annotation", "Test"),
+);

--- a/test/valid-data/type-mapped-indexed-access-annotation/main.ts
+++ b/test/valid-data/type-mapped-indexed-access-annotation/main.ts
@@ -1,0 +1,19 @@
+type UrlTypes = {
+    /**
+     * @pattern ^https:\/\/.*$
+     */
+    url: string;
+};
+
+interface AllFields {
+    field1: string;
+    field2: string;
+}
+
+type UrlFields = {
+    [key in keyof AllFields]?: UrlTypes["url"];
+};
+
+export interface Test {
+    foo?: UrlFields;
+}

--- a/test/valid-data/type-mapped-indexed-access-annotation/schema.json
+++ b/test/valid-data/type-mapped-indexed-access-annotation/schema.json
@@ -1,0 +1,26 @@
+{
+  "$ref": "#/definitions/Test",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Test": {
+      "additionalProperties": false,
+      "properties": {
+        "foo": {
+          "additionalProperties": false,
+          "properties": {
+            "field1": {
+              "pattern": "^https:\\/\\/.*$",
+              "type": "string"
+            },
+            "field2": {
+              "pattern": "^https:\\/\\/.*$",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
Indexed access types were being parsed through the plain parser chain, which bypassed JSDoc-aware annotation handling for property signatures.

This caused mapped types that reuse a property type through indexed access to lose annotations from the referenced property type, including validation keywords such as pattern.

Route indexed access parsing through the JSDoc-aware parser and add a regression fixture.

Fixes #1431.