### PR TITLE
fix(ci): remove duplicate npm plugin from auto config

### DIFF
--- a/.autorc.json
+++ b/.autorc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["npm", "conventional-commits", "first-time-contributor", "released", ["npm", { "setRcToken": false }]],
+  "plugins": ["conventional-commits", "first-time-contributor", "released", ["npm", { "setRcToken": false }]],
   "baseBranch": "stable",
   "prereleaseBranches": ["next"],
   "author": "GitHub Actions Bot <vega-actions-bot@users.noreply.github.com>"


### PR DESCRIPTION
## Problem

Prerelease publishing to `next` succeeds on npm but fails creating the GitHub release with:

> RequestError [HttpError]: Validation Failed: tag_name is not well-formed / Published releases must have a valid tag (422)

This has been failing on every release since the trusted-publishing change — GitHub Releases are stuck at v2.5.0 (Feb 4) while npm is at 2.9.1-next.15.

## Root cause

`714fa1dc` ("ci: use npm trusted publishing") added `["npm", { "setRcToken": false }]` but left the original bare `"npm"` entry in place, so the npm plugin is listed **twice**:

```json
"plugins": ["npm", ..., ["npm", { "setRcToken": false }]]
```

`auto`'s `loadPlugins` does no dedup — it `.apply()`s every entry — so the plugin taps the `next` hook twice. Each tap runs a full `npm version` + `npm publish`, so two prereleases are published per run (e.g. `2.9.1-next.14` **and** `next.15`). `auto`'s `next()` then joins the whole result array into a single tag name:

```
newVersion = "v2.9.1-next.14, v2.9.1-next.15"
```

which it passes to the GitHub release API as `tag_name` → 422 "not well-formed".

## Fix

