### PR TITLE
fix: preserve JSDoc description on properties with an inferred default value

### DIFF
--- a/src/NodeParser/InterfaceAndClassNodeParser.ts
+++ b/src/NodeParser/InterfaceAndClassNodeParser.ts
@@ -131,6 +131,15 @@ export class InterfaceAndClassNodeParser implements SubNodeParser {
                 if (memberType === undefined && (member as ts.PropertyDeclaration)?.initializer !== undefined) {
                     const type = this.typeChecker.getTypeAtLocation(member);
                     memberType = this.typeChecker.typeToTypeNode(type, node, ts.NodeBuilderFlags.NoTruncation);
+
+                    // `typeToTypeNode` returns a node that is detached from the AST, so
+                    // `AnnotatedNodeParser` cannot walk up to the member to read its JSDoc.
+                    // Point the synthesized node at the original declaration so annotations
+                    // such as the property description are preserved. See #1531.
+                    if (memberType) {
+                        //@ts-expect-error - parent is readonly in the public typings
+                        memberType.parent = member;
+                    }
                 }
 
                 if (memberType !== undefined) {

--- a/test/valid-data/class-jsdoc-default/index.test.ts
+++ b/test/valid-data/class-jsdoc-default/index.test.ts
@@ -1,0 +1,4 @@
+import { assertValidSchema } from "../../utils";
+import { test } from "node:test";
+
+test("valid-data - class-jsdoc-default", assertValidSchema("class-jsdoc-default", "MyObject"));

--- a/test/valid-data/class-jsdoc-default/main.ts
+++ b/test/valid-data/class-jsdoc-default/main.ts
@@ -1,0 +1,13 @@
+/**
+ * Class Description
+ */
+export class MyObject {
+    /** Property x description */
+    public x = "foo";
+
+    /** Property y description */
+    public y = 42;
+
+    /** Property z description */
+    public z = true;
+}

--- a/test/valid-data/class-jsdoc-default/schema.json
+++ b/test/valid-data/class-jsdoc-default/schema.json
@@ -1,0 +1,30 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "description": "Class Description",
+      "properties": {
+        "x": {
+          "description": "Property x description",
+          "type": "string"
+        },
+        "y": {
+          "description": "Property y description",
+          "type": "number"
+        },
+        "z": {
+          "description": "Property z description",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "x",
+        "y",
+        "z"
+      ],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
Closes #1531.

### Problem

When a class property has a default value but no explicit type annotation, its JSDoc `description` is dropped from the generated schema:

```ts
export class Foo {
  /** Whether or not foo has a bar. */
  someAttribute = true;
}
```

produces `{ "someAttribute": { "type": "boolean" } }` — the description is gone. With an explicit type (`someAttribute: boolean`) the description is kept as expected.

### Cause

For a property with an initializer but no explicit type, `InterfaceAndClassNodeParser.getProperties` synthesizes the type node via `typeChecker.typeToTypeNode(...)`. That node is **detached from the AST**, so it has no `parent`. `AnnotatedNodeParser.getAnnotatedNode` relies on walking `node.parent` up to the `PropertyDeclaration` to read the member's JSDoc — with no parent, it falls back to the synthesized node, which carries no annotations, and the description is lost.

### Fix

Point the synthesized type node's `parent` at the original declaration, so `AnnotatedNodeParser` can reach the member's JSDoc again (matching the behavior for explicitly-typed properties).

### Tests

Added the `class-jsdoc-default` valid-data fixture (a class whose properties get their types inferred from defaults) asserting that each property's description is preserved. It fails on `main` and passes with this change.

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.9.1-next.17`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: Vismay ([@vismaytiwari](https://github.com/vismaytiwari))
  
  :heart: Jonathan Puckey ([@puckey](https://github.com/puckey))
  
  :heart: Momo Kornher ([@mrgrain](https://github.com/mrgrain))
  
  :heart: _Kerman ([@kermanx](https://github.com/kermanx))
  
  :heart: Ninjackson ([@ninjack-dev](https://github.com/ninjack-dev))
  
  :heart: Orgad Shaneh ([@orgads](https://github.com/orgads))
  
  :heart: Antonin CELESTIN ([@aciwecloud](https://github.com/aciwecloud))
  
  #### 🚀 Enhancement
  
  - feat: support ReturnType<T>, type predicates, and fix typeof for function declarations [#2512](https://github.com/vega/ts-json-schema-generator/pull/2512) ([@puckey](https://github.com/puckey))
  - feat: Upgrade to TypeScript 6, maintain TS5 compatibility [#2509](https://github.com/vega/ts-json-schema-generator/pull/2509) ([@arthurfiorette](https://github.com/arthurfiorette) [@Copilot](https://github.com/Copilot))
  
  #### 🐛 Bug Fix
  
  - fix: preserve JSDoc description on properties with an inferred default value [#2534](https://github.com/vega/ts-json-schema-generator/pull/2534) ([@vismaytiwari](https://github.com/vismaytiwari))
  - fix(ci): remove duplicate npm plugin from auto config [#2525](https://github.com/vega/ts-json-schema-generator/pull/2525) ([@puckey](https://github.com/puckey))
  - fix: relative --tsconfig path breaks @types resolution [#2520](https://github.com/vega/ts-json-schema-generator/pull/2520) ([@mrgrain](https://github.com/mrgrain))
  - fix: getTypeByKey should search baseTypes before additionalProperties [#2521](https://github.com/vega/ts-json-schema-generator/pull/2521) ([@kermanx](https://github.com/kermanx))
  - fix: add `issues` and `pull-requests` write permissions to publish-auto workflow [#2516](https://github.com/vega/ts-json-schema-generator/pull/2516) ([@Copilot](https://github.com/Copilot))
  - Add support for `infer` in conditionals operating on function parameters [#2495](https://github.com/vega/ts-json-schema-generator/pull/2495) ([@ninjack-dev](https://github.com/ninjack-dev))
  - fix: preserve mapped indexed access annotations [#2501](https://github.com/vega/ts-json-schema-generator/pull/2501) ([@orgads](https://github.com/orgads))
  - ci: publish only from main repository [#2502](https://github.com/vega/ts-json-schema-generator/pull/2502) ([@orgads](https://github.com/orgads))
  - fix: array ref used as rest item [#2496](https://github.com/vega/ts-json-schema-generator/pull/2496) ([@aciwecloud](https://github.com/aciwecloud))
  - fix: mapped types required type [#2492](https://github.com/vega/ts-json-schema-generator/pull/2492) ([@aciwecloud](https://github.com/aciwecloud))
  - fix: Include types referenced only in `additionalItems` in schema definitions [#2477](https://github.com/vega/ts-json-schema-generator/pull/2477) ([@aciwecloud](https://github.com/aciwecloud))
  
  #### ⚠️ Pushed to `next`
  
  - ci: update dependabot config to be quarterly, simplify auto-merge ([@domoritz](https://github.com/domoritz))
  
  #### 🔩 Dependency Updates
  
  - chore(deps): bump actions/checkout from 6 to 7 [#2527](https://github.com/vega/ts-json-schema-generator/pull/2527) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump dependabot/fetch-metadata from 2 to 3 [#2528](https://github.com/vega/ts-json-schema-generator/pull/2528) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump codecov/codecov-action from 6 to 7 [#2529](https://github.com/vega/ts-json-schema-generator/pull/2529) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv from 8.18.0 to 8.20.0 [#2533](https://github.com/vega/ts-json-schema-generator/pull/2533) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump globals from 17.4.0 to 17.7.0 [#2532](https://github.com/vega/ts-json-schema-generator/pull/2532) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.5.5 to 5.5.6 [#2530](https://github.com/vega/ts-json-schema-generator/pull/2530) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump esbuild and tsx [#2524](https://github.com/vega/ts-json-schema-generator/pull/2524) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump brace-expansion from 5.0.5 to 5.0.6 [#2523](https://github.com/vega/ts-json-schema-generator/pull/2523) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump fast-uri from 3.1.0 to 3.1.2 [#2522](https://github.com/vega/ts-json-schema-generator/pull/2522) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.57.2 to 8.58.0 [#2517](https://github.com/vega/ts-json-schema-generator/pull/2517) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump lodash from 4.17.23 to 4.18.1 [#2518](https://github.com/vega/ts-json-schema-generator/pull/2518) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.57.1 to 8.57.2 [#2510](https://github.com/vega/ts-json-schema-generator/pull/2510) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump brace-expansion [#2507](https://github.com/vega/ts-json-schema-generator/pull/2507) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump codecov/codecov-action from 5 to 6 [#2506](https://github.com/vega/ts-json-schema-generator/pull/2506) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump handlebars from 4.7.8 to 4.7.9 [#2505](https://github.com/vega/ts-json-schema-generator/pull/2505) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump picomatch [#2503](https://github.com/vega/ts-json-schema-generator/pull/2503) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 10.0.3 to 10.1.0 [#2499](https://github.com/vega/ts-json-schema-generator/pull/2499) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.57.0 to 8.57.1 [#2500](https://github.com/vega/ts-json-schema-generator/pull/2500) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump flatted from 3.3.1 to 3.4.2 [#2498](https://github.com/vega/ts-json-schema-generator/pull/2498) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.56.1 to 8.57.0 [#2494](https://github.com/vega/ts-json-schema-generator/pull/2494) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.39.2 to 10.0.3 [#2487](https://github.com/vega/ts-json-schema-generator/pull/2487) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.10.13 to 24.12.0 [#2486](https://github.com/vega/ts-json-schema-generator/pull/2486) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.56.0 to 8.56.1 [#2488](https://github.com/vega/ts-json-schema-generator/pull/2488) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 11
  
  - _Kerman ([@kermanx](https://github.com/kermanx))
  - [@Copilot](https://github.com/Copilot)
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Antonin CELESTIN ([@aciwecloud](https://github.com/aciwecloud))
  - Arthur Fiorette ([@arthurfiorette](https://github.com/arthurfiorette))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
  - Jonathan Puckey ([@puckey](https://github.com/puckey))
  - Momo Kornher ([@mrgrain](https://github.com/mrgrain))
  - Ninjackson ([@ninjack-dev](https://github.com/ninjack-dev))
  - Orgad Shaneh ([@orgads](https://github.com/orgads))
  - Vismay ([@vismaytiwari](https://github.com/vismaytiwari))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
