### PR TITLE
feat: fall back to type checker for non-generic type aliases with unresolvable utility types

### DIFF
--- a/src/NodeParser/TypeAliasNodeParser.ts
+++ b/src/NodeParser/TypeAliasNodeParser.ts
@@ -1,10 +1,19 @@
 import ts from "typescript";
-import type { Context, NodeParser } from "../NodeParser.js";
+import { Context, type NodeParser } from "../NodeParser.js";
 import type { SubNodeParser } from "../SubNodeParser.js";
 import { AliasType } from "../Type/AliasType.js";
+import { AnnotatedType } from "../Type/AnnotatedType.js";
+import { ArrayType } from "../Type/ArrayType.js";
 import type { BaseType } from "../Type/BaseType.js";
+import { DefinitionType } from "../Type/DefinitionType.js";
+import { IntersectionType } from "../Type/IntersectionType.js";
 import { NeverType } from "../Type/NeverType.js";
-import type { ReferenceType } from "../Type/ReferenceType.js";
+import { OptionalType } from "../Type/OptionalType.js";
+import { ReferenceType } from "../Type/ReferenceType.js";
+import { RestType } from "../Type/RestType.js";
+import { TupleType } from "../Type/TupleType.js";
+import { UnionType } from "../Type/UnionType.js";
+import { isErroredUnknownType } from "../Type/UnknownType.js";
 import { getKey } from "../Utils/nodeKey.js";
 
 export class TypeAliasNodeParser implements SubNodeParser {
@@ -18,7 +27,8 @@ export class TypeAliasNodeParser implements SubNodeParser {
     }
 
     public createType(node: ts.TypeAliasDeclaration, context: Context, reference?: ReferenceType): BaseType {
-        if (node.typeParameters?.length) {
+        const isGeneric = !!node.typeParameters?.length;
+        if (isGeneric) {
             for (const typeParam of node.typeParameters) {
                 const nameSymbol = this.typeChecker.getSymbolAtLocation(typeParam.name)!;
                 context.pushParameter(nameSymbol.name);
@@ -37,7 +47,39 @@ export class TypeAliasNodeParser implements SubNodeParser {
             reference.setName(name);
         }
 
-        const type = this.childNodeParser.createType(node.type, context);
+        // For non-generic type aliases, snapshot the resolved type BEFORE AST parsing.
+        // The parser chain (e.g. PromiseNodeParser) can mutate the type checker's cache,
+        // so we must capture it first. InTypeAlias expands type references inline,
+        // NoTruncation prevents incomplete synthesized nodes.
+        let resolvedTypeNode: ts.TypeNode | undefined;
+        if (!isGeneric) {
+            const resolvedTsType = this.typeChecker.getTypeAtLocation(node);
+            const typeNode = this.typeChecker.typeToTypeNode(
+                resolvedTsType,
+                undefined,
+                ts.NodeBuilderFlags.IgnoreErrors | ts.NodeBuilderFlags.InTypeAlias | ts.NodeBuilderFlags.NoTruncation,
+            );
+            if (typeNode) {
+                resolvedTypeNode = typeNode;
+            }
+        }
+
+        let type = this.childNodeParser.createType(node.type, context);
+
+        // Fall back to the pre-resolved type when AST parsing produced an errored UnknownType.
+        // Only keep the fallback if it actually resolved without errors itself.
+        if (resolvedTypeNode && hasErroredUnknown(type)) {
+            try {
+                setParentsRecursive(resolvedTypeNode);
+                const fallback = this.childNodeParser.createType(resolvedTypeNode, new Context(node));
+                if (!hasErroredUnknown(fallback)) {
+                    type = fallback;
+                }
+            } catch {
+                // keep original type
+            }
+        }
+
         if (type instanceof NeverType) {
             return new NeverType();
         }
@@ -54,4 +96,39 @@ export class TypeAliasNodeParser implements SubNodeParser {
 
         return argumentIds.length ? `${fullName}<${argumentIds.join(",")}>` : fullName;
     }
+}
+
+function setParentsRecursive(node: ts.Node): void {
+    ts.forEachChild(node, (child) => {
+        (child as any).parent = node;
+        setParentsRecursive(child);
+    });
+}
+
+function hasErroredUnknown(type: BaseType, seen = new Set<BaseType>()): boolean {
+    if (seen.has(type)) return false;
+    seen.add(type);
+
+    if (isErroredUnknownType(type)) return true;
+
+    if (type instanceof ReferenceType) {
+        return type.hasType() ? hasErroredUnknown(type.getType(), seen) : false;
+    }
+    if (
+        type instanceof AliasType ||
+        type instanceof AnnotatedType ||
+        type instanceof DefinitionType ||
+        type instanceof OptionalType ||
+        type instanceof RestType
+    ) {
+        return hasErroredUnknown(type.getType(), seen);
+    }
+    if (type instanceof ArrayType) {
+        return hasErroredUnknown(type.getItem(), seen);
+    }
+    if (type instanceof UnionType || type instanceof IntersectionType || type instanceof TupleType) {
+        return type.getTypes().some((t) => hasErroredUnknown(t, seen));
+    }
+
+    return false;
 }

--- a/src/NodeParser/TypeLiteralNodeParser.ts
+++ b/src/NodeParser/TypeLiteralNodeParser.ts
@@ -40,15 +40,15 @@ export class TypeLiteralNodeParser implements SubNodeParser {
 
         const properties = node.members
             .filter(
-                (element): element is PropertySignature | MethodSignature =>
-                    ts.isPropertySignature(element) || ts.isMethodSignature(element),
+                (element): element is (PropertySignature | MethodSignature) & { type: ts.TypeNode } =>
+                    (ts.isPropertySignature(element) || ts.isMethodSignature(element)) && element.type !== undefined,
             )
             .filter((propertyNode) => !isNodeHidden(propertyNode))
             .map(
                 (propertyNode) =>
                     new ObjectProperty(
                         this.getPropertyName(propertyNode.name),
-                        this.childNodeParser.createType(propertyNode.type!, context),
+                        this.childNodeParser.createType(propertyNode.type, context),
                         !propertyNode.questionToken,
                     ),
             )

--- a/test/config/type-awaited-return-type/index.test.ts
+++ b/test/config/type-awaited-return-type/index.test.ts
@@ -1,0 +1,20 @@
+import { it } from "node:test";
+import { assertConfigSchema } from "../../utils";
+
+it(
+    "config - type-awaited-return-type",
+    assertConfigSchema(
+        "type-awaited-return-type",
+        {
+            type: [
+                "MyArrayType",
+                "MyInferredType",
+                "MyNestedRefType",
+                "MyPrimitiveType",
+                "MyUnionType",
+                "MyUnresolvableType",
+            ],
+        },
+        true,
+    ),
+);

--- a/test/config/type-awaited-return-type/main.ts
+++ b/test/config/type-awaited-return-type/main.ts
@@ -1,0 +1,15 @@
+import type {
+    returnsArray,
+    returnsInferred,
+    returnsNestedRef,
+    returnsPrimitive,
+    returnsUnion,
+    returnsUnresolvable,
+} from "./source.js";
+
+export type MyArrayType = Awaited<ReturnType<typeof returnsArray>>;
+export type MyInferredType = Awaited<ReturnType<typeof returnsInferred>>;
+export type MyNestedRefType = Awaited<ReturnType<typeof returnsNestedRef>>;
+export type MyPrimitiveType = Awaited<ReturnType<typeof returnsPrimitive>>;
+export type MyUnionType = Awaited<ReturnType<typeof returnsUnion>>;
+export type MyUnresolvableType = Awaited<ReturnType<typeof returnsUnresolvable>>;

--- a/test/config/type-awaited-return-type/schema.json
+++ b/test/config/type-awaited-return-type/schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyArrayType": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "bar": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "bar"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "MyInferredType": {
+      "additionalProperties": false,
+      "properties": {
+        "bar": {
+          "type": "string"
+        },
+        "qux": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "bar",
+        "qux"
+      ],
+      "type": "object"
+    },
+    "MyNestedRefType": {
+      "additionalProperties": false,
+      "properties": {
+        "bar": {
+          "additionalProperties": false,
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "value"
+          ],
+          "type": "object"
+        },
+        "count": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "bar",
+        "count"
+      ],
+      "type": "object"
+    },
+    "MyPrimitiveType": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "not": {}
+        }
+      ]
+    },
+    "MyUnionType": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "bar",
+              "type": "string"
+            },
+            "value": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "baz",
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "MyUnresolvableType": {
+      "description": "Failed to correctly infer type"
+    }
+  }
+}

