### PR TITLE
fix: resolve unrepresentable type references (e.g. zod z.infer) via type checker fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,8 @@
         "tsx": "^4.21.0",
         "typescript-eslint": "^8.57.2",
         "vega": "^6.2.0",
-        "vega-lite": "^6.4.2"
+        "vega-lite": "^6.4.2",
+        "zod": "^4.4.3"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -9085,6 +9086,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "tsx": "^4.21.0",
     "typescript-eslint": "^8.57.2",
     "vega": "^6.2.0",
-    "vega-lite": "^6.4.2"
+    "vega-lite": "^6.4.2",
+    "zod": "^4.4.3"
   },
   "packageManager": "npm@11.12.1",
   "publishConfig": {

--- a/src/NodeParser/TypeReferenceNodeParser.ts
+++ b/src/NodeParser/TypeReferenceNodeParser.ts
@@ -7,6 +7,7 @@ import { ArrayType } from "../Type/ArrayType.js";
 import type { BaseType } from "../Type/BaseType.js";
 import { StringType } from "../Type/StringType.js";
 import { UnknownType } from "../Type/UnknownType.js";
+import { UnhandledError } from "../Error/Errors.js";
 import { symbolAtNode } from "../Utils/symbolAtNode.js";
 
 const invalidTypes: Record<number, boolean> = {
@@ -42,7 +43,7 @@ export class TypeReferenceNodeParser implements SubNodeParser {
                 return new AnyType();
             }
 
-            return this.childNodeParser.createType(declaration, this.createSubContext(node, context));
+            return this.createTypeFromDeclaration(declaration, node, context);
         }
 
         if (typeSymbol.flags & ts.SymbolFlags.TypeParameter) {
@@ -77,10 +78,69 @@ export class TypeReferenceNodeParser implements SubNodeParser {
             return new AnnotatedType(new StringType(), { format: "uri" }, false);
         }
 
-        return this.childNodeParser.createType(
+        return this.createTypeFromDeclaration(
             typeSymbol.declarations!.filter((n: ts.Declaration) => !invalidTypes[n.kind])[0],
-            this.createSubContext(node, context),
+            node,
+            context,
         );
+    }
+
+    /**
+     * Resolves a referenced declaration through the child parser, falling back to the
+     * type checker's already-resolved type when structural re-parsing crashes.
+     *
+     * Re-parsing the AST can drive the parser into type-level machinery of third-party
+     * libraries (e.g. `zod`'s `z.infer<typeof schema>` conditional types, whose return
+     * type is built from deep generics) that cannot be statically re-derived. When that
+     * happens an unexpected (non-controlled) error is thrown; in that case we delegate to
+     * the type checker, which has already resolved such references to a concrete type.
+     */
+    protected createTypeFromDeclaration(
+        declaration: ts.Declaration,
+        node: ts.TypeReferenceNode,
+        context: Context,
+    ): BaseType {
+        try {
+            return this.childNodeParser.createType(declaration, this.createSubContext(node, context));
+        } catch (error) {
+            if (error instanceof UnhandledError) {
+                const resolved = this.createTypeFromChecker(node, context);
+                if (resolved) {
+                    return resolved;
+                }
+            }
+            throw error;
+        }
+    }
+
+    /**
+     * Builds a base type from the type checker's fully-resolved type for the given
+     * reference node. Returns undefined when the checker cannot offer a trustworthy
+     * concrete type (e.g. it collapses to `any`/`unknown`), so callers can rethrow the
+     * original error instead of silently substituting a meaningless schema.
+     */
+    protected createTypeFromChecker(node: ts.TypeReferenceNode, context: Context): BaseType | undefined {
+        let resolvedType: ts.Type;
+        try {
+            resolvedType = this.typeChecker.getTypeFromTypeNode(node);
+        } catch {
+            return undefined;
+        }
+
+        const typeNode = this.typeChecker.typeToTypeNode(resolvedType, node, ts.NodeBuilderFlags.IgnoreErrors);
+
+        if (!typeNode || typeNode.kind === ts.SyntaxKind.AnyKeyword || typeNode.kind === ts.SyntaxKind.UnknownKeyword) {
+            return undefined;
+        }
+        try {
+            const result = this.childNodeParser.createType(typeNode, context);
+            if (result instanceof AnyType || result instanceof UnknownType) {
+                return undefined;
+            }
+            return result;
+        } catch {
+            return undefined;
+        }
     }
 
     protected createSubContext(node: ts.TypeReferenceNode, parentContext: Context): Context {

--- a/test/valid-data/type-typeof-zod-infer/index.test.ts
+++ b/test/valid-data/type-typeof-zod-infer/index.test.ts
@@ -1,0 +1,4 @@
+import { assertValidSchema } from "../../utils";
+import { test } from "node:test";
+
+test("valid-data - type-typeof-zod-infer", assertValidSchema("type-typeof-zod-infer", "MyObject"));

--- a/test/valid-data/type-typeof-zod-infer/main.ts
+++ b/test/valid-data/type-typeof-zod-infer/main.ts
@@ -1,0 +1,27 @@
+import * as zod from "zod";
+
+// Regression test for resolving types derived via zod's `z.infer<typeof schema>`.
+// The schema builder's return type is built from deep generics that the generator
+// cannot re-derive by statically re-parsing the AST. The type checker, however,
+// resolves `z.infer<...>` to a concrete type, which the generator now falls back to.
+// See https://github.com/vega/ts-json-schema-generator/issues/758
+
+const NumberSchema = zod.number();
+type NumberType = zod.infer<typeof NumberSchema>;
+
+const ObjectSchema = zod.object({
+    name: zod.string(),
+    age: zod.number().optional(),
+    role: zod.enum(["admin", "user"]),
+});
+
+const UnionSchema = zod.discriminatedUnion("kind", [
+    zod.object({ kind: zod.literal("a"), value: zod.string() }),
+    zod.object({ kind: zod.literal("b"), count: zod.number() }),
+]);
+
+export interface MyObject {
+    numberField: NumberType;
+    objectField: zod.infer<typeof ObjectSchema>;
+    unionField: zod.infer<typeof UnionSchema>;
+}

--- a/test/valid-data/type-typeof-zod-infer/schema.json
+++ b/test/valid-data/type-typeof-zod-infer/schema.json
@@ -1,0 +1,81 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "numberField": {
+          "type": "number"
+        },
+        "objectField": {
+          "additionalProperties": false,
+          "properties": {
+            "age": {
+              "type": "number"
+            },
+            "name": {
+              "type": "string"
+            },
+            "role": {
+              "enum": [
+                "admin",
+                "user"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "role"
+          ],
+          "type": "object"
+        },
+        "unionField": {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "kind": {
+                  "const": "a",
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "count": {
+                  "type": "number"
+                },
+                "kind": {
+                  "const": "b",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "count"
+              ],
+              "type": "object"
+            }
+          ]
+        }
+      },
+      "required": [
+        "numberField",
+        "objectField",
+        "unionField"
+      ],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes a crash (`Unhandled error while creating Base Type`) when generating a
schema from types derived through third-party type-level machinery, most
notably zod's `z.infer<typeof schema>`. Even the minimal case below crashed:

```ts
import * as zod from "zod";
const Foo = zod.number();
type FooType = zod.infer<typeof Foo>;

export interface Example {
    foo: FooType; // -> Unhandled error while creating Base Type
}
```

Refs #758 (the issue was closed by #1947, but only one crash path was patched;
the generator still crashed one frame deeper — see "Root cause" below).

## Problem

Any type derived via `z.infer<typeof schema>` (from `z.number()` up to
`z.discriminatedUnion(...)`) crashed both the CLI and the API. This was
reproducible with the simplest possible schema and was independent of schema
complexity. Hand-written unions worked because they never reach the value/
call-expression path described below.

## Root cause

To resolve `type FooType = z.infer<typeof Foo>`, the parser chain traverses:

```
TypeAliasNodeParser            // FooType
  -> TypeReferenceNodeParser   // zod.infer<...>  (conditional type)
    -> TypeofNodeParser        // typeof Foo -> const Foo's initializer
      -> CallExpressionParser  // zod.number()
        -> typeToTypeNode()    // convert ZodNumber type back to an AST node
          -> (recurse)         // crash: synthesized node has no symbol
```

`TypeofNodeParser` resolves `typeof Foo` by re-parsing Foo's *value* initializer
(`zod.number()`) as a type. `CallExpressionParser` then takes the call's return
type and round-trips it through `typeToTypeNode`. For zod's deeply generic
return types this produces a synthesized node whose `typeName` has no resolvable
symbol, so `TypeReferenceNodeParser` throws `Cannot read properties of undefined
(reading 'flags')` — wrapped into `UnhandledError` (code 109).

Crucially, **the TypeScript checker already resolves the whole reference to a
concrete type** (e.g. `z.infer<typeof Foo>` -> `number`). The generator simply
never asked it, preferring to re-derive the type from the AST, which is
impossible for this kind of library-level type derivation.

#1947 only narrowed the `typeArguments` special-case in `CallExpressionParser`
so the flow no longer tripped on `.types`; it still fell through to
`typeToTypeNode` and crashed one frame deeper, so the original issue was not
actually resolved.

## Solution

In `TypeReferenceNodeParser`, wrap structural resolution of a referenced
declaration and, **only when it crashes with an unexpected error**, fall back to
the type checker's already-resolved type for the reference:

1. `getTypeFromTypeNode(node)` — let the checker fully resolve the reference
   (handles `z.infer<...>` and similar conditional/infer chains).
2. `typeToTypeNode(...)` — convert the resolved type back to an AST node and
   parse that instead.

### Why this is safe (no behavior change for the happy/sad paths)

- The fallback is gated on `error instanceof UnhandledError`, i.e. it only
  triggers on an actual **crash** (a raw exception wrapped by
  `ChainNodeParser`). Controlled errors (`UnknownNodeError`, `LogicError`, …)
  propagate unchanged, so all existing error semantics are preserved.
- `createTypeFromChecker` refuses to emit a schema when the checker cannot offer
  a **trustworthy concrete type**: it returns `undefined` (and the original
  error is rethrown) if resolution yields `any`/`unknown` or if the converted
  node fails to parse. The generator therefore never silently substitutes a
  meaningless schema for a genuinely broken reference.
- The successful path is untouched.

## Result

All previously-crashing cases now produce correct schemas, e.g.:

| zod schema | output |
|---|---|
| `z.number()` | `{"type":"number"}` |
| `z.object({a, b})` | object with typed properties |
| `z.object({}).strict()` | object, `additionalProperties: false` |
| nested `z.object` + `z.array` | nested object/array |
| `z.discriminatedUnion(...)` | `anyOf` with `const` discriminators |
| optional + `z.enum(...)` | correct `required` + `enum` |

## Tests

- New regression test `test/valid-data/type-typeof-zod-infer` covering
  `z.number`, `z.object` (with optional + enum), and `z.discriminatedUnion`.
- Full suite: **378 pass / 0 fail** (was 377).
- `tsc --noEmit` and `eslint` clean.

## Notes

- The regression test depends on `zod`, added as a `devDependency`. A
  dependency-free test cannot reproduce this crash: a locally-declared generic
  interface *is* structurally resolvable, so it never produces the symbol-less
  synthesized node that only real library generics (like zod's) trigger. Happy
  to drop the devDep / rework the test if maintainers prefer.
- Built on `next` (the default branch).
