### PR TITLE
fix: unwrap rest elements in tuple indexed access

### DIFF
--- a/src/NodeParser/IndexedAccessTypeNodeParser.ts
+++ b/src/NodeParser/IndexedAccessTypeNodeParser.ts
@@ -2,11 +2,13 @@ import ts from "typescript";
 import { LogicError } from "../Error/Errors.js";
 import type { Context, NodeParser } from "../NodeParser.js";
 import type { SubNodeParser } from "../SubNodeParser.js";
+import { ArrayType } from "../Type/ArrayType.js";
 import type { BaseType } from "../Type/BaseType.js";
 import { LiteralType } from "../Type/LiteralType.js";
 import { NeverType } from "../Type/NeverType.js";
 import { NumberType } from "../Type/NumberType.js";
 import { ReferenceType } from "../Type/ReferenceType.js";
+import { RestType } from "../Type/RestType.js";
 import { StringType } from "../Type/StringType.js";
 import { TupleType } from "../Type/TupleType.js";
 import { UnionType } from "../Type/UnionType.js";
@@ -46,6 +48,26 @@ export class IndexedAccessTypeNodeParser implements SubNodeParser {
         return undefined;
     }
 
+    private getTupleIndexTypes(tupleType: TupleType): BaseType[] {
+        return tupleType.getTypes().flatMap((type) => {
+            const derefed = derefType(type);
+            if (!(derefed instanceof RestType)) {
+                return type;
+            }
+
+            const restType = derefType(derefed.getType());
+            if (restType instanceof ArrayType) {
+                return restType.getItem();
+            }
+
+            if (restType instanceof TupleType) {
+                return this.getTupleIndexTypes(restType);
+            }
+
+            return derefed;
+        });
+    }
+
     public createType(node: ts.IndexedAccessTypeNode, context: Context): BaseType {
         const indexType = derefType(this.childNodeParser.createType(node.indexType, context));
         const indexedType = this.createIndexedType(node.objectType, context, indexType);
@@ -71,7 +93,7 @@ export class IndexedAccessTypeNodeParser implements SubNodeParser {
             const propertyType = getTypeByKey(objectType, type);
             if (!propertyType) {
                 if (type instanceof NumberType && objectType instanceof TupleType) {
-                    return new UnionType(objectType.getTypes());
+                    return new UnionType(this.getTupleIndexTypes(objectType)).normalize();
                 }
 
                 if (type instanceof LiteralType) {

--- a/test/valid-data/type-indexed-access-tuple-rest/index.test.ts
+++ b/test/valid-data/type-indexed-access-tuple-rest/index.test.ts
@@ -1,0 +1,7 @@
+import { assertValidSchema } from "../../utils";
+import { test } from "node:test";
+
+test(
+    "valid-data - type-indexed-access-tuple-rest",
+    assertValidSchema("type-indexed-access-tuple-rest", "TupleElement"),
+);

--- a/test/valid-data/type-indexed-access-tuple-rest/main.ts
+++ b/test/valid-data/type-indexed-access-tuple-rest/main.ts
@@ -1,0 +1,3 @@
+type Tuple = [string, ...number[]];
+
+export type TupleElement = Tuple[number];

--- a/test/valid-data/type-indexed-access-tuple-rest/schema.json
+++ b/test/valid-data/type-indexed-access-tuple-rest/schema.json
@@ -1,0 +1,12 @@
+{
+  "$ref": "#/definitions/TupleElement",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "TupleElement": {
+      "type": [
+        "string",
+        "number"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### Problem
Indexed access on a variadic tuple currently treats a rest element as the rest array itself. For `[string, ...number[]][number]`, the generated schema allows `string | number[]`, but TypeScript's indexed access type is `string | number`.

### Reproducer
```ts
type Tuple = [string, ...number[]];
export type TupleElement = Tuple[number];
```
Before this change `TupleElement` generated `anyOf: [{ type: "string" }, { type: "array", items: { type: "number" } }]`; it should generate `type: ["string", "number"]`.

### Fix
When resolving `Tuple[number]`, unwrap tuple rest elements to their element types before building the union. This keeps fixed tuple elements unchanged while making variadic rest elements contribute their item type.

### Testing
Added `test/valid-data/type-indexed-access-tuple-rest`.

- Before fix: `npx tsx --test 'test/valid-data/type-indexed-access-tuple-rest/index.test.ts'` failed with `actual anyOf` containing a number array.
- After fix: `npx tsx --test 'test/valid-data/type-indexed-access-tuple-rest/index.test.ts'` passed.
- `npm run lint` passed with 49 pre-existing warnings and 0 errors.
- `npm run build` passed.
- `npm test` passed.