--- a/test/config/type-awaited-return-type/schema.json
+++ b/test/config/type-awaited-return-type/schema.json
@@ -64,10 +64,10 @@
     "MyPrimitiveType": {
       "anyOf": [
         {
-          "type": "string"
+          "not": {}
         },
         {
-          "not": {}
+          "type": "string"
         }
       ]
     },

--- a/test/config/type-awaited-return-type/source.ts
+++ b/test/config/type-awaited-return-type/source.ts
@@ -1,0 +1,34 @@
+interface Bar {
+    id: string;
+    value: string;
+}
+
+export async function returnsArray() {
+    return [{ bar: "a" }, { bar: "b" }];
+}
+
+export async function returnsInferred() {
+    return { bar: "baz", qux: 42 };
+}
+
+export async function returnsNestedRef() {
+    return { bar: {} as Bar, count: 42 };
+}
+
+export async function returnsPrimitive(): Promise<string | undefined> {
+    return "bar";
+}
+
+export async function returnsUnion() {
+    if (Math.random() > 0.5) {
+        return { kind: "bar" as const, value: 1 };
+    }
+    return { kind: "baz" as const, value: "qux" };
+}
+
+export async function returnsUnresolvable() {
+    return {
+        name: "test",
+        handler: (x: number) => x * 2,
+    };
+}

--- a/test/config/type-awaited-return-type/tsconfig.json
+++ b/test/config/type-awaited-return-type/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "files": ["main.ts", "source.ts"]
+}

--- a/test/config/type-awaited-return-type/tsconfig.json
+++ b/test/config/type-awaited-return-type/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "target": "ES2022",
     "module": "ES2022",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "skipLibCheck": true
   },


### PR DESCRIPTION
## Summary

- For non-generic type aliases like `Awaited<ReturnType<typeof fn>>`, AST-based parsing can fail when utility types can't be resolved structurally, producing `"Failed to correctly infer type"`
- Pre-resolves these aliases via the type checker before AST parsing, then falls back to the resolved type node when an errored `UnknownType` is detected
- Uses `InTypeAlias` and `NoTruncation` flags to produce complete synthesized nodes
- Sets parent references on synthesized nodes lazily (only when fallback fires)
- Wraps fallback in try/catch with quality check — only keeps the fallback if it resolves without errors

## Test plan

- [x] `type-awaited-return-type-inferred` — object return type
- [x] `type-awaited-return-type-array` — array return type
- [x] `type-awaited-return-type-union` — discriminated union return type
- [x] `type-awaited-return-type-nested-ref` — nested interface reference
- [x] `type-awaited-return-type-primitive` — `string | undefined` return type
- [x] `type-awaited-return-type-break` — function-valued properties (graceful degradation)
- [x] All existing tests pass