### PR TITLE
fix: prevent false assignability for types with methods like Map and Set

### DIFF
--- a/src/NodeParser/InterfaceAndClassNodeParser.ts
+++ b/src/NodeParser/InterfaceAndClassNodeParser.ts
@@ -61,7 +61,20 @@ export class InterfaceAndClassNodeParser implements SubNodeParser {
             }
         }
 
-        return new ObjectType(id, this.getBaseTypes(node, context), properties, additionalProperties);
+        const methodNames: string[] = [];
+        for (const m of node.members) {
+            if ((ts.isMethodSignature(m) || ts.isMethodDeclaration(m)) && m.name) {
+                methodNames.push(this.getPropertyName(m.name));
+            }
+        }
+        return new ObjectType(
+            id,
+            this.getBaseTypes(node, context),
+            properties,
+            additionalProperties,
+            false,
+            methodNames,
+        );
     }
 
     /**

--- a/src/Type/ObjectType.ts
+++ b/src/Type/ObjectType.ts
@@ -27,6 +27,9 @@ export class ObjectType extends BaseType {
         private additionalProperties: BaseType | boolean,
         // whether the object is `object`
         private nonPrimitive: boolean = false,
+        // Method names not included in properties — used by isAssignableTo to
+        // prevent false structural matches against types with methods (e.g. Map).
+        private methodNames: readonly string[] = [],
     ) {
         super();
     }
@@ -46,5 +49,8 @@ export class ObjectType extends BaseType {
     }
     public getNonPrimitive(): boolean {
         return this.nonPrimitive;
+    }
+    public getMethodNames(): readonly string[] {
+        return this.methodNames;
     }
 }

--- a/src/Utils/isAssignableTo.ts
+++ b/src/Utils/isAssignableTo.ts
@@ -218,6 +218,17 @@ export function isAssignableTo(
         } else if (source instanceof ObjectType) {
             const sourceMembers = getObjectProperties(source);
 
+            // If the target has methods not represented as properties, source must also
+            // have them as properties or methods. This prevents false positives like
+            // {size: number} being considered assignable to Map<K,V>.
+            const targetMethods = target.getMethodNames();
+            if (targetMethods.length > 0) {
+                const sourceNames = new Set([...sourceMembers.map((m) => m.getName()), ...source.getMethodNames()]);
+                if (targetMethods.some((name) => !sourceNames.has(name))) {
+                    return false;
+                }
+            }
+
             // Check if target has properties in common with source
             const inCommon = targetMembers.some((targetMember) =>
                 sourceMembers.some((sourceMember) => targetMember.getName() === sourceMember.getName()),

--- a/test/config/type-awaited-return-type-break/index.test.ts
+++ b/test/config/type-awaited-return-type-break/index.test.ts
@@ -1,0 +1,13 @@
+import { it } from "node:test";
+import { assertConfigSchema } from "../../utils";
+
+it(
+    "config - type-awaited-return-type-break",
+    assertConfigSchema(
+        "type-awaited-return-type-break",
+        {
+            type: "MyType",
+        },
+        true,
+    ),
+);

--- a/test/config/type-awaited-return-type-break/main.ts
+++ b/test/config/type-awaited-return-type-break/main.ts
@@ -1,0 +1,3 @@
+import type { MyType } from "./source.js";
+
+export type { MyType };

--- a/test/config/type-awaited-return-type-break/schema.json
+++ b/test/config/type-awaited-return-type-break/schema.json
@@ -1,0 +1,58 @@
+{
+  "$ref": "#/definitions/MyType",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Immutable<Bar>": {
+      "additionalProperties": false,
+      "properties": {
+        "boost": {
+          "$ref": "#/definitions/Immutable%3Cboolean%3E"
+        },
+        "geo": {
+          "$ref": "#/definitions/Immutable%3C%5Bnumber%2Cnumber%5D%3E"
+        },
+        "id": {
+          "$ref": "#/definitions/Immutable%3Cstring%3E"
+        },
+        "size": {
+          "$ref": "#/definitions/Immutable%3Cnumber%3E"
+        }
+      },
+      "required": [
+        "id",
+        "size",
+        "boost",
+        "geo"
+      ],
+      "type": "object"
+    },
+    "Immutable<[number,number]>": {
+      "additionalProperties": false,
+      "properties": {
+        "0": {
+          "$ref": "#/definitions/Immutable%3Cnumber%3E"
+        },
+        "1": {
+          "$ref": "#/definitions/Immutable%3Cnumber%3E"
+        }
+      },
+      "required": [
+        "0",
+        "1"
+      ],
+      "type": "object"
+    },
+    "Immutable<boolean>": {
+      "type": "boolean"
+    },
+    "Immutable<number>": {
+      "type": "number"
+    },
+    "Immutable<string>": {
+      "type": "string"
+    },
+    "MyType": {
+      "$ref": "#/definitions/Immutable%3CBar%3E"
+    }
+  }
+}

--- a/test/config/type-awaited-return-type-break/source.ts
+++ b/test/config/type-awaited-return-type-break/source.ts
@@ -1,0 +1,17 @@
+type ImmutablePrimitive = undefined | null | boolean | string | number | ((...args: any[]) => any);
+type ImmutableObject<T> = { readonly [K in keyof T]: Immutable<T[K]> };
+
+export type Immutable<T> = T extends ImmutablePrimitive
+    ? T
+    : T extends Map<infer K, infer V>
+      ? ReadonlyMap<Immutable<K>, Immutable<V>>
+      : ImmutableObject<T>;
+
+export interface Bar {
+    id: string;
+    size: number;
+    boost: boolean;
+    geo: [number, number];
+}
+
+export type MyType = Immutable<Bar>;

--- a/test/config/type-awaited-return-type-break/tsconfig.json
+++ b/test/config/type-awaited-return-type-break/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "files": ["main.ts", "source.ts"]
+}

--- a/test/config/type-awaited-return-type-break/tsconfig.json
+++ b/test/config/type-awaited-return-type-break/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "target": "ES2022",
     "module": "ES2022",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "skipLibCheck": true
   },

--- a/test/config/type-self-referencing-method/index.test.ts
+++ b/test/config/type-self-referencing-method/index.test.ts
@@ -1,0 +1,7 @@
+import { it } from "node:test";
+import { assertConfigSchema } from "../../utils";
+
+it(
+    "config - type-self-referencing-method",
+    assertConfigSchema("type-self-referencing-method", { type: "MyType" }, true),
+);

--- a/test/config/type-self-referencing-method/main.ts
+++ b/test/config/type-self-referencing-method/main.ts
@@ -1,0 +1,3 @@
+import type { MyType } from "./source.js";
+
+export type { MyType };

--- a/test/config/type-self-referencing-method/schema.json
+++ b/test/config/type-self-referencing-method/schema.json
@@ -1,0 +1,18 @@
+{
+  "$ref": "#/definitions/MyType",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyType": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/test/config/type-self-referencing-method/source.ts
+++ b/test/config/type-self-referencing-method/source.ts
@@ -1,0 +1,7 @@
+interface App {
+    name: string;
+    use(middleware: any): this;
+    listen(port: number): this;
+}
+
+export type MyType = Pick<App, "name">;

--- a/test/config/type-self-referencing-method/tsconfig.json
+++ b/test/config/type-self-referencing-method/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "files": ["main.ts", "source.ts"]
+}

--- a/test/config/type-self-referencing-method/tsconfig.json
+++ b/test/config/type-self-referencing-method/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "target": "ES2022",
     "module": "ES2022",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "skipLibCheck": true
   },


### PR DESCRIPTION
## Summary

- Interfaces like `Map` and `Set` have method signatures that aren't included in `ObjectType` properties, causing `isAssignableTo` to consider any object with a `size` property assignable to `Map`
- This produced wrong conditional type branches (e.g. `Immutable<Bar>` with `T extends Map<infer K, infer V>` incorrectly matching when `Bar` has a `size` property)
- Track method names on `ObjectType`, collected in `InterfaceAndClassNodeParser`
- Check method names in `isAssignableTo` to reject false structural matches

## Test plan

- [x] `type-awaited-return-type-break` — `Immutable<T>` with Map/Set branches correctly resolves all properties
- [x] `type-self-referencing-method` — interfaces with `this`-returning methods don't cause stack overflow
- [x] All existing tests pass (250/250)