Remove the duplicate, keeping the `setRcToken: false` entry (correct for the OIDC trusted-publishing setup). This stops the double-publish and the malformed tag name. Existing missed GitHub releases won't be backfilled automatically, but future releases will create releases again.

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.9.1-next.16`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: Jonathan Puckey ([@puckey](https://github.com/puckey))
  
  :heart: Momo Kornher ([@mrgrain](https://github.com/mrgrain))
  
  :heart: _Kerman ([@kermanx](https://github.com/kermanx))
  
  :heart: Ninjackson ([@ninjack-dev](https://github.com/ninjack-dev))
  
  :heart: Orgad Shaneh ([@orgads](https://github.com/orgads))
  
  :heart: Antonin CELESTIN ([@aciwecloud](https://github.com/aciwecloud))
  
  #### 🚀 Enhancement
  
  - feat: support ReturnType<T>, type predicates, and fix typeof for function declarations [#2512](https://github.com/vega/ts-json-schema-generator/pull/2512) ([@puckey](https://github.com/puckey))
  - feat: Upgrade to TypeScript 6, maintain TS5 compatibility [#2509](https://github.com/vega/ts-json-schema-generator/pull/2509) ([@arthurfiorette](https://github.com/arthurfiorette) [@Copilot](https://github.com/Copilot))
  
  #### 🐛 Bug Fix
  
  - fix(ci): remove duplicate npm plugin from auto config [#2525](https://github.com/vega/ts-json-schema-generator/pull/2525) ([@puckey](https://github.com/puckey))
  - fix: relative --tsconfig path breaks @types resolution [#2520](https://github.com/vega/ts-json-schema-generator/pull/2520) ([@mrgrain](https://github.com/mrgrain))
  - fix: getTypeByKey should search baseTypes before additionalProperties [#2521](https://github.com/vega/ts-json-schema-generator/pull/2521) ([@kermanx](https://github.com/kermanx))
  - fix: add `issues` and `pull-requests` write permissions to publish-auto workflow [#2516](https://github.com/vega/ts-json-schema-generator/pull/2516) ([@Copilot](https://github.com/Copilot))
  - Add support for `infer` in conditionals operating on function parameters [#2495](https://github.com/vega/ts-json-schema-generator/pull/2495) ([@ninjack-dev](https://github.com/ninjack-dev))
  - fix: preserve mapped indexed access annotations [#2501](https://github.com/vega/ts-json-schema-generator/pull/2501) ([@orgads](https://github.com/orgads))
  - ci: publish only from main repository [#2502](https://github.com/vega/ts-json-schema-generator/pull/2502) ([@orgads](https://github.com/orgads))
  - fix: array ref used as rest item [#2496](https://github.com/vega/ts-json-schema-generator/pull/2496) ([@aciwecloud](https://github.com/aciwecloud))
  - fix: mapped types required type [#2492](https://github.com/vega/ts-json-schema-generator/pull/2492) ([@aciwecloud](https://github.com/aciwecloud))
  - fix: Include types referenced only in `additionalItems` in schema definitions [#2477](https://github.com/vega/ts-json-schema-generator/pull/2477) ([@aciwecloud](https://github.com/aciwecloud))
  
  #### ⚠️ Pushed to `next`
  
  - ci: update dependabot config to be quarterly, simplify auto-merge ([@domoritz](https://github.com/domoritz))
  
  #### 🔩 Dependency Updates
  
  - chore(deps): bump esbuild and tsx [#2524](https://github.com/vega/ts-json-schema-generator/pull/2524) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump brace-expansion from 5.0.5 to 5.0.6 [#2523](https://github.com/vega/ts-json-schema-generator/pull/2523) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump fast-uri from 3.1.0 to 3.1.2 [#2522](https://github.com/vega/ts-json-schema-generator/pull/2522) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.57.2 to 8.58.0 [#2517](https://github.com/vega/ts-json-schema-generator/pull/2517) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump lodash from 4.17.23 to 4.18.1 [#2518](https://github.com/vega/ts-json-schema-generator/pull/2518) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.57.1 to 8.57.2 [#2510](https://github.com/vega/ts-json-schema-generator/pull/2510) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump brace-expansion [#2507](https://github.com/vega/ts-json-schema-generator/pull/2507) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump codecov/codecov-action from 5 to 6 [#2506](https://github.com/vega/ts-json-schema-generator/pull/2506) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump handlebars from 4.7.8 to 4.7.9 [#2505](https://github.com/vega/ts-json-schema-generator/pull/2505) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump picomatch [#2503](https://github.com/vega/ts-json-schema-generator/pull/2503) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 10.0.3 to 10.1.0 [#2499](https://github.com/vega/ts-json-schema-generator/pull/2499) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.57.0 to 8.57.1 [#2500](https://github.com/vega/ts-json-schema-generator/pull/2500) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump flatted from 3.3.1 to 3.4.2 [#2498](https://github.com/vega/ts-json-schema-generator/pull/2498) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.56.1 to 8.57.0 [#2494](https://github.com/vega/ts-json-schema-generator/pull/2494) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.39.2 to 10.0.3 [#2487](https://github.com/vega/ts-json-schema-generator/pull/2487) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.10.13 to 24.12.0 [#2486](https://github.com/vega/ts-json-schema-generator/pull/2486) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.56.0 to 8.56.1 [#2488](https://github.com/vega/ts-json-schema-generator/pull/2488) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 10
  
  - _Kerman ([@kermanx](https://github.com/kermanx))
  - [@Copilot](https://github.com/Copilot)
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Antonin CELESTIN ([@aciwecloud](https://github.com/aciwecloud))
  - Arthur Fiorette ([@arthurfiorette](https://github.com/arthurfiorette))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
  - Jonathan Puckey ([@puckey](https://github.com/puckey))
  - Momo Kornher ([@mrgrain](https://github.com/mrgrain))
  - Ninjackson ([@ninjack-dev](https://github.com/ninjack-dev))
  - Orgad Shaneh ([@orgads](https://github.com/orgads))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
