### PR TITLE
fix: getTypeByKey should search baseTypes before additionalProperties

### DIFF
--- a/src/Utils/typeKeys.ts
+++ b/src/Utils/typeKeys.ts
@@ -118,18 +118,18 @@ export function getTypeByKey(type: BaseType, index: LiteralType | StringType | N
             }
         }
 
-        const additionalProperty = type.getAdditionalProperties();
-        if (additionalProperty instanceof BaseType) {
-            return additionalProperty;
-        } else if (additionalProperty === true) {
-            return new AnyType();
-        }
-
         for (const subType of type.getBaseTypes()) {
             const subKeyType = getTypeByKey(subType, index);
             if (subKeyType) {
                 return subKeyType;
             }
+        }
+
+        const additionalProperty = type.getAdditionalProperties();
+        if (additionalProperty instanceof BaseType) {
+            return additionalProperty;
+        } else if (additionalProperty === true) {
+            return new AnyType();
         }
 
         return undefined;

--- a/test/valid-data/type-mapped-inherit-optional/index.test.ts
+++ b/test/valid-data/type-mapped-inherit-optional/index.test.ts
@@ -1,0 +1,3 @@
+import { assertValidSchema } from "../../utils.js";
+
+assertValidSchema("type-mapped-inherit-optional", "*", { additionalProperties: true });

--- a/test/valid-data/type-mapped-inherit-optional/main.ts
+++ b/test/valid-data/type-mapped-inherit-optional/main.ts
@@ -1,0 +1,18 @@
+export interface TransitionOptions {
+    transition?: string;
+}
+
+export interface Frontmatter extends TransitionOptions {
+    layout?: string;
+    title?: string;
+}
+
+export type TestOmit = Omit<Frontmatter, "title">;
+
+export interface HeadmatterConfig extends TransitionOptions {
+    author?: string;
+}
+
+export interface Headmatter extends HeadmatterConfig, Omit<Frontmatter, "title"> {
+    defaults?: Frontmatter;
+}

--- a/test/valid-data/type-mapped-inherit-optional/schema.json
+++ b/test/valid-data/type-mapped-inherit-optional/schema.json
@@ -1,0 +1,48 @@
+{
+  "$ref": "#/definitions/Headmatter",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Frontmatter": {
+      "properties": {
+        "layout": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "transition": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Headmatter": {
+      "properties": {
+        "author": {
+          "type": "string"
+        },
+        "defaults": {
+          "$ref": "#/definitions/Frontmatter"
+        },
+        "layout": {
+          "type": "string"
+        },
+        "transition": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "TestOmit": {
+      "properties": {
+        "layout": {
+          "type": "string"
+        },
+        "transition": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
## Problem

When `additionalProperties` is enabled, `getTypeByKey` incorrectly returns `AnyType` for inherited properties that are not declared directly on the object. This causes optional inherited properties in mapped types like `Omit<T, K>` to be incorrectly marked as `required` in the generated schema.

### Reproduction

Given:
```ts
export interface TransitionOptions {
  transition?: string;
}

export interface Frontmatter extends TransitionOptions {
  layout?: string;
  title?: string;
}

export interface Headmatter extends HeadmatterConfig, Omit<Frontmatter, 'title'> {
  defaults?: Frontmatter;
}
```

With `additionalProperties: true`, the generated schema for `Headmatter` incorrectly includes:
```json
{ "required": ["transition"] }
```

even though `transition` is optional in both base types.

## Root Cause

In `getTypeByKey`, when a property is not found in the object's direct properties, the code checks `additionalProperties` **before** recursively searching `baseTypes`. When `additionalProperties === true`, it immediately returns `AnyType`, bypassing the correct type resolution from the base class.

## Fix

Swap the order: search `baseTypes` first, and only fall back to `additionalProperties` if the property is not found in any base type.

Fixes downstream issue: [slidevjs/slidev#2532](https://github.com/slidevjs/slidev/issues/2532)