### PR TITLE
feat: support dynamic import nodes

### DIFF
--- a/factory/parser.ts
+++ b/factory/parser.ts
@@ -23,6 +23,7 @@ import { EnumNodeParser } from "../src/NodeParser/EnumNodeParser.js";
 import { ExpressionWithTypeArgumentsNodeParser } from "../src/NodeParser/ExpressionWithTypeArgumentsNodeParser.js";
 import { FunctionNodeParser } from "../src/NodeParser/FunctionNodeParser.js";
 import { HiddenNodeParser } from "../src/NodeParser/HiddenTypeNodeParser.js";
+import { ImportTypeNodeParser } from "../src/NodeParser/ImportTypeNodeParser.js";
 import { IndexedAccessTypeNodeParser } from "../src/NodeParser/IndexedAccessTypeNodeParser.js";
 import { InferTypeNodeParser } from "../src/NodeParser/InferTypeNodeParser.js";
 import { InterfaceAndClassNodeParser } from "../src/NodeParser/InterfaceAndClassNodeParser.js";
@@ -138,6 +139,7 @@ export function createParser(program: ts.Program, config: CompletedConfig, augme
 
         .addNodeParser(new PromiseNodeParser(typeChecker, chainNodeParser))
         .addNodeParser(new TypeReferenceNodeParser(typeChecker, chainNodeParser))
+        .addNodeParser(new ImportTypeNodeParser(typeChecker, chainNodeParser))
         .addNodeParser(new ExpressionWithTypeArgumentsNodeParser(typeChecker, chainNodeParser))
         .addNodeParser(new IndexedAccessTypeNodeParser(typeChecker, withJsDoc(chainNodeParser)))
         .addNodeParser(new InferTypeNodeParser(typeChecker, chainNodeParser))

--- a/src/NodeParser/ImportTypeNodeParser.ts
+++ b/src/NodeParser/ImportTypeNodeParser.ts
@@ -1,0 +1,42 @@
+import ts from "typescript";
+import { Context, type NodeParser } from "../NodeParser.js";
+import type { SubNodeParser } from "../SubNodeParser.js";
+import type { BaseType } from "../Type/BaseType.js";
+
+export class ImportTypeNodeParser implements SubNodeParser {
+    public constructor(
+        protected typeChecker: ts.TypeChecker,
+        protected childNodeParser: NodeParser,
+    ) {}
+
+    public supportsNode(node: ts.ImportTypeNode): boolean {
+        return node.kind === ts.SyntaxKind.ImportType;
+    }
+
+    public createType(node: ts.ImportTypeNode, context: Context): BaseType {
+        // Resolve the symbol from the qualifier (e.g., `MyType` in `import("./module").MyType`)
+        const symbolLocation = node.qualifier ?? node;
+        const typeSymbol = this.typeChecker.getSymbolAtLocation(symbolLocation)!;
+
+        // Handle transitive re-exports
+        if (typeSymbol.flags & ts.SymbolFlags.Alias) {
+            const aliasedSymbol = this.typeChecker.getAliasedSymbol(typeSymbol);
+            return this.childNodeParser.createType(
+                aliasedSymbol.declarations![0],
+                this.createSubContext(node, context),
+            );
+        }
+
+        return this.childNodeParser.createType(typeSymbol.declarations![0], this.createSubContext(node, context));
+    }
+
+    protected createSubContext(node: ts.ImportTypeNode, parentContext: Context): Context {
+        const subContext = new Context(node);
+        if (node.typeArguments?.length) {
+            for (const typeArg of node.typeArguments) {
+                subContext.pushArgument(this.childNodeParser.createType(typeArg, parentContext));
+            }
+        }
+        return subContext;
+    }
+}

--- a/test/valid-data/import-dynamic/index.test.ts
+++ b/test/valid-data/import-dynamic/index.test.ts
@@ -1,0 +1,4 @@
+import { assertValidSchema } from "../../utils";
+import { test } from "node:test";
+
+test("valid-data - import-dynamic", assertValidSchema("import-dynamic", "MyObject"));

--- a/test/valid-data/import-dynamic/main.ts
+++ b/test/valid-data/import-dynamic/main.ts
@@ -1,0 +1,4 @@
+export interface MyObject {
+    field: import("./module").MySubObject<string>;
+    aliased: import("./reexport").MySubObject<number>;
+}

--- a/test/valid-data/import-dynamic/module.ts
+++ b/test/valid-data/import-dynamic/module.ts
@@ -1,0 +1,3 @@
+export interface MySubObject<ValueType = string> {
+    value: ValueType;
+}

--- a/test/valid-data/import-dynamic/reexport.ts
+++ b/test/valid-data/import-dynamic/reexport.ts
@@ -1,0 +1,1 @@
+export { MySubObject } from "./module";

--- a/test/valid-data/import-dynamic/schema.json
+++ b/test/valid-data/import-dynamic/schema.json
@@ -1,0 +1,46 @@
+{
+  "$ref": "#/definitions/MyObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "additionalProperties": false,
+      "properties": {
+        "aliased": {
+          "$ref": "#/definitions/MySubObject%3Cnumber%3E"
+        },
+        "field": {
+          "$ref": "#/definitions/MySubObject%3Cstring%3E"
+        }
+      },
+      "required": [
+        "field",
+        "aliased"
+      ],
+      "type": "object"
+    },
+    "MySubObject<number>": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    },
+    "MySubObject<string>": {
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
See the attached test case for an issue example

Before the fix, the generator crashes

```
Error: Unknown node of kind "LastTypeNode"
    at ChainNodeParser.getNodeParser (ts-json-schema-generator/src/ChainNodeParser.ts:60:15)
    at ChainNodeParser.createType (ts-json-schema-generator/src/ChainNodeParser.ts:37:29)
    at AnnotatedNodeParser.createType (ts-json-schema-generator/src/NodeParser/AnnotatedNodeParser.ts:34:47)
    at <anonymous> (ts-json-schema-generator/src/NodeParser/InterfaceAndClassNodeParser.ts:155:46)
    at Array.map (<anonymous>)
    at InterfaceAndClassNodeParser.getProperties (ts-json-schema-generator/src/NodeParser/InterfaceAndClassNodeParser.ts:151:14)
    at InterfaceAndClassNodeParser.createType (ts-json-schema-generator/src/NodeParser/InterfaceAndClassNodeParser.ts:48:33)
    at AnnotatedNodeParser.createType (ts-json-schema-generator/src/NodeParser/AnnotatedNodeParser.ts:34:47)
    at ExposeNodeParser.createType (ts-json-schema-generator/src/ExposeNodeParser.ts:23:45)
    at CircularReferenceNodeParser.createType (ts-json-schema-generator/src/CircularReferenceNodeParser.ts:24:43)
```

After the fix, it generates the expected schema
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.9.1-next.18`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from new contributors! :tada:
  
  Thanks for all your work!
  
  :heart: Boris Serdiuk ([@just-boris](https://github.com/just-boris))
  
  :heart: Vismay ([@vismaytiwari](https://github.com/vismaytiwari))
  
  :heart: Jonathan Puckey ([@puckey](https://github.com/puckey))
  
  :heart: Momo Kornher ([@mrgrain](https://github.com/mrgrain))
  
  :heart: _Kerman ([@kermanx](https://github.com/kermanx))
  
  :heart: Ninjackson ([@ninjack-dev](https://github.com/ninjack-dev))
  
  :heart: Orgad Shaneh ([@orgads](https://github.com/orgads))
  
  :heart: Antonin CELESTIN ([@aciwecloud](https://github.com/aciwecloud))
  
  #### 🚀 Enhancement
  
  - feat: support dynamic import nodes [#2535](https://github.com/vega/ts-json-schema-generator/pull/2535) ([@just-boris](https://github.com/just-boris))
  - feat: support ReturnType<T>, type predicates, and fix typeof for function declarations [#2512](https://github.com/vega/ts-json-schema-generator/pull/2512) ([@puckey](https://github.com/puckey))
  - feat: Upgrade to TypeScript 6, maintain TS5 compatibility [#2509](https://github.com/vega/ts-json-schema-generator/pull/2509) ([@arthurfiorette](https://github.com/arthurfiorette) [@Copilot](https://github.com/Copilot))
  
  #### 🐛 Bug Fix
  
  - fix: preserve JSDoc description on properties with an inferred default value [#2534](https://github.com/vega/ts-json-schema-generator/pull/2534) ([@vismaytiwari](https://github.com/vismaytiwari))
  - fix(ci): remove duplicate npm plugin from auto config [#2525](https://github.com/vega/ts-json-schema-generator/pull/2525) ([@puckey](https://github.com/puckey))
  - fix: relative --tsconfig path breaks @types resolution [#2520](https://github.com/vega/ts-json-schema-generator/pull/2520) ([@mrgrain](https://github.com/mrgrain))
  - fix: getTypeByKey should search baseTypes before additionalProperties [#2521](https://github.com/vega/ts-json-schema-generator/pull/2521) ([@kermanx](https://github.com/kermanx))
  - fix: add `issues` and `pull-requests` write permissions to publish-auto workflow [#2516](https://github.com/vega/ts-json-schema-generator/pull/2516) ([@Copilot](https://github.com/Copilot))
  - Add support for `infer` in conditionals operating on function parameters [#2495](https://github.com/vega/ts-json-schema-generator/pull/2495) ([@ninjack-dev](https://github.com/ninjack-dev))
  - fix: preserve mapped indexed access annotations [#2501](https://github.com/vega/ts-json-schema-generator/pull/2501) ([@orgads](https://github.com/orgads))
  - ci: publish only from main repository [#2502](https://github.com/vega/ts-json-schema-generator/pull/2502) ([@orgads](https://github.com/orgads))
  - fix: array ref used as rest item [#2496](https://github.com/vega/ts-json-schema-generator/pull/2496) ([@aciwecloud](https://github.com/aciwecloud))
  - fix: mapped types required type [#2492](https://github.com/vega/ts-json-schema-generator/pull/2492) ([@aciwecloud](https://github.com/aciwecloud))
  - fix: Include types referenced only in `additionalItems` in schema definitions [#2477](https://github.com/vega/ts-json-schema-generator/pull/2477) ([@aciwecloud](https://github.com/aciwecloud))
  
  #### ⚠️ Pushed to `next`
  
  - ci: update dependabot config to be quarterly, simplify auto-merge ([@domoritz](https://github.com/domoritz))
  
  #### 🔩 Dependency Updates
  
  - chore(deps-dev): bump @types/node from 24.12.0 to 26.0.1 [#2531](https://github.com/vega/ts-json-schema-generator/pull/2531) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump actions/checkout from 6 to 7 [#2527](https://github.com/vega/ts-json-schema-generator/pull/2527) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump dependabot/fetch-metadata from 2 to 3 [#2528](https://github.com/vega/ts-json-schema-generator/pull/2528) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump codecov/codecov-action from 6 to 7 [#2529](https://github.com/vega/ts-json-schema-generator/pull/2529) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump ajv from 8.18.0 to 8.20.0 [#2533](https://github.com/vega/ts-json-schema-generator/pull/2533) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump globals from 17.4.0 to 17.7.0 [#2532](https://github.com/vega/ts-json-schema-generator/pull/2532) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint-plugin-prettier from 5.5.5 to 5.5.6 [#2530](https://github.com/vega/ts-json-schema-generator/pull/2530) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump esbuild and tsx [#2524](https://github.com/vega/ts-json-schema-generator/pull/2524) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump brace-expansion from 5.0.5 to 5.0.6 [#2523](https://github.com/vega/ts-json-schema-generator/pull/2523) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump fast-uri from 3.1.0 to 3.1.2 [#2522](https://github.com/vega/ts-json-schema-generator/pull/2522) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.57.2 to 8.58.0 [#2517](https://github.com/vega/ts-json-schema-generator/pull/2517) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump lodash from 4.17.23 to 4.18.1 [#2518](https://github.com/vega/ts-json-schema-generator/pull/2518) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.57.1 to 8.57.2 [#2510](https://github.com/vega/ts-json-schema-generator/pull/2510) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump brace-expansion [#2507](https://github.com/vega/ts-json-schema-generator/pull/2507) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump codecov/codecov-action from 5 to 6 [#2506](https://github.com/vega/ts-json-schema-generator/pull/2506) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump handlebars from 4.7.8 to 4.7.9 [#2505](https://github.com/vega/ts-json-schema-generator/pull/2505) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps): bump picomatch [#2503](https://github.com/vega/ts-json-schema-generator/pull/2503) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 10.0.3 to 10.1.0 [#2499](https://github.com/vega/ts-json-schema-generator/pull/2499) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.57.0 to 8.57.1 [#2500](https://github.com/vega/ts-json-schema-generator/pull/2500) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump flatted from 3.3.1 to 3.4.2 [#2498](https://github.com/vega/ts-json-schema-generator/pull/2498) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.56.1 to 8.57.0 [#2494](https://github.com/vega/ts-json-schema-generator/pull/2494) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump eslint from 9.39.2 to 10.0.3 [#2487](https://github.com/vega/ts-json-schema-generator/pull/2487) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump @types/node from 24.10.13 to 24.12.0 [#2486](https://github.com/vega/ts-json-schema-generator/pull/2486) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - chore(deps-dev): bump typescript-eslint from 8.56.0 to 8.56.1 [#2488](https://github.com/vega/ts-json-schema-generator/pull/2488) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 12
  
  - _Kerman ([@kermanx](https://github.com/kermanx))
  - [@Copilot](https://github.com/Copilot)
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Antonin CELESTIN ([@aciwecloud](https://github.com/aciwecloud))
  - Arthur Fiorette ([@arthurfiorette](https://github.com/arthurfiorette))
  - Boris Serdiuk ([@just-boris](https://github.com/just-boris))
  - Dominik Moritz ([@domoritz](https://github.com/domoritz))
  - Jonathan Puckey ([@puckey](https://github.com/puckey))
  - Momo Kornher ([@mrgrain](https://github.com/mrgrain))
  - Ninjackson ([@ninjack-dev](https://github.com/ninjack-dev))
  - Orgad Shaneh ([@orgads](https://github.com/orgads))
  - Vismay ([@vismaytiwari](https://github.com/vismaytiwari))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
