### PR TITLE
ci: publish only from main repository

### DIFF
--- a/.github/workflows/publish-auto.yml
+++ b/.github/workflows/publish-auto.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci') }}
+    if: ${{ github.repository_owner == 'vega' && !contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci') }}
 
     name: Make a release and publish to NPM
     steps:


### PR DESCRIPTION
Attempts to publish from forks always fail.