### PR TITLE
fix: prefix local refs with schema id

### DIFF
--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -54,12 +54,18 @@ export class SchemaGenerator {
             {},
         );
 
-        return {
+        const schema: Schema = {
             ...(this.config?.schemaId ? { $id: this.config.schemaId } : {}),
             $schema: "http://json-schema.org/draft-07/schema#",
             ...(rootTypeDefinition ?? {}),
             definitions: reachableDefinitions,
         };
+
+        if (this.config?.schemaId) {
+            this.addSchemaIdToReferences(schema, this.config.schemaId);
+        }
+
+        return schema;
     }
 
     protected getRootNodes(fullNames: string[] | undefined): ts.Node[] {
@@ -164,6 +170,23 @@ export class SchemaGenerator {
             return definitions;
         }, childDefinitions);
     }
+
+    protected addSchemaIdToReferences(value: unknown, schemaId: string): void {
+        if (Array.isArray(value)) {
+            for (const item of value) {
+                this.addSchemaIdToReferences(item, schemaId);
+            }
+        } else if (value !== null && typeof value === "object") {
+            const object = value as Record<string, unknown>;
+            if (typeof object.$ref === "string" && object.$ref.startsWith("#")) {
+                object.$ref = `${schemaId}${object.$ref}`;
+            }
+            for (const child of Object.values(object)) {
+                this.addSchemaIdToReferences(child, schemaId);
+            }
+        }
+    }
+
     protected partitionFiles(): {
         projectFiles: ts.SourceFile[];
         externalFiles: ts.SourceFile[];

--- a/test/valid-data/annotation-id/schema.json
+++ b/test/valid-data/annotation-id/schema.json
@@ -1,6 +1,6 @@
 {
   "$id": "Test",
-  "$ref": "#/definitions/MyObject",
+  "$ref": "Test#/definitions/MyObject",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "MyNestedObject": {
@@ -13,7 +13,7 @@
       "additionalProperties": false,
       "properties": {
         "nested": {
-          "$ref": "#/definitions/MyNestedObject"
+          "$ref": "Test#/definitions/MyNestedObject"
         }
       },
       "required": [

--- a/test/valid-data/schema-id-ref-prefix/index.test.ts
+++ b/test/valid-data/schema-id-ref-prefix/index.test.ts
@@ -1,0 +1,4 @@
+import { test } from "node:test";
+import { assertValidSchema } from "../../utils";
+
+test("valid-data - schema-id-ref-prefix", assertValidSchema("schema-id-ref-prefix", "*", { schemaId: "api" }));

--- a/test/valid-data/schema-id-ref-prefix/main.ts
+++ b/test/valid-data/schema-id-ref-prefix/main.ts
@@ -1,0 +1,5 @@
+export type ApiSchema = {
+    N: B;
+};
+
+export type B = string;

--- a/test/valid-data/schema-id-ref-prefix/schema.json
+++ b/test/valid-data/schema-id-ref-prefix/schema.json
@@ -1,0 +1,21 @@
+{
+  "$id": "api",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "ApiSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "N": {
+          "$ref": "api#/definitions/B"
+        }
+      },
+      "required": [
+        "N"
+      ],
+      "type": "object"
+    },
+    "B": {
+      "type": "string"
+    }
+  }
+}

--- a/test/valid-data/type-aliases-primitive-with-id/schema.json
+++ b/test/valid-data/type-aliases-primitive-with-id/schema.json
@@ -1,6 +1,6 @@
 {
   "$id": "testId",
-  "$ref": "#/definitions/MyString",
+  "$ref": "testId#/definitions/MyString",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "MyString": {


### PR DESCRIPTION
Fixes #1732

## Root cause

The configured `schemaId` was only emitted as the root `$id`. Generated references remained fragment-only (`#/definitions/...`), so consumers expecting explicit schema-qualified references did not receive the configured ID.

## Fix

After definition reachability is calculated, prefix generated local `$ref` values with the configured schema ID. Applying the prefix after pruning keeps local references available to the existing reachability analysis and leaves external references unchanged.

## Tests

- Added a regression fixture covering a nested definition reference with `schemaId: "api"`
- Updated existing schema-ID fixtures to verify root and nested references
- `npx tsx --test test/valid-data/schema-id-ref-prefix/index.test.ts test/valid-data/annotation-id/index.test.ts test/valid-data/type-aliases-primitive-with-id/index.test.ts` — 3 passed
- `npm test` — 380 passed
- `npm run build` — passed
- `npm run lint -- --no-cache` — passed with 49 pre-existing warnings and 0 errors