### PR TITLE
fix: relative --tsconfig path breaks @types resolution

### DIFF
--- a/factory/program.ts
+++ b/factory/program.ts
@@ -6,6 +6,7 @@ import type { CompletedConfig, Config } from "../src/Config.js";
 import { BuildError } from "../src/Error/Errors.js";
 
 function loadTsConfigFile(configFile: string) {
+    configFile = path.resolve(configFile);
     const raw = ts.sys.readFile(configFile);
 
     if (!raw) {

--- a/test/config/tsconfig-support/tsconfig.json
+++ b/test/config/tsconfig-support/tsconfig.json
@@ -8,6 +8,7 @@
     "strictNullChecks": false,
     "allowJs": true,
     "rootDir": "./src",
+    "types": ["node"],
     "paths": {
       "@src/*": ["./src/*"]
     }

--- a/test/unit/createProgram.test.ts
+++ b/test/unit/createProgram.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { createProgram } from "../../factory/program";
+import { DEFAULT_CONFIG } from "../../src/Config.js";
+
+describe("createProgram", () => {
+    it("resolves a relative tsconfig path for correct @types resolution in monorepos", () => {
+        const tsconfig = "test/config/tsconfig-support/tsconfig.json";
+
+        // Preconditions: the tsconfig path must be relative and @types must not
+        // exist in the cwd, so that resolution depends on walking up directories
+        assert.ok(!path.isAbsolute(tsconfig), "tsconfig path must be relative");
+        assert.ok(
+            !fs.existsSync(path.join(path.dirname(tsconfig), "node_modules", "@types")),
+            "test fixture must not have local @types",
+        );
+
+        // Precondition: the tsconfig must explicitly list types, which triggers
+        // the bug when the config file path is not resolved to absolute
+        const raw = JSON.parse(fs.readFileSync(tsconfig, "utf8"));
+        assert.ok(raw.compilerOptions?.types?.length > 0, "tsconfig must explicitly list types");
+
+        const program = createProgram({
+            ...DEFAULT_CONFIG,
+            type: "MyObject",
+            tsconfig,
+            skipTypeCheck: false,
+        });
+
+        assert.ok(program);
+    });
+});


### PR DESCRIPTION
When `--tsconfig` receives a relative path (e.g. `--tsconfig tsconfig.json`), `loadTsConfigFile` passes it as-is to `ts.parseConfigFileTextToJson` and `ts.parseJsonConfigFileContent`. This causes TypeScript's default type root resolution to fail — it can no longer walk up parent directories to find `@types` packages in hoisted `node_modules` (common in yarn/npm workspaces).

The result is a "Type check error" with "Cannot find type definition file for ..." messages, even though the types are correctly installed and TypeScript itself can find them when given an absolute path.

The fix resolves the config file path to absolute at the top of `loadTsConfigFile`, which restores correct type root resolution behavior.

Closes #2519

---

> [!NOTE]
> This bug was investigated, reported, and fixed with the help of [Kiro](https://kiro.dev), an AI assistant. It was human-reviewed by me.
