### PR TITLE
feat: support ReturnType<T>, type predicates, and fix typeof for function declarations

### DIFF
--- a/src/NodeParser/FunctionNodeParser.ts
+++ b/src/NodeParser/FunctionNodeParser.ts
@@ -3,8 +3,10 @@ import type { SubNodeParser } from "../SubNodeParser.js";
 import type { BaseType } from "../Type/BaseType.js";
 import { FunctionType } from "../Type/FunctionType.js";
 import type { FunctionOptions } from "../Config.js";
+import { BooleanType } from "../Type/BooleanType.js";
 import { NeverType } from "../Type/NeverType.js";
 import { DefinitionType } from "../Type/DefinitionType.js";
+import { VoidType } from "../Type/VoidType.js";
 import type { Context, NodeParser } from "../NodeParser.js";
 import { ObjectProperty, ObjectType } from "../Type/ObjectType.js";
 import { getKey } from "../Utils/nodeKey.js";
@@ -91,7 +93,16 @@ export function getReturnType(
         | ts.ConstructorTypeNode,
     context: Context,
 ): BaseType | undefined {
-    return node.type ? childNodeParser.createType(node.type, context) : undefined;
+    if (!node.type) {
+        return undefined;
+    }
+    // Type predicates (`value is T` / `asserts value is T` / `asserts value`)
+    // are compile-time-only constructs. At runtime, type guards return boolean
+    // and assertion functions return void.
+    if (ts.isTypePredicateNode(node.type)) {
+        return node.type.assertsModifier ? new VoidType() : new BooleanType();
+    }
+    return childNodeParser.createType(node.type, context);
 }
 
 export function getTypeName(

--- a/src/NodeParser/FunctionNodeParser.ts
+++ b/src/NodeParser/FunctionNodeParser.ts
@@ -34,7 +34,11 @@ export class FunctionNodeParser implements SubNodeParser {
         }
 
         const name = getTypeName(node);
-        const func = new FunctionType(node, getNamedArguments(this.childNodeParser, node, context));
+        const func = new FunctionType(
+            node,
+            getNamedArguments(this.childNodeParser, node, context),
+            getReturnType(this.childNodeParser, node, context),
+        );
 
         return name ? new DefinitionType(name, func) : func;
     }
@@ -75,6 +79,19 @@ export function getNamedArguments(
         }),
         false,
     );
+}
+
+export function getReturnType(
+    childNodeParser: NodeParser,
+    node:
+        | ts.FunctionTypeNode
+        | ts.FunctionExpression
+        | ts.FunctionDeclaration
+        | ts.ArrowFunction
+        | ts.ConstructorTypeNode,
+    context: Context,
+): BaseType | undefined {
+    return node.type ? childNodeParser.createType(node.type, context) : undefined;
 }
 
 export function getTypeName(

--- a/src/NodeParser/TypeofNodeParser.ts
+++ b/src/NodeParser/TypeofNodeParser.ts
@@ -8,6 +8,7 @@ import { getKey } from "../Utils/nodeKey.js";
 import { LiteralType } from "../Type/LiteralType.js";
 import { NeverType } from "../Type/NeverType.js";
 import { FunctionType } from "../Type/FunctionType.js";
+import { getNamedArguments, getReturnType } from "./FunctionNodeParser.js";
 import { LogicError } from "../Error/Errors.js";
 
 export class TypeofNodeParser implements SubNodeParser {
@@ -63,8 +64,12 @@ export class TypeofNodeParser implements SubNodeParser {
             return this.childNodeParser.createType(valueDec.initializer, context);
         }
 
-        if (valueDec.kind === ts.SyntaxKind.FunctionDeclaration) {
-            return new FunctionType(<ts.FunctionDeclaration>valueDec);
+        if (ts.isFunctionDeclaration(valueDec)) {
+            return new FunctionType(
+                valueDec,
+                getNamedArguments(this.childNodeParser, valueDec, context),
+                getReturnType(this.childNodeParser, valueDec, context),
+            );
         }
 
         throw new LogicError(valueDec, `Invalid type query for this declaration. (ts.SyntaxKind = ${valueDec.kind})`);

--- a/src/Type/FunctionType.ts
+++ b/src/Type/FunctionType.ts
@@ -8,6 +8,7 @@ export class FunctionType extends BaseType {
     constructor(
         node?: ts.FunctionTypeNode | ts.FunctionExpression | ts.FunctionDeclaration | ts.ArrowFunction,
         protected namedArguments?: ObjectType,
+        protected returnType?: BaseType,
     ) {
         super();
 
@@ -26,5 +27,9 @@ export class FunctionType extends BaseType {
 
     public getNamedArguments(): ObjectType | undefined {
         return this.namedArguments;
+    }
+
+    public getReturnType(): BaseType | undefined {
+        return this.returnType;
     }
 }

--- a/src/Utils/isAssignableTo.ts
+++ b/src/Utils/isAssignableTo.ts
@@ -124,15 +124,42 @@ export function isAssignableTo(
         return true;
     }
 
-    // Function types may need to add to inferMap
+    // Function types: compare parameters and return types, supporting infer in both positions
+    // (e.g. Parameters<T> uses (...args: infer P) => any, ReturnType<T> uses (...args: any) => infer R)
     if (target instanceof FunctionType) {
         if (source instanceof FunctionType) {
-            return isAssignableTo(
-                target.getNamedArguments() ?? new NeverType(),
-                source.getNamedArguments() ?? new NeverType(),
-                inferMap,
-                insideTypes,
-            );
+            const targetArgs = target.getNamedArguments();
+            const sourceArgs = source.getNamedArguments();
+
+            if (targetArgs instanceof InferType) {
+                // Populates inferMap with the inferred parameter type
+                isAssignableTo(targetArgs, sourceArgs ?? new NeverType(), inferMap, insideTypes);
+            } else {
+                const targetProps = targetArgs ? getObjectProperties(targetArgs) : [];
+                // All-any params (e.g. (...args: any)) match any function signature
+                const targetParamsAcceptAny =
+                    targetProps.length === 0 || targetProps.every((p) => derefType(p.getType()) instanceof AnyType);
+
+                if (!targetParamsAcceptAny) {
+                    const argsAssignable = isAssignableTo(
+                        targetArgs!,
+                        sourceArgs ?? new NeverType(),
+                        inferMap,
+                        insideTypes,
+                    );
+                    if (!argsAssignable) {
+                        return false;
+                    }
+                }
+            }
+
+            const targetReturn = target.getReturnType();
+            const sourceReturn = source.getReturnType();
+            if (targetReturn && sourceReturn) {
+                return isAssignableTo(targetReturn, sourceReturn, inferMap, insideTypes);
+            }
+
+            return true;
         }
 
         return false;

--- a/test/valid-data/type-predicate/index.test.ts
+++ b/test/valid-data/type-predicate/index.test.ts
@@ -1,0 +1,4 @@
+import { assertValidSchema } from "../../utils";
+import { test } from "node:test";
+
+test("valid-data - type-predicate", assertValidSchema("type-predicate", "*"));

--- a/test/valid-data/type-predicate/main.ts
+++ b/test/valid-data/type-predicate/main.ts
@@ -1,0 +1,39 @@
+// Named function declarations with type predicates
+function isString(value: unknown): value is string {
+    return typeof value === "string";
+}
+
+function assertIsString(value: unknown): asserts value is string {
+    if (typeof value !== "string") {
+        throw new Error("Not a string");
+    }
+}
+
+function assertTruthy(value: unknown): asserts value {
+    if (!value) {
+        throw new Error("Not truthy");
+    }
+}
+
+// Arrow function with type predicate
+const isNumber = (value: unknown): value is number => typeof value === "number";
+
+// Interface using typeof
+export interface MyObject {
+    isString: typeof isString;
+    assertIsString: typeof assertIsString;
+    assertTruthy: typeof assertTruthy;
+    name: string;
+}
+
+// Inline function type literals with type predicates
+export interface WithInlinePredicates {
+    check: (value: unknown) => value is string;
+    assert: (value: unknown) => asserts value;
+    assertIs: (value: unknown) => asserts value is number;
+}
+
+// this-based type predicates
+export interface MyClass {
+    isValid(): this is MyClass & { valid: true };
+}

--- a/test/valid-data/type-predicate/schema.json
+++ b/test/valid-data/type-predicate/schema.json
@@ -1,0 +1,195 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyClass": {
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "assertIsString": {
+          "$comment": "(value: unknown) => asserts value is string",
+          "properties": {
+            "namedArgs": {
+              "additionalProperties": false,
+              "properties": {
+                "value": {}
+              },
+              "required": [
+                "value"
+              ],
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "assertTruthy": {
+          "$comment": "(value: unknown) => asserts value",
+          "properties": {
+            "namedArgs": {
+              "additionalProperties": false,
+              "properties": {
+                "value": {}
+              },
+              "required": [
+                "value"
+              ],
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "isString": {
+          "$comment": "(value: unknown) => value is string",
+          "properties": {
+            "namedArgs": {
+              "additionalProperties": false,
+              "properties": {
+                "value": {}
+              },
+              "required": [
+                "value"
+              ],
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "isString",
+        "assertIsString",
+        "assertTruthy",
+        "name"
+      ],
+      "type": "object"
+    },
+    "WithInlinePredicates": {
+      "additionalProperties": false,
+      "properties": {
+        "assert": {
+          "$comment": "(value: unknown) => asserts value",
+          "properties": {
+            "namedArgs": {
+              "additionalProperties": false,
+              "properties": {
+                "value": {}
+              },
+              "required": [
+                "value"
+              ],
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "assertIs": {
+          "$comment": "(value: unknown) => asserts value is number",
+          "properties": {
+            "namedArgs": {
+              "additionalProperties": false,
+              "properties": {
+                "value": {}
+              },
+              "required": [
+                "value"
+              ],
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "check": {
+          "$comment": "(value: unknown) => value is string",
+          "properties": {
+            "namedArgs": {
+              "additionalProperties": false,
+              "properties": {
+                "value": {}
+              },
+              "required": [
+                "value"
+              ],
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "check",
+        "assert",
+        "assertIs"
+      ],
+      "type": "object"
+    },
+    "assertIsString": {
+      "$comment": "(value: unknown) => asserts value is string",
+      "properties": {
+        "namedArgs": {
+          "additionalProperties": false,
+          "properties": {
+            "value": {}
+          },
+          "required": [
+            "value"
+          ],
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "assertTruthy": {
+      "$comment": "(value: unknown) => asserts value",
+      "properties": {
+        "namedArgs": {
+          "additionalProperties": false,
+          "properties": {
+            "value": {}
+          },
+          "required": [
+            "value"
+          ],
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "isNumber": {
+      "$comment": "(value: unknown) => value is number",
+      "properties": {
+        "namedArgs": {
+          "additionalProperties": false,
+          "properties": {
+            "value": {}
+          },
+          "required": [
+            "value"
+          ],
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "isString": {
+      "$comment": "(value: unknown) => value is string",
+      "properties": {
+        "namedArgs": {
+          "additionalProperties": false,
+          "properties": {
+            "value": {}
+          },
+          "required": [
+            "value"
+          ],
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  }
+}

--- a/test/valid-data/type-typeof-function/schema.json
+++ b/test/valid-data/type-typeof-function/schema.json
@@ -5,7 +5,22 @@
       "additionalProperties": false,
       "properties": {
         "checkServerIdentity": {
-          "$comment": "(hostname: string) => Error | undefined"
+          "$comment": "(hostname: string) => Error | undefined",
+          "properties": {
+            "namedArgs": {
+              "additionalProperties": false,
+              "properties": {
+                "hostname": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "hostname"
+              ],
+              "type": "object"
+            }
+          },
+          "type": "object"
         },
         "otherProp": {
           "type": "string"

--- a/test/valid-data/type-utility-parameters/index.test.ts
+++ b/test/valid-data/type-utility-parameters/index.test.ts
@@ -1,0 +1,4 @@
+import { assertValidSchema } from "../../utils";
+import { test } from "node:test";
+
+test("valid-data - type-utility-parameters", assertValidSchema("type-utility-parameters", "MyParameters"));

--- a/test/valid-data/type-utility-parameters/main.ts
+++ b/test/valid-data/type-utility-parameters/main.ts
@@ -1,0 +1,5 @@
+function myFunction(a: string, b: number) {
+    return { a, b };
+}
+
+export type MyParameters = Parameters<typeof myFunction>;

--- a/test/valid-data/type-utility-parameters/schema.json
+++ b/test/valid-data/type-utility-parameters/schema.json
@@ -1,0 +1,22 @@
+{
+  "$ref": "#/definitions/MyParameters",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyParameters": {
+      "additionalProperties": false,
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "a",
+        "b"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/test/valid-data/type-utility-return-type-arrow/index.test.ts
+++ b/test/valid-data/type-utility-return-type-arrow/index.test.ts
@@ -1,0 +1,7 @@
+import { assertValidSchema } from "../../utils";
+import { test } from "node:test";
+
+test(
+    "valid-data - type-utility-return-type-arrow",
+    assertValidSchema("type-utility-return-type-arrow", "MyReturnType"),
+);

--- a/test/valid-data/type-utility-return-type-arrow/main.ts
+++ b/test/valid-data/type-utility-return-type-arrow/main.ts
@@ -1,0 +1,3 @@
+const myArrowFunc = (x: string): number => x.length;
+
+export type MyReturnType = ReturnType<typeof myArrowFunc>;

--- a/test/valid-data/type-utility-return-type-arrow/schema.json
+++ b/test/valid-data/type-utility-return-type-arrow/schema.json
@@ -1,0 +1,9 @@
+{
+  "$ref": "#/definitions/MyReturnType",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyReturnType": {
+      "type": "number"
+    }
+  }
+}

--- a/test/valid-data/type-utility-return-type/index.test.ts
+++ b/test/valid-data/type-utility-return-type/index.test.ts
@@ -1,0 +1,4 @@
+import { assertValidSchema } from "../../utils";
+import { test } from "node:test";
+
+test("valid-data - type-utility-return-type", assertValidSchema("type-utility-return-type", "MyReturnType"));

--- a/test/valid-data/type-utility-return-type/main.ts
+++ b/test/valid-data/type-utility-return-type/main.ts
@@ -1,0 +1,5 @@
+function myFunction(a: string, b: number): { name: string; value: number } {
+    return { name: a, value: b };
+}
+
+export type MyReturnType = ReturnType<typeof myFunction>;

--- a/test/valid-data/type-utility-return-type/schema.json
+++ b/test/valid-data/type-utility-return-type/schema.json
@@ -1,0 +1,22 @@
+{
+  "$ref": "#/definitions/MyReturnType",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyReturnType": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #2491

## Summary

Builds on #2495 which added `Parameters<T>` support for inline function types.

- **`ReturnType<T>`** - `FunctionType` now tracks return types, enabling `infer` in the return position
- **Type predicate handling** - `value is T` resolves to `boolean`, `asserts value` resolves to `void`
- **`TypeofNodeParser` fix** - `typeof` now creates `FunctionType` with full parameter and return type info, so `Parameters<typeof foo>` and `ReturnType<typeof foo>` work for function declarations

### Changes

- **`FunctionType`** - added `returnType` field and `getReturnType()` accessor
- **`FunctionNodeParser`** - extracted `getReturnType()` helper; handles `TypePredicateNode`
- **`TypeofNodeParser`** - creates `FunctionType` with full parameter and return type info for function declarations
- **`isAssignableTo`** - extended function type comparison to support `infer` in return position and skip structural comparison when target params are all `any`-typed

## Test plan

- [x] Added `type-utility-return-type` - `ReturnType<typeof fn>` with function declaration
- [x] Added `type-utility-return-type-arrow` - `ReturnType<typeof fn>` with arrow function
- [x] Added `type-utility-parameters` - `Parameters<typeof foo>` (covers the `typeof` path not tested by #2495)
- [x] Added `type-predicate` - type guards and assertion functions
- [x] Updated `type-typeof-function` golden schema for new `namedArgs` output
- [x] All existing tests pass